### PR TITLE
Fix CI npm cache error and clarify one-branch-per-issue rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm
 
       - name: Install dependencies
         run: npm ci

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -35,6 +35,8 @@ Before writing anything, read the files you'll be modifying or sitting alongside
 
 ## Step 5 — Branch
 
+**Always create a new branch from an up-to-date main. Never commit directly to main. Never reuse a branch from a previous issue. Each issue gets its own branch and its own PR.**
+
 ```bash
 git checkout main && git pull
 git checkout -b feat/issue-NNN-short-description


### PR DESCRIPTION
## What this does
- Removes `cache: npm` from `setup-node` in `ci.yml` — this option requires `package-lock.json` to already exist on the base branch before the PR lands, causing spurious CI failures during bootstrapping
- Adds an explicit bolded rule to `AGENT_GUIDE.md`: always create a new branch from main for each issue, never reuse branches or commit directly to main

## Test plan
- [x] CI should pass on this PR without the lock file error