### PR TITLE
feat: fixed-timestep tick loop with system registration (closes #3)

### DIFF
--- a/src/core/tickLoop.ts
+++ b/src/core/tickLoop.ts
@@ -1,0 +1,71 @@
+import type { GameWorld } from '@core/world'
+import type { SystemFn } from '@core/types'
+
+const DEFAULT_TICKS_PER_SECOND = 20
+
+/**
+ * A running tick loop returned by `createTickLoop`.
+ */
+export type TickLoop = {
+  /** Start ticking. No-op if already running. */
+  start: () => void
+  /** Stop ticking. No-op if already stopped. */
+  stop: () => void
+  /** Total number of ticks that have been executed. */
+  readonly tick: number
+  /** Total elapsed game time in seconds (tick * dt). */
+  readonly elapsed: number
+}
+
+/**
+ * Creates a fixed-timestep game loop that calls each registered system
+ * once per tick in the order they are provided.
+ *
+ * Uses `setInterval` so it works headlessly (no `requestAnimationFrame`).
+ *
+ * @param world          - The ECS world passed to every system each tick.
+ * @param systems        - Ordered array of system functions to invoke per tick.
+ * @param ticksPerSecond - How many ticks to run per second (default: 20).
+ */
+export function createTickLoop(
+  world: GameWorld,
+  systems: SystemFn[],
+  ticksPerSecond: number = DEFAULT_TICKS_PER_SECOND,
+): TickLoop {
+  const dt = 1 / ticksPerSecond
+
+  let tickCount = 0
+  let elapsedTime = 0
+  let intervalId: ReturnType<typeof setInterval> | null = null
+
+  function runTick(): void {
+    for (let i = 0; i < systems.length; i++) {
+      systems[i]!(world, dt)
+    }
+    tickCount += 1
+    elapsedTime += dt
+  }
+
+  const loop: TickLoop = {
+    start(): void {
+      if (intervalId !== null) return
+      intervalId = setInterval(runTick, (1 / ticksPerSecond) * 1000)
+    },
+
+    stop(): void {
+      if (intervalId === null) return
+      clearInterval(intervalId)
+      intervalId = null
+    },
+
+    get tick(): number {
+      return tickCount
+    },
+
+    get elapsed(): number {
+      return elapsedTime
+    },
+  }
+
+  return loop
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,0 +1,9 @@
+import type { GameWorld } from '@core/world'
+
+/**
+ * A system function receives the ECS world and the elapsed time (in seconds)
+ * since the last tick, and performs all of its mutations in-place.
+ *
+ * Systems are pure: no return value, no stored state, no browser APIs.
+ */
+export type SystemFn = (world: GameWorld, dt: number) => void

--- a/tests/core/tickLoop.test.ts
+++ b/tests/core/tickLoop.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createGameWorld } from '@core/world'
+import { createTickLoop } from '@core/tickLoop'
+import type { SystemFn } from '@core/types'
+import type { GameWorld } from '@core/world'
+
+describe('createTickLoop', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('calls systems in registration order each tick', () => {
+    const world = createGameWorld()
+    const callOrder: number[] = []
+
+    const sysA: SystemFn = (_w: GameWorld, _dt: number): void => { callOrder.push(1) }
+    const sysB: SystemFn = (_w: GameWorld, _dt: number): void => { callOrder.push(2) }
+    const sysC: SystemFn = (_w: GameWorld, _dt: number): void => { callOrder.push(3) }
+
+    const loop = createTickLoop(world, [sysA, sysB, sysC], 20)
+    loop.start()
+
+    vi.advanceTimersByTime(50) // 1 tick at 20 tps = 50 ms
+
+    expect(callOrder).toEqual([1, 2, 3])
+  })
+
+  it('passes the correct dt to systems', () => {
+    const world = createGameWorld()
+    const receivedDts: number[] = []
+
+    const sys: SystemFn = (_w: GameWorld, dt: number): void => { receivedDts.push(dt) }
+
+    const loop = createTickLoop(world, [sys], 20)
+    loop.start()
+
+    vi.advanceTimersByTime(50) // one tick
+
+    expect(receivedDts).toHaveLength(1)
+    expect(receivedDts[0]).toBeCloseTo(1 / 20)
+  })
+
+  it('uses a default of 20 ticks per second', () => {
+    const world = createGameWorld()
+    let callCount = 0
+
+    const sys: SystemFn = (): void => { callCount++ }
+
+    const loop = createTickLoop(world, [sys]) // no ticksPerSecond arg
+    loop.start()
+
+    vi.advanceTimersByTime(1000) // 1 second → 20 ticks
+
+    expect(callCount).toBe(20)
+  })
+
+  it('increments tick count correctly', () => {
+    const world = createGameWorld()
+    const loop = createTickLoop(world, [], 20)
+    loop.start()
+
+    vi.advanceTimersByTime(150) // 3 ticks at 20 tps
+
+    expect(loop.tick).toBe(3)
+  })
+
+  it('accumulates elapsed time correctly', () => {
+    const world = createGameWorld()
+    const loop = createTickLoop(world, [], 20)
+    loop.start()
+
+    vi.advanceTimersByTime(200) // 4 ticks → 0.2 s
+
+    expect(loop.elapsed).toBeCloseTo(4 / 20)
+  })
+
+  it('stop() halts the loop — no further system calls after stop', () => {
+    const world = createGameWorld()
+    let callCount = 0
+
+    const sys: SystemFn = (): void => { callCount++ }
+
+    const loop = createTickLoop(world, [sys], 20)
+    loop.start()
+
+    vi.advanceTimersByTime(100) // 2 ticks
+    loop.stop()
+    vi.advanceTimersByTime(500) // would be 10 more ticks if running
+
+    expect(callCount).toBe(2)
+  })
+
+  it('stop() does not change tick or elapsed after halting', () => {
+    const world = createGameWorld()
+    const loop = createTickLoop(world, [], 20)
+    loop.start()
+
+    vi.advanceTimersByTime(100) // 2 ticks
+    loop.stop()
+
+    const tickAfterStop = loop.tick
+    const elapsedAfterStop = loop.elapsed
+
+    vi.advanceTimersByTime(1000)
+
+    expect(loop.tick).toBe(tickAfterStop)
+    expect(loop.elapsed).toBe(elapsedAfterStop)
+  })
+
+  it('start() is a no-op when already running', () => {
+    const world = createGameWorld()
+    let callCount = 0
+
+    const sys: SystemFn = (): void => { callCount++ }
+
+    const loop = createTickLoop(world, [sys], 20)
+    loop.start()
+    loop.start() // second call — should not register a second interval
+
+    vi.advanceTimersByTime(1000) // 1 second
+
+    // If two intervals were registered this would be ~40; it should be 20.
+    expect(callCount).toBe(20)
+  })
+
+  it('stop() is a no-op when already stopped', () => {
+    const world = createGameWorld()
+    const loop = createTickLoop(world, [], 20)
+
+    // Should not throw when never started
+    expect(() => loop.stop()).not.toThrow()
+
+    loop.start()
+    loop.stop()
+
+    // Second stop should also not throw
+    expect(() => loop.stop()).not.toThrow()
+  })
+
+  it('passes the world instance to each system', () => {
+    const world = createGameWorld()
+    const receivedWorlds: GameWorld[] = []
+
+    const sys: SystemFn = (w: GameWorld): void => { receivedWorlds.push(w) }
+
+    const loop = createTickLoop(world, [sys], 20)
+    loop.start()
+
+    vi.advanceTimersByTime(50) // one tick
+
+    expect(receivedWorlds).toHaveLength(1)
+    expect(receivedWorlds[0]).toBe(world)
+  })
+
+  it('tick and elapsed start at zero before any ticks', () => {
+    const world = createGameWorld()
+    const loop = createTickLoop(world, [], 20)
+
+    expect(loop.tick).toBe(0)
+    expect(loop.elapsed).toBe(0)
+  })
+
+  it('supports a custom ticksPerSecond', () => {
+    const world = createGameWorld()
+    let callCount = 0
+
+    const sys: SystemFn = (): void => { callCount++ }
+
+    const loop = createTickLoop(world, [sys], 10) // 10 tps
+    loop.start()
+
+    vi.advanceTimersByTime(1000) // 1 second → 10 ticks
+
+    expect(callCount).toBe(10)
+  })
+})


### PR DESCRIPTION
Closes #3

## What this does
Adds `createTickLoop(world, systems, ticksPerSecond)` in `src/core/tickLoop.ts` — a fixed-timestep game loop that drives registered systems at a configurable rate (default 20 ticks/sec). Uses `setInterval` so it works headlessly with no DOM dependency. Also adds the `SystemFn` type alias to `src/core/types.ts` as a shared contract for all system functions.

## Acceptance criteria covered
- [x] `src/core/tickLoop.ts` exports `createTickLoop(world, systems, ticksPerSecond)`
- [x] `SystemFn` type `(world: GameWorld, dt: number) => void` in `src/core/types.ts`
- [x] `TickLoop` interface with `start()`, `stop()`, `tick` (count), `elapsed` (seconds)
- [x] Default 20 ticks/sec
- [x] Works headlessly (uses `setInterval`, no `requestAnimationFrame`)
- [x] Unit tests in `tests/core/tickLoop.test.ts`

## Test plan
- [x] Systems called in registration order each tick
- [x] Correct `dt` value passed to systems (1 / ticksPerSecond)
- [x] Default 20 ticks/sec fires 20 times in 1000 ms
- [x] Custom `ticksPerSecond` (10 tps) fires 10 times in 1000 ms
- [x] `tick` count increments correctly
- [x] `elapsed` accumulates correctly
- [x] `stop()` halts the loop — no further calls after stop
- [x] `stop()` does not change `tick` or `elapsed` after halting
- [x] `start()` is a no-op when already running (no double-interval)
- [x] `stop()` is a no-op when already stopped (no throw)
- [x] World instance passed to each system is the same reference
- [x] `tick` and `elapsed` start at zero before any ticks