### PR TITLE
Add World3D data structure with 3D tile array and z-level indexing

### DIFF
--- a/src/map/tileTypes.ts
+++ b/src/map/tileTypes.ts
@@ -1,0 +1,8 @@
+export const enum TileType {
+  Air   = 0,
+  Stone = 1,
+  Soil  = 2,
+  Water = 3,
+  Floor = 4,
+  Wall  = 5,
+}

--- a/src/map/world3d.ts
+++ b/src/map/world3d.ts
@@ -1,0 +1,51 @@
+import { WORLD_WIDTH, WORLD_HEIGHT, WORLD_DEPTH } from '@core/constants'
+import { TileType } from '@map/tileTypes'
+
+export type World3D = {
+  tiles:     Uint8Array
+  materials: Uint8Array
+  flags:     Uint8Array
+  width:     number
+  height:    number
+  depth:     number
+}
+
+export function createWorld3D(
+  width:  number = WORLD_WIDTH,
+  height: number = WORLD_HEIGHT,
+  depth:  number = WORLD_DEPTH,
+): World3D {
+  const size = width * height * depth
+  return {
+    tiles:     new Uint8Array(size),
+    materials: new Uint8Array(size),
+    flags:     new Uint8Array(size),
+    width,
+    height,
+    depth,
+  }
+}
+
+export function tileIndex(x: number, y: number, z: number, w: World3D): number {
+  return z * w.width * w.height + y * w.width + x
+}
+
+function inBounds(x: number, y: number, z: number, w: World3D): boolean {
+  return x >= 0 && x < w.width &&
+         y >= 0 && y < w.height &&
+         z >= 0 && z < w.depth
+}
+
+export function getTile(x: number, y: number, z: number, w: World3D): TileType {
+  if (!inBounds(x, y, z, w)) {
+    return TileType.Air
+  }
+  return (w.tiles[tileIndex(x, y, z, w)] ?? TileType.Air) as TileType
+}
+
+export function setTile(x: number, y: number, z: number, w: World3D, type: TileType): void {
+  if (!inBounds(x, y, z, w)) {
+    return
+  }
+  w.tiles[tileIndex(x, y, z, w)] = type
+}

--- a/tests/map/world3d.test.ts
+++ b/tests/map/world3d.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest'
+import { createWorld3D, tileIndex, getTile, setTile } from '@map/world3d'
+import { TileType } from '@map/tileTypes'
+
+describe('createWorld3D', () => {
+  it('creates a world with default dimensions', () => {
+    const w = createWorld3D()
+    expect(w.width).toBe(128)
+    expect(w.height).toBe(128)
+    expect(w.depth).toBe(16)
+  })
+
+  it('creates typed arrays with correct size', () => {
+    const w = createWorld3D(4, 4, 2)
+    const expectedSize = 4 * 4 * 2
+    expect(w.tiles.length).toBe(expectedSize)
+    expect(w.materials.length).toBe(expectedSize)
+    expect(w.flags.length).toBe(expectedSize)
+  })
+
+  it('initialises all tiles to Air (0)', () => {
+    const w = createWorld3D(4, 4, 2)
+    expect(w.tiles.every(v => v === TileType.Air)).toBe(true)
+  })
+
+  it('accepts custom dimensions', () => {
+    const w = createWorld3D(10, 20, 5)
+    expect(w.width).toBe(10)
+    expect(w.height).toBe(20)
+    expect(w.depth).toBe(5)
+  })
+})
+
+describe('tileIndex', () => {
+  it('returns 0 for origin (0,0,0)', () => {
+    const w = createWorld3D(4, 4, 2)
+    expect(tileIndex(0, 0, 0, w)).toBe(0)
+  })
+
+  it('increments by 1 for adjacent x', () => {
+    const w = createWorld3D(4, 4, 2)
+    expect(tileIndex(1, 0, 0, w)).toBe(1)
+    expect(tileIndex(2, 0, 0, w)).toBe(2)
+  })
+
+  it('increments by width for adjacent y', () => {
+    const w = createWorld3D(4, 4, 2)
+    expect(tileIndex(0, 1, 0, w)).toBe(4)
+    expect(tileIndex(0, 2, 0, w)).toBe(8)
+  })
+
+  it('increments by width*height for adjacent z', () => {
+    const w = createWorld3D(4, 4, 2)
+    expect(tileIndex(0, 0, 1, w)).toBe(16)
+  })
+
+  it('computes compound index correctly', () => {
+    const w = createWorld3D(4, 4, 2)
+    // z=1, y=2, x=3 → 1*16 + 2*4 + 3 = 27
+    expect(tileIndex(3, 2, 1, w)).toBe(27)
+  })
+})
+
+describe('getTile', () => {
+  it('returns Air for an untouched cell', () => {
+    const w = createWorld3D(4, 4, 2)
+    expect(getTile(1, 1, 0, w)).toBe(TileType.Air)
+  })
+
+  it('returns Air for negative x (out-of-bounds)', () => {
+    const w = createWorld3D(4, 4, 2)
+    expect(getTile(-1, 0, 0, w)).toBe(TileType.Air)
+  })
+
+  it('returns Air for x >= width (out-of-bounds)', () => {
+    const w = createWorld3D(4, 4, 2)
+    expect(getTile(4, 0, 0, w)).toBe(TileType.Air)
+  })
+
+  it('returns Air for y out-of-bounds', () => {
+    const w = createWorld3D(4, 4, 2)
+    expect(getTile(0, -1, 0, w)).toBe(TileType.Air)
+    expect(getTile(0, 4, 0, w)).toBe(TileType.Air)
+  })
+
+  it('returns Air for z out-of-bounds', () => {
+    const w = createWorld3D(4, 4, 2)
+    expect(getTile(0, 0, -1, w)).toBe(TileType.Air)
+    expect(getTile(0, 0, 2, w)).toBe(TileType.Air)
+  })
+
+  it('returns the tile type after setTile', () => {
+    const w = createWorld3D(4, 4, 2)
+    setTile(2, 3, 1, w, TileType.Stone)
+    expect(getTile(2, 3, 1, w)).toBe(TileType.Stone)
+  })
+})
+
+describe('setTile', () => {
+  it('sets a tile and the value is readable via getTile', () => {
+    const w = createWorld3D(4, 4, 2)
+    setTile(0, 0, 0, w, TileType.Wall)
+    expect(getTile(0, 0, 0, w)).toBe(TileType.Wall)
+  })
+
+  it('does not throw for out-of-bounds coordinates', () => {
+    const w = createWorld3D(4, 4, 2)
+    expect(() => setTile(-1, 0, 0, w, TileType.Stone)).not.toThrow()
+    expect(() => setTile(0, 0, 99, w, TileType.Stone)).not.toThrow()
+  })
+
+  it('does not mutate the array for out-of-bounds writes', () => {
+    const w = createWorld3D(4, 4, 2)
+    setTile(99, 99, 99, w, TileType.Stone)
+    expect(w.tiles.every(v => v === TileType.Air)).toBe(true)
+  })
+
+  it('sets all TileType variants correctly', () => {
+    const w = createWorld3D(4, 4, 2)
+    const types: TileType[] = [
+      TileType.Air,
+      TileType.Stone,
+      TileType.Soil,
+      TileType.Water,
+      TileType.Floor,
+      TileType.Wall,
+    ]
+    for (const type of types) {
+      setTile(0, 0, 0, w, type)
+      expect(getTile(0, 0, 0, w)).toBe(type)
+    }
+  })
+
+  it('sets tiles independently across different cells', () => {
+    const w = createWorld3D(4, 4, 2)
+    setTile(0, 0, 0, w, TileType.Stone)
+    setTile(1, 0, 0, w, TileType.Soil)
+    setTile(0, 1, 0, w, TileType.Water)
+    expect(getTile(0, 0, 0, w)).toBe(TileType.Stone)
+    expect(getTile(1, 0, 0, w)).toBe(TileType.Soil)
+    expect(getTile(0, 1, 0, w)).toBe(TileType.Water)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `TileType` enum (`Air=0`, `Stone=1`, `Soil=2`, `Water=3`, `Floor=4`, `Wall=5`) in `src/map/tileTypes.ts`
- Implements `createWorld3D()` returning a `World3D` struct backed by `Uint8Array` typed arrays for tiles, materials, and flags
- Provides `tileIndex(x, y, z, w)`, `getTile()`, and `setTile()` helpers with safe out-of-bounds handling (returns `TileType.Air` silently for reads, no-ops for writes)

## Test plan

- [x] `createWorld3D` — default and custom dimensions, correct array sizes, zero-initialised
- [x] `tileIndex` — origin, x/y/z increments, compound index
- [x] `getTile` — returns `Air` for untouched cells and all out-of-bounds coordinates (negative and ≥ dimension)
- [x] `setTile` — round-trips all `TileType` variants, independent cells, no-op and no-throw on out-of-bounds
- All 41 tests pass (`npm test`)
- `npm run lint` and `npm run typecheck` pass on committed files

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)