### PR TITLE
Add YAML loader for materials with Zod validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pwarf",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pwarf",
-      "version": "1.0.0",
+      "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
         "@types/react": "^19.2.14",
@@ -14,10 +14,12 @@
         "bitecs": "^0.4.0",
         "pixi.js": "^8.17.0",
         "react": "^19.2.4",
-        "react-dom": "^19.2.4"
+        "react-dom": "^19.2.4",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
+        "@types/node": "^25.5.0",
         "@typescript-eslint/eslint-plugin": "^8.57.0",
         "@typescript-eslint/parser": "^8.57.0",
         "@vitejs/plugin-react": "^6.0.0",
@@ -598,6 +600,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.2.14",
@@ -2503,6 +2515,13 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -2743,6 +2762,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "ISC",
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
+    "@types/node": "^25.5.0",
     "@typescript-eslint/eslint-plugin": "^8.57.0",
     "@typescript-eslint/parser": "^8.57.0",
     "@vitejs/plugin-react": "^6.0.0",
@@ -37,6 +38,7 @@
     "bitecs": "^0.4.0",
     "pixi.js": "^8.17.0",
     "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.4",
+    "zod": "^4.3.6"
   }
 }

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,0 +1,12 @@
+import { loadMaterials } from './loaders/materials'
+import type { Material } from './loaders/materials'
+
+export type { Material }
+
+type GameDataShape = {
+  materials: readonly Material[]
+}
+
+export const GameData: GameDataShape = Object.freeze({
+  materials: Object.freeze(loadMaterials()),
+})

--- a/src/data/loaders/materials.ts
+++ b/src/data/loaders/materials.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod'
+import yaml from 'js-yaml'
+import materialsRaw from '../materials.yaml?raw'
+
+const MaterialSchema = z.object({
+  id:       z.string(),
+  name:     z.string(),
+  category: z.enum(['stone', 'metal', 'soil', 'organic']),
+  color:    z.string().regex(/^#[0-9a-f]{6}$/i),
+  hardness: z.number().min(0).max(10),
+})
+
+export type Material = z.infer<typeof MaterialSchema>
+
+export function loadMaterials(): Material[] {
+  const raw = yaml.load(materialsRaw)
+  return z.array(MaterialSchema).parse(raw)
+}

--- a/src/data/materials.yaml
+++ b/src/data/materials.yaml
@@ -1,0 +1,29 @@
+- id: granite
+  name: Granite
+  category: stone
+  color: "#a89080"
+  hardness: 7
+
+- id: limestone
+  name: Limestone
+  category: stone
+  color: "#c8b89a"
+  hardness: 3
+
+- id: iron_ore
+  name: Iron Ore
+  category: stone
+  color: "#8b4513"
+  hardness: 5
+
+- id: iron_bar
+  name: Iron Bar
+  category: metal
+  color: "#808080"
+  hardness: 8
+
+- id: soil
+  name: Soil
+  category: soil
+  color: "#6b4f2a"
+  hardness: 1

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tests/data/materials.test.ts
+++ b/tests/data/materials.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest'
+import { writeFileSync, unlinkSync } from 'fs'
+import { join } from 'path'
+import yaml from 'js-yaml'
+import { z } from 'zod'
+import { loadMaterials } from '@data/loaders/materials'
+import type { Material } from '@data/loaders/materials'
+
+describe('loadMaterials()', () => {
+  it('loads and validates the materials.yaml file', () => {
+    const materials = loadMaterials()
+    expect(materials).toBeInstanceOf(Array)
+    expect(materials.length).toBeGreaterThanOrEqual(5)
+  })
+
+  it('includes the required five materials by id', () => {
+    const materials = loadMaterials()
+    const ids = materials.map((m) => m.id)
+    expect(ids).toContain('granite')
+    expect(ids).toContain('limestone')
+    expect(ids).toContain('iron_ore')
+    expect(ids).toContain('iron_bar')
+    expect(ids).toContain('soil')
+  })
+
+  it('each material has the correct shape', () => {
+    const materials = loadMaterials()
+    for (const material of materials) {
+      expect(material).toHaveProperty('id')
+      expect(material).toHaveProperty('name')
+      expect(['stone', 'metal', 'soil', 'organic']).toContain(material.category)
+      expect(material.color).toMatch(/^#[0-9a-f]{6}$/i)
+      expect(material.hardness).toBeGreaterThanOrEqual(0)
+      expect(material.hardness).toBeLessThanOrEqual(10)
+    }
+  })
+
+  it('granite has stone category and valid hardness', () => {
+    const materials = loadMaterials()
+    const granite = materials.find((m) => m.id === 'granite')
+    expect(granite).toBeDefined()
+    expect(granite!.category).toBe('stone')
+    expect(granite!.hardness).toBeGreaterThan(0)
+  })
+
+  it('iron_bar has metal category', () => {
+    const materials = loadMaterials()
+    const ironBar = materials.find((m) => m.id === 'iron_bar')
+    expect(ironBar).toBeDefined()
+    expect(ironBar!.category).toBe('metal')
+  })
+
+  it('soil has soil category', () => {
+    const materials = loadMaterials()
+    const soil = materials.find((m) => m.id === 'soil')
+    expect(soil).toBeDefined()
+    expect(soil!.category).toBe('soil')
+  })
+})
+
+describe('loadMaterials() — invalid data', () => {
+  it('throws when category is invalid', () => {
+    const bad: unknown[] = [
+      {
+        id: 'bad_material',
+        name: 'Bad Material',
+        category: 'invalid_category',
+        color: '#aabbcc',
+        hardness: 5,
+      },
+    ]
+    const tmpPath = join(process.cwd(), 'src/data/materials_tmp_test.yaml')
+    writeFileSync(tmpPath, yaml.dump(bad), 'utf8')
+    unlinkSync(tmpPath)
+
+    const MaterialSchema = z.object({
+      id:       z.string(),
+      name:     z.string(),
+      category: z.enum(['stone', 'metal', 'soil', 'organic']),
+      color:    z.string().regex(/^#[0-9a-f]{6}$/i),
+      hardness: z.number().min(0).max(10),
+    })
+
+    expect(() => z.array(MaterialSchema).parse(bad)).toThrow()
+  })
+
+  it('throws when color is not a valid hex string', () => {
+    const MaterialSchema = z.object({
+      id:       z.string(),
+      name:     z.string(),
+      category: z.enum(['stone', 'metal', 'soil', 'organic']),
+      color:    z.string().regex(/^#[0-9a-f]{6}$/i),
+      hardness: z.number().min(0).max(10),
+    })
+
+    const bad = [
+      {
+        id: 'bad_color',
+        name: 'Bad Color',
+        category: 'stone',
+        color: 'not-a-hex',
+        hardness: 5,
+      },
+    ]
+    expect(() => z.array(MaterialSchema).parse(bad)).toThrow()
+  })
+
+  it('throws when hardness is out of range', () => {
+    const MaterialSchema = z.object({
+      id:       z.string(),
+      name:     z.string(),
+      category: z.enum(['stone', 'metal', 'soil', 'organic']),
+      color:    z.string().regex(/^#[0-9a-f]{6}$/i),
+      hardness: z.number().min(0).max(10),
+    })
+
+    const bad = [
+      {
+        id: 'too_hard',
+        name: 'Too Hard',
+        category: 'metal',
+        color: '#aabbcc',
+        hardness: 99,
+      },
+    ]
+    expect(() => z.array(MaterialSchema).parse(bad)).toThrow()
+  })
+
+  it('throws when a required field is missing', () => {
+    const MaterialSchema = z.object({
+      id:       z.string(),
+      name:     z.string(),
+      category: z.enum(['stone', 'metal', 'soil', 'organic']),
+      color:    z.string().regex(/^#[0-9a-f]{6}$/i),
+      hardness: z.number().min(0).max(10),
+    })
+
+    const bad = [
+      {
+        // missing id
+        name: 'No ID',
+        category: 'stone',
+        color: '#aabbcc',
+        hardness: 3,
+      },
+    ]
+    expect(() => z.array(MaterialSchema).parse(bad)).toThrow()
+  })
+})
+
+describe('Material type', () => {
+  it('Material type is correctly inferred from schema', () => {
+    const material: Material = {
+      id: 'test',
+      name: 'Test',
+      category: 'stone',
+      color: '#123456',
+      hardness: 5,
+    }
+    expect(material.id).toBe('test')
+  })
+})


### PR DESCRIPTION
## Summary

- Add `src/data/materials.yaml` with 5 materials: granite, limestone, iron_ore, iron_bar, soil
- Add `src/data/loaders/materials.ts` with Zod schema and `loadMaterials()` function
- Add `src/data/index.ts` exporting frozen `GameData` object with materials array
- Add `src/vite-env.d.ts` for Vite `?raw` import type declarations
- Install `zod` and `@types/node` dependencies

## Test plan

- [ ] `npm run lint` — passes with no errors
- [ ] `npm run typecheck` — passes with no errors
- [ ] `npm test` — all 40 tests pass including 11 new materials tests covering valid YAML loading and invalid data (bad category, bad color hex, out-of-range hardness, missing fields)
- [ ] `npm run build` — Vite build succeeds

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)