### PR TITLE
feat: HeadlessGame API for programmatic game control (closes #9)

### DIFF
--- a/src/core/HeadlessGame.ts
+++ b/src/core/HeadlessGame.ts
@@ -1,0 +1,164 @@
+import { addEntity, addComponent, query } from 'bitecs'
+import { createGameWorld } from '@core/world'
+import type { GameWorld } from '@core/world'
+import { Position } from '@core/components/position'
+import { createWorld3D, setTile } from '@map/world3d'
+import type { World3D } from '@map/world3d'
+import { TileType } from '@map/tileTypes'
+import { WORLD_WIDTH, WORLD_HEIGHT, WORLD_DEPTH } from '@core/constants'
+import type { GameState, DwarfStatus, ItemCount } from '@core/types'
+
+type MineDesignation = {
+  x1: number; y1: number; z1: number
+  x2: number; y2: number; z2: number
+}
+
+type HeadlessGameOpts = {
+  seed: number
+  width?: number
+  height?: number
+  depth?: number
+}
+
+/**
+ * Programmatic, browser-free interface for running the game simulation.
+ * Used by tests and CI. Zero DOM dependencies — no window, document, canvas,
+ * or requestAnimationFrame.
+ */
+export class HeadlessGame {
+  private readonly seed: number
+  private readonly width: number
+  private readonly height: number
+  private readonly depth: number
+
+  private world: GameWorld | null = null
+  // Stored for future use by systems that need tile data
+  private map: World3D | null = null
+  private readonly mineDesignations: MineDesignation[] = []
+  private _tickCount = 0
+
+  constructor(opts: HeadlessGameOpts) {
+    this.seed = opts.seed
+    this.width = opts.width ?? WORLD_WIDTH
+    this.height = opts.height ?? WORLD_HEIGHT
+    this.depth = opts.depth ?? WORLD_DEPTH
+  }
+
+  /**
+   * Initialize the ECS world, generate the starting map (flat stone floor at z=0),
+   * and spawn 7 dwarves at the center of the map on the surface.
+   */
+  embark(): void {
+    this.world = createGameWorld()
+    this.map = createWorld3D(this.width, this.height, this.depth)
+    this._tickCount = 0
+
+    // Lay a flat stone floor at z=0 across the entire map
+    for (let y = 0; y < this.height; y++) {
+      for (let x = 0; x < this.width; x++) {
+        setTile(x, y, 0, this.map, TileType.Stone)
+      }
+    }
+
+    const centerX = Math.floor(this.width / 2)
+    const centerY = Math.floor(this.height / 2)
+
+    // Spawn 7 starting dwarves at the map center on the surface (z=0)
+    for (let i = 0; i < 7; i++) {
+      const eid = addEntity(this.world)
+      addComponent(this.world, eid, Position)
+      Position.x[eid] = centerX
+      Position.y[eid] = centerY
+      Position.z[eid] = 0
+    }
+  }
+
+  /**
+   * Advance the simulation by one tick and return the resulting GameState.
+   * Runs synchronously — no browser APIs used.
+   */
+  tick(): GameState {
+    if (this.world === null) {
+      throw new Error('Call embark() before tick()')
+    }
+    // No systems registered yet — advance the counter only.
+    // When systems are added they will be called here with the fixed dt.
+    this._tickCount += 1
+    return this._buildState()
+  }
+
+  /**
+   * Run N ticks and return the final GameState.
+   */
+  runFor(ticks: number): GameState {
+    if (this.world === null) {
+      throw new Error('Call embark() before runFor()')
+    }
+    for (let i = 0; i < ticks; i++) {
+      this.tick()
+    }
+    return this._buildState()
+  }
+
+  /**
+   * Mark a cuboid region for mining. Stored for future jobSystem integration.
+   */
+  designateMine(x1: number, y1: number, z1: number, x2: number, y2: number, z2: number): void {
+    this.mineDesignations.push({ x1, y1, z1, x2, y2, z2 })
+  }
+
+  /**
+   * Returns the list of stored mine designations (readable for tests).
+   */
+  getMineDesignations(): readonly MineDesignation[] {
+    return this.mineDesignations
+  }
+
+  /**
+   * Returns current stock counts. Empty array until the stocks system is implemented.
+   */
+  getStocks(): ItemCount[] {
+    return []
+  }
+
+  /**
+   * Returns the status of all dwarf entities (entities that have a Position component).
+   */
+  getDwarves(): DwarfStatus[] {
+    if (this.world === null) {
+      throw new Error('Call embark() before getDwarves()')
+    }
+
+    const entities = query(this.world, [Position])
+    const result: DwarfStatus[] = []
+
+    for (let i = 0; i < entities.length; i++) {
+      const eid = entities[i]!
+      result.push({
+        eid,
+        x: Position.x[eid] ?? 0,
+        y: Position.y[eid] ?? 0,
+        z: Position.z[eid] ?? 0,
+        hunger: 0,
+        thirst: 0,
+        sleep: 0,
+        happiness: 1,
+        job: null,
+      })
+    }
+
+    return result
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private _buildState(): GameState {
+    return {
+      tick: this._tickCount,
+      dwarves: this.getDwarves(),
+      stocks: this.getStocks(),
+    }
+  }
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -7,3 +7,45 @@ import type { GameWorld } from '@core/world'
  * Systems are pure: no return value, no stored state, no browser APIs.
  */
 export type SystemFn = (world: GameWorld, dt: number) => void
+
+/**
+ * Commands dispatched from player input (keyboard / mouse) to the command handler.
+ */
+export type GameCommand =
+  | { type: 'MOVE_CAMERA'; dx: number; dy: number }
+  | { type: 'CHANGE_Z'; dz: number }
+  | { type: 'TILE_CLICK'; x: number; y: number; z: number }
+  | { type: 'TILE_RIGHT_CLICK'; x: number; y: number; z: number }
+  | { type: 'CANCEL' }
+
+/**
+ * Snapshot of a single dwarf's state, returned by HeadlessGame.getDwarves().
+ */
+export type DwarfStatus = {
+  eid: number
+  x: number
+  y: number
+  z: number
+  hunger: number
+  thirst: number
+  sleep: number
+  happiness: number
+  job: string | null
+}
+
+/**
+ * A count of a specific item type, returned by HeadlessGame.getStocks().
+ */
+export type ItemCount = {
+  itemType: string
+  count: number
+}
+
+/**
+ * A snapshot of the full game state, returned by HeadlessGame.tick() and runFor().
+ */
+export type GameState = {
+  tick: number
+  dwarves: DwarfStatus[]
+  stocks: ItemCount[]
+}

--- a/tests/core/HeadlessGame.test.ts
+++ b/tests/core/HeadlessGame.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { HeadlessGame } from '@core/HeadlessGame'
+
+describe('HeadlessGame', () => {
+  let game: HeadlessGame
+
+  beforeEach(() => {
+    game = new HeadlessGame({ seed: 42, width: 32, height: 32, depth: 4 })
+  })
+
+  describe('embark()', () => {
+    it('spawns exactly 7 dwarves', () => {
+      game.embark()
+      expect(game.getDwarves()).toHaveLength(7)
+    })
+
+    it('places dwarves at the center of the map at z=0', () => {
+      game.embark()
+      const dwarves = game.getDwarves()
+      for (const dwarf of dwarves) {
+        expect(dwarf.x).toBe(16)   // Math.floor(32 / 2)
+        expect(dwarf.y).toBe(16)
+        expect(dwarf.z).toBe(0)
+      }
+    })
+
+    it('resets the tick counter on re-embark', () => {
+      game.embark()
+      game.tick()
+      game.embark()
+      const state = game.tick()
+      expect(state.tick).toBe(1)
+    })
+  })
+
+  describe('tick()', () => {
+    it('increments the tick counter by 1', () => {
+      game.embark()
+      const s1 = game.tick()
+      expect(s1.tick).toBe(1)
+      const s2 = game.tick()
+      expect(s2.tick).toBe(2)
+    })
+
+    it('returns a GameState with dwarves and stocks fields', () => {
+      game.embark()
+      const state = game.tick()
+      expect(state).toHaveProperty('tick')
+      expect(state).toHaveProperty('dwarves')
+      expect(state).toHaveProperty('stocks')
+    })
+
+    it('throws if called before embark()', () => {
+      expect(() => game.tick()).toThrow('Call embark() before tick()')
+    })
+  })
+
+  describe('runFor(n)', () => {
+    it('returns GameState with tick === n after running n ticks', () => {
+      game.embark()
+      const state = game.runFor(10)
+      expect(state.tick).toBe(10)
+    })
+
+    it('returns tick === 0 when n === 0', () => {
+      game.embark()
+      const state = game.runFor(0)
+      expect(state.tick).toBe(0)
+    })
+
+    it('accumulates ticks across multiple runFor calls', () => {
+      game.embark()
+      game.runFor(5)
+      const state = game.runFor(3)
+      expect(state.tick).toBe(8)
+    })
+
+    it('throws if called before embark()', () => {
+      expect(() => game.runFor(1)).toThrow('Call embark() before runFor()')
+    })
+  })
+
+  describe('designateMine()', () => {
+    it('stores a single mine designation', () => {
+      game.embark()
+      game.designateMine(1, 2, 0, 5, 6, 0)
+      const designations = game.getMineDesignations()
+      expect(designations).toHaveLength(1)
+      expect(designations[0]).toEqual({ x1: 1, y1: 2, z1: 0, x2: 5, y2: 6, z2: 0 })
+    })
+
+    it('stores multiple designations independently', () => {
+      game.embark()
+      game.designateMine(0, 0, 0, 2, 2, 0)
+      game.designateMine(10, 10, 1, 15, 15, 1)
+      expect(game.getMineDesignations()).toHaveLength(2)
+    })
+  })
+
+  describe('getStocks()', () => {
+    it('returns an empty array (stocks system not yet built)', () => {
+      game.embark()
+      expect(game.getStocks()).toEqual([])
+    })
+  })
+
+  describe('getDwarves()', () => {
+    it('returns DwarfStatus objects with required fields', () => {
+      game.embark()
+      const dwarves = game.getDwarves()
+      expect(dwarves.length).toBeGreaterThan(0)
+      const dwarf = dwarves[0]!
+      expect(typeof dwarf.eid).toBe('number')
+      expect(typeof dwarf.x).toBe('number')
+      expect(typeof dwarf.y).toBe('number')
+      expect(typeof dwarf.z).toBe('number')
+      expect(typeof dwarf.hunger).toBe('number')
+      expect(typeof dwarf.thirst).toBe('number')
+      expect(typeof dwarf.sleep).toBe('number')
+      expect(typeof dwarf.happiness).toBe('number')
+      expect(dwarf.job === null || typeof dwarf.job === 'string').toBe(true)
+    })
+
+    it('throws if called before embark()', () => {
+      expect(() => game.getDwarves()).toThrow('Call embark() before getDwarves()')
+    })
+  })
+
+  describe('no browser globals', () => {
+    it('runs ticks without accessing window, document, or requestAnimationFrame', () => {
+      // This test runs in Node/Vitest without jsdom. If any browser global were
+      // accessed, an error would be thrown here.
+      game.embark()
+      game.runFor(10)
+      expect(game.getDwarves()).toHaveLength(7)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Closes #9

Implements the `HeadlessGame` class in `src/core/HeadlessGame.ts` — a programmatic, browser-free interface for running the game simulation. It wraps ECS world creation, tile map initialization, and dwarf entity spawning behind a clean API used by tests and CI. Also adds `GameState`, `DwarfStatus`, and `ItemCount` types to `src/core/types.ts`.

## Acceptance criteria

- [x] `src/core/HeadlessGame.ts` exports `HeadlessGame` class
- [x] Constructor accepts `{ seed, width?, height?, depth? }`
- [x] `embark()` initializes world (flat stone floor at z=0, 7 dwarves at center)
- [x] `tick()` advances one game tick, returns `GameState`
- [x] `runFor(n)` runs N ticks, returns final `GameState`
- [x] `designateMine(x1,y1,z1,x2,y2,z2)` stores the designation (stub)
- [x] `getStocks()` returns `ItemCount[]` (empty array, stocks not yet built)
- [x] `getDwarves()` returns `DwarfStatus[]` with position and stub need values
- [x] Zero browser APIs — no window, document, canvas, requestAnimationFrame

## Test plan

- [ ] `npm run lint` — passes with no warnings
- [ ] `npm run typecheck` — passes with strict mode on
- [ ] `npm test` — all 68 tests pass including new HeadlessGame suite
- [ ] `npm run build` — clean production build

Tests cover: 7 dwarves after embark, correct map-center placement, tick counter increments, `runFor(10)` returns `tick === 10`, designation storage, pre-embark error throwing, no browser globals in Node environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)