### PR TITLE
docs: add agent model selection rules to CLAUDE.md (closes #94)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,3 +80,11 @@ TILE_SIZE = 16px, TICKS_PER_SECOND = 20, MAX_ENTITIES = 10 000
 ## Branch policy
 
 One branch per issue (see CI/agent guide in `.github/`). PRs target `main`.
+
+## Agent model selection
+
+- **Subagents** (research, search, exploration, file reads): use `model: "sonnet"`
+- **Trivial lookups** (single file search, simple one-off questions): use `model: "haiku"`
+- **Main context** (synthesis, architectural decisions, writing code): opus (default — no override needed)
+
+Never spawn a subagent with opus. Reserve the main context for work that requires synthesis across multiple sources or non-trivial code generation.


### PR DESCRIPTION
Closes #94

## What this does
Adds a new `## Agent model selection` section to CLAUDE.md specifying which Claude model to use in each context, so subagents don't wastefully consume opus capacity.

## Acceptance criteria covered
- [x] haiku for trivial lookups (single file search, simple questions)
- [x] sonnet for all spawned subagents (research, search, exploration)
- [x] opus reserved for main context only (synthesis, architecture, code writing)

## Test plan
- [x] Docs-only change — no code modified