### PR TITLE
docs: add review-prs and squash-prs Claude skills (closes #98)

### DIFF
--- a/.claude/commands/review-prs.md
+++ b/.claude/commands/review-prs.md
@@ -1,0 +1,47 @@
+Review all open pull requests and report anything that needs attention. For each open PR, check:
+
+1. **Merge conflicts** — if `mergeable` is `CONFLICTING`, the branch needs to be rebased onto main
+2. **CI failures** — if the latest check run has `conclusion: FAILURE`, fetch the failed log and summarize the error
+3. **Needs squash** — if the branch has more than one commit ahead of main, it must be squashed before merging
+4. **Stale / no CI** — if there are no check runs yet or the last run is very old, flag it
+
+Steps:
+
+```bash
+# Get all open PRs with merge status and CI checks
+gh pr list --state open --json number,title,headRefName,mergeable,statusCheckRollup
+```
+
+For each PR, check commit count ahead of main:
+```bash
+git log --oneline origin/<branch> ^origin/main
+```
+
+For each PR with a CI failure, fetch the failed log:
+```bash
+gh run view <run-id> --log-failed
+```
+
+Then produce a concise report in this format:
+
+---
+## PR Health Report
+
+### Needs rebase
+- #N — <title> (`feat/branch-name` conflicts with main)
+
+### CI failing
+- #N — <title>: <one-line summary of the error>
+
+### Needs squash
+- #N — <title>: X commits, must be squashed to 1
+
+### All clear
+- #N — <title> ✓
+
+---
+
+After the report, ask the user which items they'd like to address. If they say "fix them all" or similar, work through each one:
+- For a **rebase**: check out the branch, `git fetch origin main`, `git rebase origin/main`, resolve any conflicts, then `git push --force-with-lease`
+- For a **CI failure**: read the relevant source files, fix the error, commit, and push
+- For a **squash**: check out the branch, `git reset --soft origin/main`, recommit with a clean message, then `git push --force-with-lease`

--- a/.claude/commands/squash-prs.md
+++ b/.claude/commands/squash-prs.md
@@ -1,0 +1,30 @@
+Squash all open PRs down to a single commit each (per branch policy).
+
+Steps:
+
+```bash
+# List all open PRs
+gh pr list --state open --json number,title,headRefName
+```
+
+For each PR branch, check how many commits it has ahead of main:
+```bash
+git log --oneline origin/<branch> ^origin/main
+```
+
+Skip any branch that already has exactly one commit.
+
+For each branch with more than one commit:
+1. Check out the branch: `git checkout <branch>`
+2. Soft-reset to main: `git reset --soft origin/main`
+3. Commit with the PR title as the message (keep the `closes #N` reference): `git commit -m "..."`
+4. Force push: `git push --force-with-lease`
+
+After squashing all branches, confirm with a summary:
+
+---
+## Squash complete
+
+- #N — <title>: squashed <X> commits → 1 ✓
+- #N — <title>: already 1 commit, skipped ✓
+---


### PR DESCRIPTION
## Summary
- Adds `/review-prs` skill: checks all open PRs for merge conflicts, CI failures, multi-commit branches, and stale CI
- Adds `/squash-prs` skill: squashes all open PR branches to a single commit per branch policy

closes #98