### PR TITLE
feat: phase 0 integration — wired tick loop, renderer, movement system (closes #11)

### DIFF
--- a/src/core/HeadlessGame.ts
+++ b/src/core/HeadlessGame.ts
@@ -5,8 +5,9 @@ import { Position } from '@core/components/position'
 import { createWorld3D, setTile } from '@map/world3d'
 import type { World3D } from '@map/world3d'
 import { TileType } from '@map/tileTypes'
-import { WORLD_WIDTH, WORLD_HEIGHT, WORLD_DEPTH } from '@core/constants'
+import { WORLD_WIDTH, WORLD_HEIGHT, WORLD_DEPTH, TICKS_PER_SECOND } from '@core/constants'
 import type { GameState, DwarfStatus, ItemCount } from '@core/types'
+import { movementSystem } from '@systems/movementSystem'
 
 type MineDesignation = {
   x1: number; y1: number; z1: number
@@ -74,6 +75,17 @@ export class HeadlessGame {
   }
 
   /**
+   * Returns the World3D tile map. Used by the renderer in browser context.
+   * Throws if called before embark().
+   */
+  getMap(): World3D {
+    if (this.map === null) {
+      throw new Error('Call embark() before getMap()')
+    }
+    return this.map
+  }
+
+  /**
    * Advance the simulation by one tick and return the resulting GameState.
    * Runs synchronously — no browser APIs used.
    */
@@ -81,8 +93,8 @@ export class HeadlessGame {
     if (this.world === null) {
       throw new Error('Call embark() before tick()')
     }
-    // No systems registered yet — advance the counter only.
-    // When systems are added they will be called here with the fixed dt.
+    const dt = 1 / TICKS_PER_SECOND
+    movementSystem(this.world, dt)
     this._tickCount += 1
     return this._buildState()
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,19 +1,9 @@
-import { createWorld3D, setTile } from '@map/world3d'
-import { TileType } from '@map/tileTypes'
+import { HeadlessGame } from '@core/HeadlessGame'
 import { createRenderer } from '@ui/renderer'
+import { TICKS_PER_SECOND } from '@core/constants'
 
-const WIDTH  = 128
-const HEIGHT = 128
-const DEPTH  = 16
-
-const world = createWorld3D(WIDTH, HEIGHT, DEPTH)
-
-// Fill z=0 with Stone tiles
-for (let y = 0; y < HEIGHT; y++) {
-  for (let x = 0; x < WIDTH; x++) {
-    setTile(x, y, 0, world, TileType.Stone)
-  }
-}
+const game = new HeadlessGame({ seed: 42 })
+game.embark()
 
 const appEl = document.getElementById('app')
 if (!appEl) throw new Error('No #app element found')
@@ -23,8 +13,37 @@ canvas.width  = 512
 canvas.height = 512
 appEl.appendChild(canvas)
 
+let cameraX = 0
+let cameraY = 0
+let viewZ   = 0
+
+window.addEventListener('keydown', (e: KeyboardEvent) => {
+  switch (e.key) {
+    case 'ArrowUp':    case 'w': case 'W': cameraY -= 1; break
+    case 'ArrowDown':  case 's': case 'S': cameraY += 1; break
+    case 'ArrowLeft':  case 'a': case 'A': cameraX -= 1; break
+    case 'ArrowRight': case 'd': case 'D': cameraX += 1; break
+    case '+': case '=': viewZ += 1; break
+    case '-': viewZ -= 1; break
+  }
+  cameraX = Math.max(0, cameraX)
+  cameraY = Math.max(0, cameraY)
+  viewZ   = Math.max(0, viewZ)
+})
+
 createRenderer(canvas).then((renderer) => {
-  renderer.drawTiles(world, 0, 0, 0)
+  const map = game.getMap()
+
+  // Advance simulation at a fixed tick rate
+  setInterval(() => { game.tick() }, 1000 / TICKS_PER_SECOND)
+
+  // Render each animation frame
+  function frame(): void {
+    renderer.drawTiles(map, viewZ, cameraX, cameraY)
+    renderer.drawDwarves(game.getDwarves(), viewZ, cameraX, cameraY)
+    requestAnimationFrame(frame)
+  }
+  requestAnimationFrame(frame)
 }).catch((err: unknown) => {
   console.error('Renderer init failed', err)
 })

--- a/src/systems/movementSystem.ts
+++ b/src/systems/movementSystem.ts
@@ -1,0 +1,29 @@
+import { query } from 'bitecs'
+import type { GameWorld } from '@core/world'
+import { Position } from '@core/components/position'
+import { WORLD_WIDTH, WORLD_HEIGHT } from '@core/constants'
+
+/**
+ * Random-walk movement system: each tick every dwarf moves to a random
+ * adjacent tile or stays put (4 directions + idle = 5 outcomes).
+ */
+export function movementSystem(world: GameWorld, _dt: number): void {
+  const entities = query(world, [Position])
+  for (let i = 0; i < entities.length; i++) {
+    const eid = entities[i]!
+    let nx = Position.x[eid] ?? 0
+    let ny = Position.y[eid] ?? 0
+
+    // 0 = stay, 1 = up, 2 = down, 3 = left, 4 = right
+    const dir = Math.floor(Math.random() * 5)
+    switch (dir) {
+      case 1: ny -= 1; break
+      case 2: ny += 1; break
+      case 3: nx -= 1; break
+      case 4: nx += 1; break
+    }
+
+    Position.x[eid] = Math.max(0, Math.min(WORLD_WIDTH - 1, nx))
+    Position.y[eid] = Math.max(0, Math.min(WORLD_HEIGHT - 1, ny))
+  }
+}

--- a/src/ui/renderer.ts
+++ b/src/ui/renderer.ts
@@ -3,8 +3,11 @@ import { TILE_SIZE } from '@core/constants'
 import { type World3D, getTile } from '@map/world3d'
 import { TILE_COLORS } from './tileColors'
 
+type DwarfPos = { x: number; y: number; z: number }
+
 export type Renderer = {
   drawTiles(world: World3D, viewZ: number, cameraX: number, cameraY: number): void
+  drawDwarves(dwarves: DwarfPos[], viewZ: number, cameraX: number, cameraY: number): void
   destroy(): void
 }
 
@@ -21,6 +24,9 @@ export async function createRenderer(canvas: HTMLCanvasElement): Promise<Rendere
 
   const tilesGfx = new Graphics()
   app.stage.addChild(tilesGfx)
+
+  const dwarfGfx = new Graphics()
+  app.stage.addChild(dwarfGfx)
 
   function drawTiles(world: World3D, viewZ: number, cameraX: number, cameraY: number): void {
     tilesGfx.clear()
@@ -48,9 +54,20 @@ export async function createRenderer(canvas: HTMLCanvasElement): Promise<Rendere
     }
   }
 
+  function drawDwarves(dwarves: DwarfPos[], viewZ: number, cameraX: number, cameraY: number): void {
+    dwarfGfx.clear()
+    for (const d of dwarves) {
+      if (d.z !== viewZ) continue
+      const screenX = (d.x - cameraX) * TILE_SIZE
+      const screenY = (d.y - cameraY) * TILE_SIZE
+      // Draw dwarf as a cyan square inset 2px from the tile edges
+      dwarfGfx.rect(screenX + 2, screenY + 2, TILE_SIZE - 4, TILE_SIZE - 4).fill(0x00FFFF)
+    }
+  }
+
   function destroy(): void {
     app.destroy()
   }
 
-  return { drawTiles, destroy }
+  return { drawTiles, drawDwarves, destroy }
 }

--- a/tests/integration/phase0.test.ts
+++ b/tests/integration/phase0.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { HeadlessGame } from '@core/HeadlessGame'
+
+describe('Phase 0 integration', () => {
+  it('runs 100 ticks without error', () => {
+    const game = new HeadlessGame({ seed: 42 })
+    game.embark()
+    const state = game.runFor(100)
+    expect(state.dwarves.length).toBeGreaterThan(0)
+    expect(state.tick).toBe(100)
+  })
+
+  it('spawns exactly 7 dwarves on embark', () => {
+    const game = new HeadlessGame({ seed: 1 })
+    game.embark()
+    const state = game.runFor(0)
+    expect(state.dwarves.length).toBe(7)
+  })
+
+  it('dwarves stay within world bounds after 100 ticks', () => {
+    const game = new HeadlessGame({ seed: 7 })
+    game.embark()
+    const state = game.runFor(100)
+    for (const d of state.dwarves) {
+      expect(d.x).toBeGreaterThanOrEqual(0)
+      expect(d.y).toBeGreaterThanOrEqual(0)
+      expect(d.x).toBeLessThan(128)
+      expect(d.y).toBeLessThan(128)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `movementSystem` — random-walk SystemFn that moves dwarves each tick, clamped to world bounds
- `HeadlessGame` now calls `movementSystem` in `tick()` and exposes `getMap()` for the renderer
- `renderer.ts` gains `drawDwarves()` — renders each dwarf as a cyan inset square on its tile
- `main.ts` wired end-to-end: `HeadlessGame` embark, `createRenderer`, fixed-rate `setInterval` tick loop, `requestAnimationFrame` render loop, and keyboard camera pan + z-level change
- Adds `tests/integration/phase0.test.ts` with 3 headless assertions: 100-tick run, exact dwarf count (7), and world-bounds check

## Test plan
- [ ] `npm test` — all 71 tests pass
- [ ] `npm run build` — production build succeeds
- [ ] `npm run dev` — PixiJS canvas renders gray stone tiles with 7 cyan dwarves moving around
- [ ] Arrow keys / WASD pan the camera; `+`/`-` change the z-level

🤖 Generated with [Claude Code](https://claude.com/claude-code)