### PR TITLE
feat: structured logging via Axiom (closes #104)

### DIFF
--- a/src/core/HeadlessGame.ts
+++ b/src/core/HeadlessGame.ts
@@ -8,6 +8,7 @@ import { TileType } from '@map/tileTypes'
 import { WORLD_WIDTH, WORLD_HEIGHT, WORLD_DEPTH, TICKS_PER_SECOND } from '@core/constants'
 import type { GameState, DwarfStatus, ItemCount } from '@core/types'
 import { movementSystem } from '@systems/movementSystem'
+import { log } from '@core/logger'
 
 type MineDesignation = {
   x1: number; y1: number; z1: number
@@ -61,6 +62,13 @@ export class HeadlessGame {
       }
     }
 
+    log('info', 'world.gen.complete', {
+      seed: this.seed,
+      width: this.width,
+      height: this.height,
+      depth: this.depth,
+    })
+
     const centerX = Math.floor(this.width / 2)
     const centerY = Math.floor(this.height / 2)
 
@@ -72,6 +80,8 @@ export class HeadlessGame {
       Position.y[eid] = centerY
       Position.z[eid] = 0
     }
+
+    log('info', 'embark.dwarves_spawned', { count: 7, centerX, centerY })
   }
 
   /**

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -1,0 +1,96 @@
+export type Level = 'debug' | 'info' | 'warn' | 'error'
+
+export interface LogEntry {
+  _time: string
+  level: Level
+  event: string
+  data?: Record<string, unknown>
+}
+
+type Sink = (entries: LogEntry[]) => void | Promise<void>
+
+let _buffer: LogEntry[] = []
+let _sink: Sink | null = null
+let _flushTimer: ReturnType<typeof setInterval> | null = null
+
+/**
+ * Initialize Axiom logging. Call once at app startup.
+ * No-op if token/dataset are absent — safe to call unconditionally.
+ */
+export function initLogger(config: {
+  token: string
+  dataset: string
+  flushIntervalMs?: number
+}): void {
+  const { token, dataset, flushIntervalMs = 10_000 } = config
+
+  _sink = async (entries: LogEntry[]) => {
+    try {
+      await fetch(`https://api.axiom.co/v1/datasets/${dataset}/ingest`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(entries),
+      })
+    } catch {
+      // silent failure — logging must never crash the game
+    }
+  }
+
+  _flushTimer = setInterval(() => { void _flush() }, flushIntervalMs)
+
+  if (typeof window !== 'undefined') {
+    window.addEventListener('beforeunload', () => { void _flush() })
+  }
+}
+
+/** Replace the flush sink. Pass `null` to disable (useful in tests). */
+export function setSink(sink: Sink | null): void {
+  _sink = sink
+}
+
+/** Return a snapshot of the current in-memory buffer. */
+export function getBuffer(): readonly LogEntry[] {
+  return _buffer
+}
+
+/** Discard all buffered entries without flushing. */
+export function clearBuffer(): void {
+  _buffer = []
+}
+
+/** Stop the flush interval and clear the sink. Call in test teardown. */
+export function stopLogger(): void {
+  if (_flushTimer !== null) {
+    clearInterval(_flushTimer)
+    _flushTimer = null
+  }
+  _sink = null
+}
+
+/** Record a structured log entry. */
+export function log(level: Level, event: string, data?: Record<string, unknown>): void {
+  _buffer.push({
+    _time: new Date().toISOString(),
+    level,
+    event,
+    ...(data !== undefined ? { data } : {}),
+  })
+}
+
+/** Flush buffered entries to the sink immediately. */
+export async function flushNow(): Promise<void> {
+  await _flush()
+}
+
+async function _flush(): Promise<void> {
+  if (_buffer.length === 0 || _sink === null) return
+  const entries = _buffer.splice(0)
+  try {
+    await _sink(entries)
+  } catch {
+    // silent failure
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,13 @@
 import { HeadlessGame } from '@core/HeadlessGame'
 import { createRenderer } from '@ui/renderer'
 import { TICKS_PER_SECOND } from '@core/constants'
+import { initLogger } from '@core/logger'
+
+const axiomToken = import.meta.env.VITE_AXIOM_TOKEN
+const axiomDataset = import.meta.env.VITE_AXIOM_DATASET
+if (axiomToken !== undefined && axiomDataset !== undefined) {
+  initLogger({ token: axiomToken, dataset: axiomDataset })
+}
 
 const game = new HeadlessGame({ seed: 42 })
 game.embark()

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_AXIOM_TOKEN: string | undefined
+  readonly VITE_AXIOM_DATASET: string | undefined
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/tests/core/logger.test.ts
+++ b/tests/core/logger.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import {
+  log,
+  getBuffer,
+  clearBuffer,
+  setSink,
+  flushNow,
+  stopLogger,
+} from '@core/logger'
+import type { LogEntry } from '@core/logger'
+
+describe('logger', () => {
+  beforeEach(() => {
+    clearBuffer()
+    setSink(null)
+  })
+
+  afterEach(() => {
+    stopLogger()
+    clearBuffer()
+  })
+
+  it('buffers an entry with correct shape', () => {
+    log('info', 'test.event', { key: 'value' })
+    const buffer = getBuffer()
+    expect(buffer).toHaveLength(1)
+    const entry = buffer[0]!
+    expect(entry.level).toBe('info')
+    expect(entry.event).toBe('test.event')
+    expect(entry.data).toEqual({ key: 'value' })
+    expect(entry._time).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+
+  it('omits data field when not provided', () => {
+    log('warn', 'test.no_data')
+    const entry = getBuffer()[0]!
+    expect('data' in entry).toBe(false)
+  })
+
+  it('buffers multiple entries in order', () => {
+    log('debug', 'first')
+    log('error', 'second')
+    const buffer = getBuffer()
+    expect(buffer).toHaveLength(2)
+    expect(buffer[0]!.event).toBe('first')
+    expect(buffer[1]!.event).toBe('second')
+  })
+
+  it('flushNow sends buffered entries to the sink and clears the buffer', async () => {
+    const received: LogEntry[] = []
+    setSink((entries) => { received.push(...entries) })
+    log('info', 'a')
+    log('info', 'b')
+    await flushNow()
+    expect(received).toHaveLength(2)
+    expect(getBuffer()).toHaveLength(0)
+  })
+
+  it('flushNow is a no-op when sink is null', async () => {
+    log('info', 'no.sink')
+    await flushNow()
+    expect(getBuffer()).toHaveLength(1)
+  })
+
+  it('flushNow is a no-op when buffer is empty', async () => {
+    let called = false
+    setSink(() => { called = true })
+    await flushNow()
+    expect(called).toBe(false)
+  })
+
+  it('clearBuffer discards entries without flushing', () => {
+    log('info', 'to.discard')
+    clearBuffer()
+    expect(getBuffer()).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `src/core/logger.ts` — buffered structured logger with Axiom HTTP ingest
- Flushes on a 10s interval and on `beforeunload`; silent on failure
- No-op when `VITE_AXIOM_TOKEN` / `VITE_AXIOM_DATASET` env vars are absent
- `setSink` / `flushNow` / `stopLogger` APIs for test isolation (no network calls in tests)
- `HeadlessGame.embark()` logs `world.gen.complete` and `embark.dwarves_spawned`
- 7 new unit tests, all 100 tests passing

## Secrets needed

Before this does anything in production, add these to the repo's GitHub Actions secrets (and your local `.env.local`):

| Secret | Description |
|---|---|
| `VITE_AXIOM_TOKEN` | Axiom API token (from Axiom → Settings → API Tokens) |
| `VITE_AXIOM_DATASET` | Axiom dataset name to ingest into |

🤖 Generated with [Claude Code](https://claude.com/claude-code)