### PR TITLE
fix: pass Axiom env vars to deploy build step (closes #109)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,9 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+        env:
+          VITE_AXIOM_TOKEN: ${{ secrets.VITE_AXIOM_TOKEN }}
+          VITE_AXIOM_DATASET: ${{ secrets.VITE_AXIOM_DATASET }}
       - uses: actions/configure-pages@v4
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary

- Adds `env:` block to the `npm run build` step in `deploy.yml`
- Forwards `VITE_AXIOM_TOKEN` and `VITE_AXIOM_DATASET` secrets so Vite bakes them into the production bundle
- Without this, the logger was silently a no-op on the deployed site

🤖 Generated with [Claude Code](https://claude.com/claude-code)