### PR TITLE
chore: add workflow_dispatch to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds a manual trigger button to the Deploy workflow so it can be run on-demand from the GitHub Actions UI without needing a push to main.

No linked issue — infra-only config change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)