### PR TITLE
feat: HUD overlay, dev server redirect, and Z-level clamp (closes #117)

### DIFF
--- a/.claude/skills/playtest/SKILL.md
+++ b/.claude/skills/playtest/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: playtest
+description: Play the pwarf game in the browser, observe what's working and what isn't, and report honest feedback. Optionally fix issues found.
+user-invocable: true
+allowed-tools: Bash, Read, Glob, Grep, Edit, Write
+---
+
+You are doing a playtest of the pwarf browser game. Follow these steps:
+
+## 1. Ensure the dev server is running
+
+Check if Vite is running on port 5173:
+```bash
+lsof -i :5173 | head -3
+```
+If not running, start it in the background: `npm run dev &` then wait 3 seconds.
+
+## 2. Load browser tools and open the game
+
+Use ToolSearch to load `mcp__claude-in-chrome__tabs_context_mcp`, then get tab context.
+Create a new tab with `mcp__claude-in-chrome__tabs_create_mcp`, then navigate it to `http://localhost:5173`.
+Wait 2 seconds for the game to load, then take a screenshot.
+
+## 3. Observe the game
+
+Take multiple screenshots over ~10 seconds while performing these checks:
+- Does the game load without errors?
+- Is the HUD visible (Z level, tick count)?
+- Are dwarves present and moving?
+- Try pressing `H` to open/close help overlay
+- Try pressing `=` and `-` to change Z levels (use JavaScript dispatch if needed: `window.dispatchEvent(new KeyboardEvent('keydown', { key: '=', bubbles: true }))`)
+- Try panning the camera with arrow key dispatches
+- Note anything broken, ugly, confusing, or missing
+
+## 4. Report findings
+
+Give honest, specific feedback as a player would:
+- **What works well** (with evidence from screenshots)
+- **Bugs found** (specific, reproducible)
+- **UX issues** (confusing controls, missing feedback, etc.)
+- **What's missing** that would make it feel more like a game
+
+## 5. Fix issues (optional)
+
+If the user asked you to fix what you found, or if there are obvious quick fixes (e.g. a typo in the HUD, a clamping bug), go ahead and fix them. For larger issues, file GitHub issues instead.
+
+After fixing, reload the game and take a final "after" screenshot to confirm the fix.

--- a/index.html
+++ b/index.html
@@ -8,6 +8,17 @@
       body, html { margin: 0; padding: 0; overflow: hidden; background: #1a1a1a; color: #ccc; font-family: monospace; }
       #app { position: relative; width: 100vw; height: 100vh; }
 
+      #hud {
+        position: absolute;
+        top: 12px;
+        left: 16px;
+        font-size: 12px;
+        color: #aaa;
+        pointer-events: none;
+        z-index: 10;
+        line-height: 1.6;
+      }
+
       #help-hint {
         position: absolute;
         bottom: 12px;
@@ -45,6 +56,10 @@
   </head>
   <body>
     <div id="app">
+      <div id="hud">
+        <div id="hud-z">Z: 0 (surface)</div>
+        <div id="hud-tick">Tick: 0</div>
+      </div>
       <div id="help-hint">H – help</div>
       <div id="help-modal">
         <div id="help-modal-box">

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { HeadlessGame } from '@core/HeadlessGame'
 import { createRenderer } from '@ui/renderer'
-import { TICKS_PER_SECOND, WORLD_WIDTH, WORLD_HEIGHT, TILE_SIZE } from '@core/constants'
+import { TICKS_PER_SECOND, WORLD_WIDTH, WORLD_HEIGHT, WORLD_DEPTH, TILE_SIZE } from '@core/constants'
 import { initLogger } from '@core/logger'
 
 const axiomToken = import.meta.env.VITE_AXIOM_TOKEN
@@ -17,6 +17,9 @@ if (!appEl) throw new Error('No #app element found')
 
 const helpModal = document.getElementById('help-modal')
 if (!helpModal) throw new Error('No #help-modal element found')
+
+const hudZ    = document.getElementById('hud-z')
+const hudTick = document.getElementById('hud-tick')
 
 helpModal.addEventListener('click', () => { helpModal.classList.remove('open') })
 
@@ -49,7 +52,8 @@ window.addEventListener('keydown', (e: KeyboardEvent) => {
   }
   cameraX = Math.max(0, cameraX)
   cameraY = Math.max(0, cameraY)
-  viewZ   = Math.max(0, viewZ)
+  viewZ   = Math.max(0, Math.min(WORLD_DEPTH - 1, viewZ))
+  if (hudZ) hudZ.textContent = `Z: ${viewZ}${viewZ === 0 ? ' (surface)' : ''}`
 })
 
 createRenderer(canvas).then((renderer) => {
@@ -64,7 +68,10 @@ createRenderer(canvas).then((renderer) => {
   })
 
   // Advance simulation at a fixed tick rate
-  setInterval(() => { game.tick() }, 1000 / TICKS_PER_SECOND)
+  setInterval(() => {
+    const state = game.tick()
+    if (hudTick) hudTick.textContent = `Tick: ${state.tick}`
+  }, 1000 / TICKS_PER_SECOND)
 
   // Render each animation frame
   function frame(): void {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,24 @@
-import { defineConfig } from 'vite'
+import { defineConfig, type Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
 import tsconfigPaths from 'vite-tsconfig-paths'
 
+const redirectRoot: Plugin = {
+  name: 'redirect-root',
+  configureServer(server) {
+    server.middlewares.use((req, res, next) => {
+      if (req.url === '/') {
+        res.writeHead(302, { Location: '/pwarf/' })
+        res.end()
+        return
+      }
+      next()
+    })
+  },
+}
+
 export default defineConfig({
   base: '/pwarf/',
-  plugins: [react(), tsconfigPaths()],
+  plugins: [react(), tsconfigPaths(), redirectRoot],
   build: {
     target: 'es2022',
   },


### PR DESCRIPTION
## Summary
- **HUD**: top-left overlay showing live Z level (`Z: 0 (surface)`) and tick count — makes game state readable at a glance
- **Dev server redirect**: navigating to `localhost:5173` now redirects to `/pwarf/` automatically via a Vite plugin
- **Z-level clamp**: `viewZ` is now clamped to `[0, WORLD_DEPTH-1]` — `+`/`=` no longer drifts past the valid range
- **`/playtest` skill**: new project skill for running browser playtests and reporting findings

## Test plan
- [ ] `npm run dev`, navigate to `http://localhost:5173` — should redirect to `/pwarf/` and show the game
- [ ] HUD visible top-left with Z and Tick updating live
- [ ] Press `=` — Z increments to 1, view goes dark (empty z-level), no dwarves visible
- [ ] Press `-` — Z returns to 0, dwarves reappear, label shows `(surface)`
- [ ] All 100 tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)