### PR TITLE
feat: idle wander + render items on map (closes #123)

### DIFF
--- a/src/core/HeadlessGame.ts
+++ b/src/core/HeadlessGame.ts
@@ -170,7 +170,7 @@ export class HeadlessGame {
     consumptionSystem(this.world, this.map, this._tickCount)
     sleepingSystem(this.world, this._tickCount)
     tantrumsSystem(this.world, this._tickCount)
-    movementSystem(this.world, dt)
+    movementSystem(this.world, dt, this.map)
     jobCleanupSystem(this.world)
 
     this._tickCount += 1
@@ -297,6 +297,28 @@ export class HeadlessGame {
       })
     }
 
+    return result
+  }
+
+  /**
+   * Returns all loose (uncarried) items in the world.
+   */
+  getItems(): { eid: number; x: number; y: number; z: number; itemType: number }[] {
+    if (this.world === null) return []
+    const world = this.world
+    const entities = query(world, [Item])
+    const result: { eid: number; x: number; y: number; z: number; itemType: number }[] = []
+    for (let i = 0; i < entities.length; i++) {
+      const eid = entities[i]!
+      if ((Item.carriedBy[eid] ?? -1) !== -1) continue
+      result.push({
+        eid,
+        x: Item.x[eid] ?? 0,
+        y: Item.y[eid] ?? 0,
+        z: Item.z[eid] ?? 0,
+        itemType: Item.itemType[eid] ?? 0,
+      })
+    }
     return result
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -160,7 +160,9 @@ function startGame(): void {
     function frame(): void {
       const worldZ = -viewZ
       const dwarves = game.getDwarves()
+      const items   = game.getItems()
       renderer.drawTiles(map, worldZ, cameraX, cameraY)
+      renderer.drawItems(items, worldZ, cameraX, cameraY)
       renderer.drawDwarves(dwarves, worldZ, cameraX, cameraY, selectedEid)
       const onLevel = dwarves.filter(d => d.z === worldZ)
       if (hudMsg) hudMsg.textContent = onLevel.length === 0 ? 'No dwarves on this level' : ''

--- a/src/systems/movementSystem.ts
+++ b/src/systems/movementSystem.ts
@@ -1,44 +1,80 @@
 import { query } from 'bitecs'
 import type { GameWorld } from '@core/world'
+import type { World3D } from '@map/world3d'
+import { getTile } from '@map/world3d'
 import { Position } from '@core/components/position'
 import { TileCoord } from '@core/components/tileCoord'
 import { DwarfAI, DwarfState } from '@core/components/dwarf'
 import { pathStore, pathIndexStore } from '@core/stores'
+import { isTilePassable } from '@systems/pathfinding'
+import { WORLD_WIDTH, WORLD_HEIGHT } from '@core/constants'
+
+const WANDER_CHANCE = 0.15  // 15% chance to take a wander step each tick when Idle
+
+const WANDER_DIRS = [
+  { dx: 1, dy: 0 }, { dx: -1, dy: 0 },
+  { dx: 0, dy: 1 }, { dx: 0, dy: -1 },
+]
 
 /**
  * Path-following movement system.
  * Each tick, advance each dwarf one step along their stored path.
- * Dwarves stand still if no path is set.
+ * Idle dwarves with no path wander randomly at a slow rate.
  */
-export function movementSystem(world: GameWorld, _dt: number): void {
+export function movementSystem(world: GameWorld, _dt: number, map?: World3D): void {
   const entities = query(world, [Position, DwarfAI])
   for (let i = 0; i < entities.length; i++) {
     const eid = entities[i]!
     if ((DwarfAI.state[eid] as DwarfState) === DwarfState.Dead) continue
 
     const path = pathStore.get(eid)
-    if (!path || path.length === 0) continue
+    if (path && path.length > 0) {
+      // Follow existing path
+      const idx = pathIndexStore.get(eid) ?? 0
+      if (idx >= path.length) {
+        pathStore.delete(eid)
+        pathIndexStore.delete(eid)
+        continue
+      }
 
-    const idx = pathIndexStore.get(eid) ?? 0
-    if (idx >= path.length) {
-      pathStore.delete(eid)
-      pathIndexStore.delete(eid)
+      const next = path[idx]!
+      // next.z is storageZ (0=surface); Position.z and TileCoord.z use negative convention
+      Position.x[eid] = next.x
+      Position.y[eid] = next.y
+      Position.z[eid] = -next.z
+      TileCoord.x[eid] = next.x
+      TileCoord.y[eid] = next.y
+      TileCoord.z[eid] = -next.z
+
+      pathIndexStore.set(eid, idx + 1)
+      if (idx + 1 >= path.length) {
+        pathStore.delete(eid)
+        pathIndexStore.delete(eid)
+      }
       continue
     }
 
-    const next = path[idx]!
-    // next.z is storageZ (0=surface); Position.z and TileCoord.z use negative convention
-    Position.x[eid] = next.x
-    Position.y[eid] = next.y
-    Position.z[eid] = -next.z
-    TileCoord.x[eid] = next.x
-    TileCoord.y[eid] = next.y
-    TileCoord.z[eid] = -next.z
+    // No path — idle wander
+    if ((DwarfAI.state[eid] as DwarfState) !== DwarfState.Idle) continue
+    if (!map) continue
+    if (Math.random() > WANDER_CHANCE) continue
 
-    pathIndexStore.set(eid, idx + 1)
-    if (idx + 1 >= path.length) {
-      pathStore.delete(eid)
-      pathIndexStore.delete(eid)
+    const cx = TileCoord.x[eid] ?? 0
+    const cy = TileCoord.y[eid] ?? 0
+    const cz = Math.abs(TileCoord.z[eid] ?? 0)
+
+    // Pick a random passable neighbor
+    const shuffled = WANDER_DIRS.slice().sort(() => Math.random() - 0.5)
+    for (const { dx, dy } of shuffled) {
+      const nx = cx + dx
+      const ny = cy + dy
+      if (nx < 0 || nx >= WORLD_WIDTH || ny < 0 || ny >= WORLD_HEIGHT) continue
+      if (!isTilePassable(getTile(nx, ny, cz, map))) continue
+      Position.x[eid] = nx
+      Position.y[eid] = ny
+      TileCoord.x[eid] = nx
+      TileCoord.y[eid] = ny
+      break
     }
   }
 }

--- a/src/ui/renderer.ts
+++ b/src/ui/renderer.ts
@@ -1,12 +1,15 @@
 import { Application, Graphics } from 'pixi.js'
 import { TILE_SIZE } from '@core/constants'
 import { type World3D, getTile } from '@map/world3d'
+import { ItemType } from '@core/components/item'
 import { TILE_COLORS } from './tileColors'
 
 type DwarfPos = { eid?: number; x: number; y: number; z: number }
+type ItemPos  = { x: number; y: number; z: number; itemType: number }
 
 export type Renderer = {
   drawTiles(world: World3D, viewZ: number, cameraX: number, cameraY: number): void
+  drawItems(items: ItemPos[], viewZ: number, cameraX: number, cameraY: number): void
   drawDwarves(dwarves: DwarfPos[], viewZ: number, cameraX: number, cameraY: number, selectedEid?: number | null): void
   resize(width: number, height: number): void
   destroy(): void
@@ -25,6 +28,9 @@ export async function createRenderer(canvas: HTMLCanvasElement): Promise<Rendere
 
   const tilesGfx = new Graphics()
   app.stage.addChild(tilesGfx)
+
+  const itemGfx = new Graphics()
+  app.stage.addChild(itemGfx)
 
   const dwarfGfx = new Graphics()
   app.stage.addChild(dwarfGfx)
@@ -55,6 +61,22 @@ export async function createRenderer(canvas: HTMLCanvasElement): Promise<Rendere
     }
   }
 
+  function drawItems(items: ItemPos[], viewZ: number, cameraX: number, cameraY: number): void {
+    itemGfx.clear()
+    for (const item of items) {
+      if (item.z !== viewZ) continue
+      const screenX = (item.x - cameraX) * TILE_SIZE
+      const screenY = (item.y - cameraY) * TILE_SIZE
+      // Food = yellow-green dot, Drink = cyan dot, other = white dot
+      const color =
+        item.itemType === ItemType.Food  ? 0xAAFF44 :
+        item.itemType === ItemType.Drink ? 0x44DDFF :
+        0xFFFFFF
+      const r = TILE_SIZE / 5
+      itemGfx.circle(screenX + TILE_SIZE / 2, screenY + TILE_SIZE / 2, r).fill(color)
+    }
+  }
+
   function drawDwarves(dwarves: DwarfPos[], viewZ: number, cameraX: number, cameraY: number, selectedEid?: number | null): void {
     dwarfGfx.clear()
     for (const d of dwarves) {
@@ -79,5 +101,5 @@ export async function createRenderer(canvas: HTMLCanvasElement): Promise<Rendere
     app.destroy()
   }
 
-  return { drawTiles, drawDwarves, resize, destroy }
+  return { drawTiles, drawItems, drawDwarves, resize, destroy }
 }

--- a/tests/integration/phase2.test.ts
+++ b/tests/integration/phase2.test.ts
@@ -51,17 +51,15 @@ describe('Phase 2 integration', () => {
     }
   }, 30_000)
 
-  it('dwarves stand still when idle (no random wander)', () => {
+  it('idle dwarves wander — positions change over 100 ticks', () => {
     const game = new HeadlessGame({ seed: 1, width: 32, height: 32, depth: 2 })
     game.embark()
     const before = game.getDwarves().map(d => ({ x: d.x, y: d.y }))
-    game.runFor(10)
+    game.runFor(100)
     const after = game.getDwarves().map(d => ({ x: d.x, y: d.y }))
-    // Dwarves should not have moved (no jobs, needs still high after 10 ticks)
-    for (let i = 0; i < before.length; i++) {
-      expect(after[i]!.x).toBe(before[i]!.x)
-      expect(after[i]!.y).toBe(before[i]!.y)
-    }
+    // At least one dwarf should have moved (wander chance 15% per tick over 100 ticks)
+    const moved = after.filter((d, i) => d.x !== before[i]!.x || d.y !== before[i]!.y)
+    expect(moved.length).toBeGreaterThan(0)
   })
 
   it('dwarves have state field in DwarfStatus', () => {


### PR DESCRIPTION
## Summary
- Idle dwarves now wander randomly (15% chance per tick to step one tile) — colony feels alive immediately on load
- Food items render as yellow-green dots, drink items as cyan dots — player can see resources exist and disappear when consumed
- `HeadlessGame.getItems()` exposes loose items for the render loop
- Updated stale test that expected no movement when idle

## Test plan
- [ ] Load game — dwarves visibly drift around the embark site
- [ ] Yellow-green and cyan dots visible near embark site
- [ ] After ~60s, dwarves seek and consume nearby items (dots disappear)
- [ ] Clicking a dwarf shows state changing to Drinking/Eating in HUD

🤖 Generated with [Claude Code](https://claude.com/claude-code)