### PR TITLE
feat: add dirty tracking to CachedState (closes #131)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+.env
+.env.local
+*.tsbuildinfo
+.DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,768 @@
+{
+  "name": "pwarf",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pwarf",
+      "version": "0.0.1",
+      "workspaces": [
+        "app",
+        "sim",
+        "shared"
+      ]
+    },
+    "app": {
+      "name": "@pwarf/app",
+      "version": "0.0.1",
+      "extraneous": true,
+      "dependencies": {
+        "@pwarf/shared": "*",
+        "@supabase/auth-helpers-react": "^0.5.0",
+        "@supabase/supabase-js": "^2.49.4",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0"
+      },
+      "devDependencies": {
+        "@tailwindcss/vite": "^4.1.3",
+        "@types/react": "^19.1.0",
+        "@types/react-dom": "^19.1.0",
+        "@vitejs/plugin-react": "^4.4.1",
+        "tailwindcss": "^4.1.3",
+        "typescript": "^5.8.3",
+        "vite": "^6.3.1"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@pwarf/shared": {
+      "resolved": "shared",
+      "link": true
+    },
+    "node_modules/@pwarf/sim": {
+      "resolved": "sim",
+      "link": true
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.99.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.99.1.tgz",
+      "integrity": "sha512-x7lKKTvKjABJt/FYcRSPiTT01Xhm2FF8RhfL8+RHMkmlwmRQ88/lREupIHKwFPW0W6pTCJqkZb7Yhpw/EZ+fNw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.99.1",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.99.1.tgz",
+      "integrity": "sha512-WQE62W5geYImCO4jzFxCk/avnK7JmOdtqu2eiPz3zOaNiIJajNRSAwMMDgEGd2EMs+sUVYj1LfBjfmW3EzHgIA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.99.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.99.1.tgz",
+      "integrity": "sha512-gtw2ibJrADvfqrpUWXGNlrYUvxttF4WVWfPpTFKOb2IRj7B6YRWMDgcrYqIuD4ZEabK4m6YKQCCGy6clgf1lPA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.99.1",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.99.1.tgz",
+      "integrity": "sha512-9EDdy/5wOseGFqxW88ShV9JMRhm7f+9JGY5x+LqT8c7R0X1CTLwg5qie8FiBWcXTZ+68yYxVWunI+7W4FhkWOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.99.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.99.1.tgz",
+      "integrity": "sha512-mf7zPfqofI62SOoyQJeNUVxe72E4rQsbWim6lTDPeLu3lHija/cP5utlQADGrjeTgOUN6znx/rWn7SjrETP1dw==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.99.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.99.1.tgz",
+      "integrity": "sha512-5MRoYD9ffXq8F6a036dm65YoSHisC3by/d22mauKE99Vrwf792KxYIIr/iqCX7E4hkuugbPZ5EGYHTB7MKy6Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.99.1",
+        "@supabase/functions-js": "2.99.1",
+        "@supabase/postgrest-js": "2.99.1",
+        "@supabase/realtime-js": "2.99.1",
+        "@supabase/storage-js": "2.99.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.7.tgz",
+      "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "shared": {
+      "name": "@pwarf/shared",
+      "version": "0.0.1",
+      "devDependencies": {
+        "typescript": "^5.7.0"
+      }
+    },
+    "sim": {
+      "name": "@pwarf/sim",
+      "version": "0.0.1",
+      "dependencies": {
+        "@pwarf/shared": "*",
+        "@supabase/supabase-js": "^2.49.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsx": "^4.19.0",
+        "typescript": "^5.7.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "pwarf",
+  "version": "0.0.1",
+  "private": true,
+  "workspaces": [
+    "app",
+    "sim",
+    "shared"
+  ],
+  "scripts": {
+    "dev:app": "npm run dev --workspace=app",
+    "dev:sim": "npm run dev --workspace=sim",
+    "build": "npm run build --workspaces"
+  }
+}

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@pwarf/shared",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  }
+}

--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -1,0 +1,39 @@
+// ============================================================
+// Simulation timing
+// ============================================================
+
+/** Target sim steps executed per real-time second */
+export const STEPS_PER_SECOND = 10;
+
+/** Total sim steps in one in-game year (30 real minutes) */
+export const STEPS_PER_YEAR = 18_000;
+
+/** Approximate sim steps in one in-game day (18000 / 365 ≈ 49) */
+export const STEPS_PER_DAY = 49;
+
+// ============================================================
+// World dimensions
+// ============================================================
+
+export const WORLD_WIDTH = 512;
+export const WORLD_HEIGHT = 512;
+
+// ============================================================
+// Dwarf needs & stress
+// ============================================================
+
+/** Upper bound for any need value */
+export const MAX_NEED = 100;
+
+/** Lower bound for any need value */
+export const MIN_NEED = 0;
+
+/** Stress level at which a dwarf may enter a tantrum */
+export const STRESS_TANTRUM_THRESHOLD = 80;
+
+// ============================================================
+// Skills
+// ============================================================
+
+/** Maximum achievable skill level for any dwarf skill */
+export const MAX_SKILL_LEVEL = 20;

--- a/shared/src/db-types.ts
+++ b/shared/src/db-types.ts
@@ -1,0 +1,455 @@
+// ============================================================
+// Enum types (matching Postgres enums as string unions)
+// ============================================================
+
+export type CivilizationStatus = 'active' | 'fallen' | 'abandoned' | 'mythic';
+
+export type CauseOfDeath =
+  | 'siege'
+  | 'flood'
+  | 'magma'
+  | 'starvation'
+  | 'tantrum_spiral'
+  | 'plague'
+  | 'undead'
+  | 'cave_in'
+  | 'forgotten_beast'
+  | 'abandonment'
+  | 'unknown'
+  | 'titan';
+
+export type DwarfStatus = 'alive' | 'dead' | 'missing' | 'ghost' | 'feral';
+
+export type ItemQuality =
+  | 'garbage'
+  | 'poor'
+  | 'standard'
+  | 'fine'
+  | 'superior'
+  | 'exceptional'
+  | 'masterwork'
+  | 'artifact';
+
+export type ItemCategory =
+  | 'weapon'
+  | 'armor'
+  | 'tool'
+  | 'food'
+  | 'drink'
+  | 'gem'
+  | 'cloth'
+  | 'furniture'
+  | 'mechanism'
+  | 'book'
+  | 'crafted'
+  | 'raw_material'
+  | 'container';
+
+export type RelationshipType =
+  | 'friend'
+  | 'rival'
+  | 'lover'
+  | 'spouse'
+  | 'parent'
+  | 'child'
+  | 'sibling'
+  | 'mentor'
+  | 'student'
+  | 'nemesis'
+  | 'acquaintance';
+
+export type FactionType =
+  | 'guild'
+  | 'noble_house'
+  | 'religious_sect'
+  | 'military_order'
+  | 'criminal'
+  | 'merchant_consortium'
+  | 'outsider_civ';
+
+export type ExpeditionStatus =
+  | 'traveling'
+  | 'active'
+  | 'looting'
+  | 'retreating'
+  | 'complete'
+  | 'lost';
+
+export type EventCategory =
+  | 'battle'
+  | 'death'
+  | 'birth'
+  | 'marriage'
+  | 'artifact_created'
+  | 'artifact_lost'
+  | 'fortress_founded'
+  | 'fortress_fallen'
+  | 'migration'
+  | 'discovery'
+  | 'myth'
+  | 'monster_sighting'
+  | 'monster_slain'
+  | 'monster_siege';
+
+export type TerrainType =
+  | 'mountain'
+  | 'forest'
+  | 'plains'
+  | 'desert'
+  | 'tundra'
+  | 'swamp'
+  | 'ocean'
+  | 'volcano'
+  | 'underground'
+  | 'haunted'
+  | 'savage'
+  | 'evil';
+
+export type MonsterType =
+  | 'forgotten_beast'
+  | 'titan'
+  | 'megabeast'
+  | 'dragon'
+  | 'demon'
+  | 'undead_lord'
+  | 'night_creature'
+  | 'giant'
+  | 'siege_beast'
+  | 'nature_spirit'
+  | 'construct'
+  | 'vermin_lord';
+
+export type MonsterStatus =
+  | 'active'
+  | 'dormant'
+  | 'slain'
+  | 'fled'
+  | 'imprisoned'
+  | 'legendary';
+
+export type MonsterBehavior =
+  | 'neutral'
+  | 'territorial'
+  | 'aggressive'
+  | 'sieging'
+  | 'corrupting'
+  | 'fleeing'
+  | 'hibernating'
+  | 'hunting';
+
+export type EncounterOutcome =
+  | 'repelled'
+  | 'overrun'
+  | 'fled'
+  | 'captured'
+  | 'negotiated'
+  | 'pyrrhic_victory'
+  | 'catastrophic_loss'
+  | 'unknown';
+
+// ============================================================
+// Row types for all tables
+// ============================================================
+
+export interface World {
+  id: string;
+  name: string;
+  seed: number;
+  width: number;
+  height: number;
+  age_years: number;
+  created_at: string;
+  is_public: boolean;
+  history_summary: Record<string, unknown>;
+}
+
+export interface WorldTile {
+  id: string;
+  world_id: string;
+  /** PostGIS geometry stored as GeoJSON or WKT — opaque at the TS layer */
+  coord: unknown;
+  x: number;
+  y: number;
+  terrain: TerrainType;
+  elevation: number;
+  biome_tags: string[];
+  explored: boolean;
+}
+
+export interface Player {
+  id: string;
+  username: string;
+  display_name: string | null;
+  world_id: string | null;
+  created_at: string;
+  last_active_at: string | null;
+  total_years_survived: number;
+  legendary_deeds: unknown[];
+}
+
+export interface Civilization {
+  id: string;
+  player_id: string;
+  world_id: string;
+  name: string;
+  epithet: string | null;
+  status: CivilizationStatus;
+  founded_year: number;
+  fallen_year: number | null;
+  cause_of_death: CauseOfDeath | null;
+  tile_x: number;
+  tile_y: number;
+  population: number;
+  wealth: number;
+  snapshot: Record<string, unknown> | null;
+  snapshot_url: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Ruin {
+  id: string;
+  civilization_id: string;
+  world_id: string;
+  name: string;
+  tile_x: number;
+  tile_y: number;
+  fallen_year: number;
+  cause_of_death: CauseOfDeath;
+  original_wealth: number;
+  remaining_wealth: number;
+  peak_population: number;
+  danger_level: number;
+  is_contaminated: boolean;
+  contamination_type: string | null;
+  ghost_count: number;
+  is_trapped: boolean;
+  resident_monster_id: string | null;
+  snapshot: Record<string, unknown> | null;
+  snapshot_url: string | null;
+  is_published: boolean;
+  created_at: string;
+}
+
+export interface Expedition {
+  id: string;
+  player_id: string;
+  ruin_id: string;
+  status: ExpeditionStatus;
+  dwarf_ids: string[];
+  started_at: string;
+  completed_at: string | null;
+  items_looted: string[];
+  dwarves_lost: number;
+  expedition_log: string | null;
+}
+
+export interface Dwarf {
+  id: string;
+  civilization_id: string;
+  name: string;
+  surname: string | null;
+  status: DwarfStatus;
+  age: number;
+  gender: string | null;
+  need_food: number;
+  need_drink: number;
+  need_sleep: number;
+  need_social: number;
+  need_purpose: number;
+  need_beauty: number;
+  stress_level: number;
+  is_in_tantrum: boolean;
+  health: number;
+  injuries: unknown[];
+  memories: unknown[];
+  trait_openness: number | null;
+  trait_conscientiousness: number | null;
+  trait_extraversion: number | null;
+  trait_agreeableness: number | null;
+  trait_neuroticism: number | null;
+  religious_devotion: number;
+  faction_id: string | null;
+  born_year: number | null;
+  died_year: number | null;
+  cause_of_death: string | null;
+  created_at: string;
+}
+
+export interface DwarfSkill {
+  id: string;
+  dwarf_id: string;
+  skill_name: string;
+  level: number;
+  xp: number;
+  last_used_year: number | null;
+}
+
+export interface DwarfRelationship {
+  id: string;
+  dwarf_a_id: string;
+  dwarf_b_id: string;
+  type: RelationshipType;
+  strength: number;
+  shared_events: unknown[];
+  formed_year: number | null;
+}
+
+export interface Faction {
+  id: string;
+  world_id: string;
+  name: string;
+  type: FactionType;
+  power_level: number;
+  disposition: number;
+  lore: string | null;
+  founded_year: number | null;
+  is_active: boolean;
+  beliefs: Record<string, unknown>;
+}
+
+export interface CivFactionRelation {
+  id: string;
+  civilization_id: string;
+  faction_id: string;
+  standing: number;
+  is_at_war: boolean;
+  trade_active: boolean;
+}
+
+export interface Item {
+  id: string;
+  name: string;
+  category: ItemCategory;
+  quality: ItemQuality;
+  material: string | null;
+  weight: number | null;
+  value: number;
+  is_artifact: boolean;
+  created_by_dwarf_id: string | null;
+  created_in_civ_id: string | null;
+  created_year: number | null;
+  held_by_dwarf_id: string | null;
+  located_in_civ_id: string | null;
+  located_in_ruin_id: string | null;
+  lore: string | null;
+  properties: Record<string, unknown>;
+  created_at: string;
+}
+
+export interface Monster {
+  id: string;
+  world_id: string;
+  name: string;
+  epithet: string | null;
+  type: MonsterType;
+  status: MonsterStatus;
+  behavior: MonsterBehavior;
+  is_named: boolean;
+  lair_tile_x: number | null;
+  lair_tile_y: number | null;
+  current_tile_x: number | null;
+  current_tile_y: number | null;
+  threat_level: number;
+  health: number;
+  size_category: string;
+  body_parts: unknown[];
+  attacks: unknown[];
+  abilities: unknown[];
+  weaknesses: unknown[];
+  lore: string | null;
+  origin_myth: string | null;
+  properties: Record<string, unknown>;
+  first_seen_year: number | null;
+  slain_year: number | null;
+  slain_by_dwarf_id: string | null;
+  slain_in_civ_id: string | null;
+  slain_in_ruin_id: string | null;
+  created_at: string;
+}
+
+export interface MonsterEncounter {
+  id: string;
+  monster_id: string;
+  world_id: string;
+  civilization_id: string | null;
+  ruin_id: string | null;
+  year: number;
+  outcome: EncounterOutcome;
+  dwarves_killed: number;
+  monster_health_after: number | null;
+  items_destroyed: string[];
+  items_stolen: string[];
+  structures_damaged: string[];
+  description: string | null;
+  encounter_log: string | null;
+  event_data: Record<string, unknown>;
+}
+
+export interface MonsterBounty {
+  id: string;
+  monster_id: string;
+  world_id: string;
+  posted_by_civ_id: string | null;
+  reward_value: number;
+  reward_item_id: string | null;
+  posted_year: number;
+  expires_year: number | null;
+  is_claimed: boolean;
+  claimed_by_player_id: string | null;
+  claimed_year: number | null;
+}
+
+export interface WorldEvent {
+  id: string;
+  world_id: string;
+  year: number;
+  category: EventCategory;
+  civilization_id: string | null;
+  ruin_id: string | null;
+  dwarf_id: string | null;
+  item_id: string | null;
+  faction_id: string | null;
+  monster_id: string | null;
+  description: string;
+  event_data: Record<string, unknown>;
+  created_at: string;
+}
+
+export interface TradeCaravan {
+  id: string;
+  world_id: string;
+  faction_id: string | null;
+  origin_civ_id: string | null;
+  destination_civ_id: string | null;
+  arrived_year: number | null;
+  departed_year: number | null;
+  manifest: Record<string, unknown>;
+  outcome: string | null;
+  reputation_delta: number | null;
+}
+
+export interface Disease {
+  id: string;
+  world_id: string;
+  name: string;
+  lethality: number;
+  contagion_rate: number;
+  incubation_days: number;
+  active_in_civs: string[];
+  active_in_ruins: string[];
+  first_seen_year: number | null;
+  is_eradicated: boolean;
+}
+
+export interface Structure {
+  id: string;
+  civilization_id: string;
+  name: string | null;
+  type: string;
+  completion_pct: number;
+  built_year: number | null;
+  ruin_id: string | null;
+  quality: ItemQuality | null;
+  notes: string | null;
+}

--- a/shared/src/events.ts
+++ b/shared/src/events.ts
@@ -1,0 +1,258 @@
+import type {
+  CauseOfDeath,
+  DwarfStatus,
+  EncounterOutcome,
+  EventCategory,
+  MonsterBehavior,
+  MonsterType,
+} from './db-types.js';
+
+// ============================================================
+// Base event shape — every sim event carries these fields
+// ============================================================
+
+export interface SimEventBase {
+  /** Monotonically increasing sim step when the event fired */
+  step: number;
+  /** In-game year */
+  year: number;
+  /** In-game day within the year (0-364) */
+  day: number;
+}
+
+// ============================================================
+// Sim tick heartbeat
+// ============================================================
+
+export interface SimTickEvent extends SimEventBase {
+  type: 'sim_tick';
+}
+
+// ============================================================
+// Dwarf events
+// ============================================================
+
+export type DwarfActionType =
+  | 'mine'
+  | 'build'
+  | 'craft'
+  | 'haul'
+  | 'eat'
+  | 'drink'
+  | 'sleep'
+  | 'socialize'
+  | 'pray'
+  | 'idle'
+  | 'patrol'
+  | 'train'
+  | 'heal'
+  | 'farm'
+  | 'brew'
+  | 'cook'
+  | 'smith'
+  | 'engrave'
+  | 'smooth'
+  | 'woodcut'
+  | 'hunt';
+
+export interface DwarfActionEvent extends SimEventBase {
+  type: 'dwarf_action';
+  dwarf_id: string;
+  action: DwarfActionType;
+  target_id: string | null;
+  target_description: string | null;
+}
+
+export interface DwarfNeedCriticalEvent extends SimEventBase {
+  type: 'dwarf_need_critical';
+  dwarf_id: string;
+  need: 'food' | 'drink' | 'sleep' | 'social' | 'purpose' | 'beauty';
+  value: number;
+}
+
+export interface DwarfTantrumEvent extends SimEventBase {
+  type: 'dwarf_tantrum';
+  dwarf_id: string;
+  stress_level: number;
+  target_dwarf_id: string | null;
+  items_destroyed: string[];
+}
+
+export interface DwarfMoodEvent extends SimEventBase {
+  type: 'dwarf_mood';
+  dwarf_id: string;
+  mood: 'strange' | 'fey' | 'possessed' | 'melancholy' | 'berserk';
+}
+
+// ============================================================
+// Combat events
+// ============================================================
+
+export interface CombatEvent extends SimEventBase {
+  type: 'combat';
+  attacker_id: string;
+  attacker_kind: 'dwarf' | 'monster';
+  defender_id: string;
+  defender_kind: 'dwarf' | 'monster';
+  damage: number;
+  description: string;
+}
+
+export interface CombatResultEvent extends SimEventBase {
+  type: 'combat_result';
+  encounter_id: string;
+  monster_id: string;
+  outcome: EncounterOutcome;
+  dwarves_killed: number;
+  monster_health_after: number;
+}
+
+// ============================================================
+// Death events
+// ============================================================
+
+export interface DeathEvent extends SimEventBase {
+  type: 'death';
+  dwarf_id: string;
+  cause: string;
+  killer_id: string | null;
+  killer_kind: 'dwarf' | 'monster' | 'environment' | null;
+}
+
+// ============================================================
+// Migration events
+// ============================================================
+
+export interface MigrationEvent extends SimEventBase {
+  type: 'migration';
+  civilization_id: string;
+  dwarf_count: number;
+  dwarf_ids: string[];
+}
+
+// ============================================================
+// Monster events
+// ============================================================
+
+export interface MonsterSpawnEvent extends SimEventBase {
+  type: 'monster_spawn';
+  monster_id: string;
+  monster_type: MonsterType;
+  name: string;
+  tile_x: number;
+  tile_y: number;
+  threat_level: number;
+}
+
+export interface MonsterMoveEvent extends SimEventBase {
+  type: 'monster_move';
+  monster_id: string;
+  from_x: number;
+  from_y: number;
+  to_x: number;
+  to_y: number;
+  behavior: MonsterBehavior;
+}
+
+export interface MonsterSiegeEvent extends SimEventBase {
+  type: 'monster_siege';
+  monster_id: string;
+  civilization_id: string;
+  description: string;
+}
+
+export interface MonsterSlainEvent extends SimEventBase {
+  type: 'monster_slain';
+  monster_id: string;
+  slain_by_dwarf_id: string | null;
+  civilization_id: string;
+}
+
+// ============================================================
+// Fortress lifecycle events
+// ============================================================
+
+export interface FortressFoundedEvent extends SimEventBase {
+  type: 'fortress_founded';
+  civilization_id: string;
+  name: string;
+  tile_x: number;
+  tile_y: number;
+}
+
+export interface FortressFallenEvent extends SimEventBase {
+  type: 'fortress_fallen';
+  civilization_id: string;
+  cause: CauseOfDeath;
+  population_at_death: number;
+  wealth_at_death: number;
+}
+
+// ============================================================
+// World / discovery events
+// ============================================================
+
+export interface DiscoveryEvent extends SimEventBase {
+  type: 'discovery';
+  civilization_id: string;
+  description: string;
+  tile_x: number;
+  tile_y: number;
+}
+
+export interface ArtifactCreatedEvent extends SimEventBase {
+  type: 'artifact_created';
+  item_id: string;
+  dwarf_id: string;
+  civilization_id: string;
+  description: string;
+}
+
+export interface TradeCaravanArrivalEvent extends SimEventBase {
+  type: 'trade_caravan_arrival';
+  caravan_id: string;
+  faction_id: string | null;
+  civilization_id: string;
+}
+
+export interface DiseaseOutbreakEvent extends SimEventBase {
+  type: 'disease_outbreak';
+  disease_id: string;
+  civilization_id: string;
+  name: string;
+  lethality: number;
+}
+
+export interface YearRollupEvent extends SimEventBase {
+  type: 'year_rollup';
+  civilization_id: string;
+  population: number;
+  wealth: number;
+  age_years: number;
+}
+
+// ============================================================
+// Union of all sim events
+// ============================================================
+
+export type SimEvent =
+  | SimTickEvent
+  | DwarfActionEvent
+  | DwarfNeedCriticalEvent
+  | DwarfTantrumEvent
+  | DwarfMoodEvent
+  | CombatEvent
+  | CombatResultEvent
+  | DeathEvent
+  | MigrationEvent
+  | MonsterSpawnEvent
+  | MonsterMoveEvent
+  | MonsterSiegeEvent
+  | MonsterSlainEvent
+  | FortressFoundedEvent
+  | FortressFallenEvent
+  | DiscoveryEvent
+  | ArtifactCreatedEvent
+  | TradeCaravanArrivalEvent
+  | DiseaseOutbreakEvent
+  | YearRollupEvent;

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,0 +1,3 @@
+export * from './db-types.js';
+export * from './constants.js';
+export * from './events.js';

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["src"]
+}

--- a/sim/package.json
+++ b/sim/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@pwarf/sim",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.49.0",
+    "@pwarf/shared": "*"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "tsx": "^4.19.0",
+    "@types/node": "^22.0.0"
+  }
+}

--- a/sim/src/index.ts
+++ b/sim/src/index.ts
@@ -1,0 +1,34 @@
+import { createClient } from "@supabase/supabase-js";
+import { SimRunner } from "./sim-runner.js";
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_KEY) {
+  console.error(
+    "[sim] SUPABASE_URL and SUPABASE_SERVICE_KEY must be set in environment"
+  );
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
+const runner = new SimRunner(supabase);
+
+// For now, accept civilization ID from env or default to a placeholder.
+const civId = process.env.CIVILIZATION_ID ?? "default";
+
+runner.start(civId).catch((err) => {
+  console.error("[sim] failed to start:", err);
+  process.exit(1);
+});
+
+// Graceful shutdown
+process.on("SIGINT", async () => {
+  await runner.stop();
+  process.exit(0);
+});
+
+process.on("SIGTERM", async () => {
+  await runner.stop();
+  process.exit(0);
+});

--- a/sim/src/phases/combat-resolution.ts
+++ b/sim/src/phases/combat-resolution.ts
@@ -1,0 +1,12 @@
+import type { SimContext } from "../sim-context.js";
+
+/**
+ * Combat Resolution Phase
+ *
+ * Detects tiles where a monster and a dwarf (or military squad) overlap.
+ * Resolves combat using attack/defense stats, equipment, skills, and
+ * randomness. Applies damage, generates wound/death events, and awards XP.
+ */
+export async function combatResolution(_ctx: SimContext): Promise<void> {
+  // stub
+}

--- a/sim/src/phases/construction-progress.ts
+++ b/sim/src/phases/construction-progress.ts
@@ -1,0 +1,12 @@
+import type { SimContext } from "../sim-context.js";
+
+/**
+ * Construction Progress Phase
+ *
+ * Advances all active construction/build jobs by one step. Checks material
+ * availability, builder assignment, and skill modifiers. Marks structures
+ * as complete when their build progress reaches 100%.
+ */
+export async function constructionProgress(_ctx: SimContext): Promise<void> {
+  // stub
+}

--- a/sim/src/phases/event-firing.ts
+++ b/sim/src/phases/event-firing.ts
@@ -1,0 +1,12 @@
+import type { SimContext } from "../sim-context.js";
+
+/**
+ * Event Firing Phase
+ *
+ * Collects all notable events that occurred during this tick (births, deaths,
+ * completed constructions, artifact creations, sieges, etc.) and writes them
+ * to the world_events table in Supabase for the UI and history log.
+ */
+export async function eventFiring(_ctx: SimContext): Promise<void> {
+  // stub
+}

--- a/sim/src/phases/index.ts
+++ b/sim/src/phases/index.ts
@@ -1,0 +1,11 @@
+export { needsDecay } from "./needs-decay.js";
+export { taskExecution } from "./task-execution.js";
+export { needSatisfaction } from "./need-satisfaction.js";
+export { stressUpdate } from "./stress-update.js";
+export { tantrumCheck } from "./tantrum-check.js";
+export { monsterPathfinding } from "./monster-pathfinding.js";
+export { combatResolution } from "./combat-resolution.js";
+export { constructionProgress } from "./construction-progress.js";
+export { jobClaiming } from "./job-claiming.js";
+export { eventFiring } from "./event-firing.js";
+export { yearlyRollup } from "./yearly-rollup.js";

--- a/sim/src/phases/job-claiming.ts
+++ b/sim/src/phases/job-claiming.ts
@@ -1,0 +1,12 @@
+import type { SimContext } from "../sim-context.js";
+
+/**
+ * Job Claiming Phase
+ *
+ * Finds all idle dwarves (those without a current task) and matches them
+ * to available work orders based on skill, proximity, and priority.
+ * Assigns the best-fit job to each idle dwarf.
+ */
+export async function jobClaiming(_ctx: SimContext): Promise<void> {
+  // stub
+}

--- a/sim/src/phases/monster-pathfinding.ts
+++ b/sim/src/phases/monster-pathfinding.ts
@@ -1,0 +1,12 @@
+import type { SimContext } from "../sim-context.js";
+
+/**
+ * Monster Pathfinding Phase
+ *
+ * For each active monster, advances its position one step along its path
+ * toward its current target (nearest dwarf, fortress entrance, etc.).
+ * Recalculates paths when blocked or when the target moves.
+ */
+export async function monsterPathfinding(_ctx: SimContext): Promise<void> {
+  // stub
+}

--- a/sim/src/phases/need-satisfaction.ts
+++ b/sim/src/phases/need-satisfaction.ts
@@ -1,0 +1,12 @@
+import type { SimContext } from "../sim-context.js";
+
+/**
+ * Need Satisfaction Phase
+ *
+ * Checks whether dwarves are adjacent to or on top of need-satisfying sources
+ * (food stockpiles, drink barrels, beds, meeting halls). If so, consumes
+ * the resource and refills the corresponding need meter.
+ */
+export async function needSatisfaction(_ctx: SimContext): Promise<void> {
+  // stub
+}

--- a/sim/src/phases/needs-decay.ts
+++ b/sim/src/phases/needs-decay.ts
@@ -1,0 +1,12 @@
+import type { SimContext } from "../sim-context.js";
+
+/**
+ * Needs Decay Phase
+ *
+ * Decrements each dwarf's need meters (hunger, thirst, sleep, social, etc.)
+ * by a small amount every simulation step. Needs that reach zero will begin
+ * generating stress in the stress-update phase.
+ */
+export async function needsDecay(_ctx: SimContext): Promise<void> {
+  // stub
+}

--- a/sim/src/phases/stress-update.ts
+++ b/sim/src/phases/stress-update.ts
@@ -1,0 +1,12 @@
+import type { SimContext } from "../sim-context.js";
+
+/**
+ * Stress Update Phase
+ *
+ * Recalculates each dwarf's stress level based on unmet needs, recent
+ * negative memories (e.g. witnessing death, sleeping in the rain), and
+ * personality traits. Positive memories and satisfied needs reduce stress.
+ */
+export async function stressUpdate(_ctx: SimContext): Promise<void> {
+  // stub
+}

--- a/sim/src/phases/tantrum-check.ts
+++ b/sim/src/phases/tantrum-check.ts
@@ -1,0 +1,12 @@
+import type { SimContext } from "../sim-context.js";
+
+/**
+ * Tantrum Check Phase
+ *
+ * Evaluates each dwarf whose stress exceeds the tantrum threshold. Triggers
+ * a tantrum event which may cause the dwarf to destroy items, start fights
+ * with other dwarves, or go berserk. Severity scales with stress level.
+ */
+export async function tantrumCheck(_ctx: SimContext): Promise<void> {
+  // stub
+}

--- a/sim/src/phases/task-execution.ts
+++ b/sim/src/phases/task-execution.ts
@@ -1,0 +1,12 @@
+import type { SimContext } from "../sim-context.js";
+
+/**
+ * Task Execution Phase
+ *
+ * For each dwarf that has a claimed job, advances that job by one work step.
+ * Handles pathfinding progress, material hauling, and skill-based work speed.
+ * Completes jobs when their remaining work reaches zero.
+ */
+export async function taskExecution(_ctx: SimContext): Promise<void> {
+  // stub
+}

--- a/sim/src/phases/yearly-rollup.ts
+++ b/sim/src/phases/yearly-rollup.ts
@@ -1,0 +1,16 @@
+import type { SimContext } from "../sim-context.js";
+
+/**
+ * Yearly Rollup Phase
+ *
+ * Runs once every STEPS_PER_YEAR steps. Handles long-cadence updates:
+ * - Aging: increments dwarf ages, triggers old-age death checks
+ * - Skill ups: awards skill level increases based on accumulated XP
+ * - Immigration: new dwarves arrive based on fortress wealth/reputation
+ * - Faction drift: updates relationships between civilizations
+ * - Disease: rolls for plague/illness outbreaks
+ * - Ruin decay: abandoned structures degrade over time
+ */
+export async function yearlyRollup(_ctx: SimContext): Promise<void> {
+  // stub
+}

--- a/sim/src/sim-context.ts
+++ b/sim/src/sim-context.ts
@@ -1,0 +1,69 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type {
+  Dwarf,
+  Item,
+  Structure,
+  Monster,
+  WorldEvent,
+} from "@pwarf/shared";
+
+/** Cached world-state slices that get loaded at start and updated incrementally. */
+export interface CachedState {
+  dwarves: Dwarf[];
+  items: Item[];
+  structures: Structure[];
+  monsters: Monster[];
+  workOrders: unknown[];
+  worldEvents: WorldEvent[];
+
+  /** IDs of entities modified during the current tick, to be flushed to DB. */
+  dirtyDwarfIds: Set<string>;
+  dirtyItemIds: Set<string>;
+  dirtyStructureIds: Set<string>;
+  dirtyMonsterIds: Set<string>;
+
+  /** Events queued during a tick, flushed by the event-firing phase. */
+  pendingEvents: WorldEvent[];
+}
+
+/** Returns a fresh CachedState with empty arrays and sets. */
+export function createEmptyCachedState(): CachedState {
+  return {
+    dwarves: [],
+    items: [],
+    structures: [],
+    monsters: [],
+    workOrders: [],
+    worldEvents: [],
+    dirtyDwarfIds: new Set(),
+    dirtyItemIds: new Set(),
+    dirtyStructureIds: new Set(),
+    dirtyMonsterIds: new Set(),
+    pendingEvents: [],
+  };
+}
+
+/**
+ * The context object threaded through every simulation phase.
+ * Holds the supabase client, civilization identity, time tracking,
+ * and the mutable cached state that phases read from and write to.
+ */
+export interface SimContext {
+  /** Authenticated Supabase client (service-role key). */
+  supabase: SupabaseClient;
+
+  /** The civilization this sim instance is driving. */
+  civilizationId: string;
+
+  /** Monotonically increasing step counter since sim start. */
+  step: number;
+
+  /** Current in-game year. */
+  year: number;
+
+  /** Current in-game day within the year. */
+  day: number;
+
+  /** Mutable cached world state, loaded at start and patched each tick. */
+  state: CachedState;
+}

--- a/sim/src/sim-runner.ts
+++ b/sim/src/sim-runner.ts
@@ -1,0 +1,101 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { STEPS_PER_SECOND, STEPS_PER_YEAR } from "@pwarf/shared";
+import type { SimContext } from "./sim-context.js";
+import { createEmptyCachedState } from "./sim-context.js";
+import {
+  needsDecay,
+  taskExecution,
+  needSatisfaction,
+  stressUpdate,
+  tantrumCheck,
+  monsterPathfinding,
+  combatResolution,
+  constructionProgress,
+  jobClaiming,
+  eventFiring,
+  yearlyRollup,
+} from "./phases/index.js";
+
+/**
+ * Main simulation loop.
+ *
+ * Runs a fixed-timestep loop at STEPS_PER_SECOND, calling each phase
+ * function in deterministic order every tick.
+ */
+export class SimRunner {
+  private supabase: SupabaseClient;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private ctx: SimContext | null = null;
+
+  stepCount = 0;
+  currentYear = 1;
+  currentDay = 1;
+
+  constructor(supabase: SupabaseClient) {
+    this.supabase = supabase;
+  }
+
+  /** Load initial state from Supabase and begin the tick loop. */
+  async start(civilizationId: string): Promise<void> {
+    const cached = createEmptyCachedState();
+
+    this.ctx = {
+      supabase: this.supabase,
+      civilizationId,
+      step: this.stepCount,
+      year: this.currentYear,
+      day: this.currentDay,
+      state: cached,
+    };
+
+    console.log(
+      `[sim] starting simulation for civilization ${civilizationId}`
+    );
+
+    const intervalMs = 1000 / STEPS_PER_SECOND;
+    this.timer = setInterval(() => {
+      void this.tick();
+    }, intervalMs);
+  }
+
+  /** Pause the loop and persist state. */
+  async stop(): Promise<void> {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    console.log(`[sim] stopped at step ${this.stepCount}`);
+  }
+
+  /** Execute one simulation step — all phases run in order. */
+  async tick(): Promise<void> {
+    if (!this.ctx) return;
+
+    this.stepCount++;
+    this.currentDay++;
+    this.ctx.step = this.stepCount;
+    this.ctx.day = this.currentDay;
+    this.ctx.year = this.currentYear;
+
+    // --- ordered phases ---
+    await needsDecay(this.ctx);
+    await taskExecution(this.ctx);
+    await needSatisfaction(this.ctx);
+    await stressUpdate(this.ctx);
+    await tantrumCheck(this.ctx);
+    await monsterPathfinding(this.ctx);
+    await combatResolution(this.ctx);
+    await constructionProgress(this.ctx);
+    await jobClaiming(this.ctx);
+    await eventFiring(this.ctx);
+
+    // Yearly rollup only fires once every STEPS_PER_YEAR steps
+    if (this.stepCount % STEPS_PER_YEAR === 0) {
+      this.currentYear++;
+      this.currentDay = 1;
+      this.ctx.year = this.currentYear;
+      this.ctx.day = this.currentDay;
+      await yearlyRollup(this.ctx);
+    }
+  }
+}

--- a/sim/tsconfig.json
+++ b/sim/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../shared" }
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "composite": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "sourceMap": true
+  }
+}


### PR DESCRIPTION
## Summary
- Type `CachedState` arrays with proper DB row types (`Dwarf[]`, `Item[]`, etc.) instead of `unknown[]`
- Add dirty tracking sets (`dirtyDwarfIds`, `dirtyItemIds`, `dirtyStructureIds`, `dirtyMonsterIds`) so phases can mark mutated entities for batched DB writes
- Add `pendingEvents` array for events queued during a tick
- Add `createEmptyCachedState()` factory function
- Update `sim-runner.ts` to use the factory

## Test plan
- [x] `npx tsc --noEmit` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)