### PR TITLE
feat: implement loadStateFromSupabase (closes #132)

### DIFF
--- a/sim/src/index.ts
+++ b/sim/src/index.ts
@@ -1,6 +1,8 @@
 import { createClient } from "@supabase/supabase-js";
 import { SimRunner } from "./sim-runner.js";
 
+export { loadStateFromSupabase } from "./load-state.js";
+
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_KEY;
 
@@ -16,8 +18,9 @@ const runner = new SimRunner(supabase);
 
 // For now, accept civilization ID from env or default to a placeholder.
 const civId = process.env.CIVILIZATION_ID ?? "default";
+const worldId = process.env.WORLD_ID ?? "default";
 
-runner.start(civId).catch((err) => {
+runner.start(civId, worldId).catch((err) => {
   console.error("[sim] failed to start:", err);
   process.exit(1);
 });

--- a/sim/src/load-state.ts
+++ b/sim/src/load-state.ts
@@ -1,0 +1,79 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Dwarf, Item, Structure, Monster } from "@pwarf/shared";
+import type { CachedState } from "./sim-context.js";
+
+/**
+ * Load the full cached state for a civilization from Supabase.
+ *
+ * Queries dwarves, items, structures, and monsters in parallel,
+ * returning a CachedState ready for the simulation loop.
+ *
+ * @param supabase  - Authenticated Supabase client (service-role key)
+ * @param civilizationId - The civilization to load state for
+ * @param worldId - The world the civilization belongs to (used for monster queries)
+ */
+export async function loadStateFromSupabase(
+  supabase: SupabaseClient,
+  civilizationId: string,
+  worldId: string,
+): Promise<CachedState> {
+  const [dwarvesResult, itemsResult, structuresResult, monstersResult] =
+    await Promise.all([
+      supabase
+        .from("dwarves")
+        .select("*")
+        .eq("civilization_id", civilizationId)
+        .eq("status", "alive"),
+
+      supabase
+        .from("items")
+        .select("*")
+        .eq("located_in_civ_id", civilizationId),
+
+      supabase
+        .from("structures")
+        .select("*")
+        .eq("civilization_id", civilizationId),
+
+      supabase
+        .from("monsters")
+        .select("*")
+        .eq("world_id", worldId)
+        .eq("status", "active"),
+    ]);
+
+  if (dwarvesResult.error) {
+    throw new Error(
+      `Failed to load dwarves for civilization ${civilizationId}: ${dwarvesResult.error.message}`,
+    );
+  }
+  if (itemsResult.error) {
+    throw new Error(
+      `Failed to load items for civilization ${civilizationId}: ${itemsResult.error.message}`,
+    );
+  }
+  if (structuresResult.error) {
+    throw new Error(
+      `Failed to load structures for civilization ${civilizationId}: ${structuresResult.error.message}`,
+    );
+  }
+  if (monstersResult.error) {
+    throw new Error(
+      `Failed to load monsters for world ${worldId}: ${monstersResult.error.message}`,
+    );
+  }
+
+  return {
+    dwarves: dwarvesResult.data as Dwarf[],
+    items: itemsResult.data as Item[],
+    structures: structuresResult.data as Structure[],
+    monsters: monstersResult.data as Monster[],
+    workOrders: [],
+    worldEvents: [],
+    dirtyDwarfIds: new Set(),
+    dirtyItemIds: new Set(),
+    dirtyStructureIds: new Set(),
+    dirtyMonsterIds: new Set(),
+    pendingEvents: [],
+  };
+}

--- a/sim/src/sim-runner.ts
+++ b/sim/src/sim-runner.ts
@@ -1,7 +1,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { STEPS_PER_SECOND, STEPS_PER_YEAR } from "@pwarf/shared";
 import type { SimContext } from "./sim-context.js";
-import { createEmptyCachedState } from "./sim-context.js";
+import { loadStateFromSupabase } from "./load-state.js";
 import {
   needsDecay,
   taskExecution,
@@ -36,8 +36,12 @@ export class SimRunner {
   }
 
   /** Load initial state from Supabase and begin the tick loop. */
-  async start(civilizationId: string): Promise<void> {
-    const cached = createEmptyCachedState();
+  async start(civilizationId: string, worldId: string): Promise<void> {
+    const cached = await loadStateFromSupabase(
+      this.supabase,
+      civilizationId,
+      worldId,
+    );
 
     this.ctx = {
       supabase: this.supabase,


### PR DESCRIPTION
## Summary
- Add `sim/src/load-state.ts` with `loadStateFromSupabase(supabase, civilizationId, worldId)`
- Queries dwarves (alive), items, structures, and monsters in parallel via `Promise.all`
- Returns typed `CachedState` with empty dirty tracking sets
- Update `sim-runner.ts` to call `loadStateFromSupabase()` during `start()` instead of using empty state
- Update `sim/src/index.ts` to read `WORLD_ID` env var and export `loadStateFromSupabase`

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Integration test with seeded Supabase data (covered by #136)

🤖 Generated with [Claude Code](https://claude.com/claude-code)