### PR TITLE
feat: implement flushToSupabase with 1s batched writes (closes #135)

### DIFF
--- a/sim/src/flush-state.ts
+++ b/sim/src/flush-state.ts
@@ -1,0 +1,100 @@
+import type { SimContext } from "./sim-context.js";
+
+/**
+ * Flush all dirty cached state to Supabase.
+ *
+ * Collects entities whose IDs appear in the dirty-tracking sets,
+ * upserts/inserts them in parallel, then clears the sets.
+ * Failures are logged but never thrown so the sim keeps running.
+ */
+export async function flushToSupabase(ctx: SimContext): Promise<void> {
+  const { supabase, state } = ctx;
+  const promises: Promise<void>[] = [];
+
+  // --- Dirty dwarves ---
+  if (state.dirtyDwarfIds.size > 0) {
+    const dirtyDwarves = state.dwarves.filter((d) =>
+      state.dirtyDwarfIds.has(d.id),
+    );
+    state.dirtyDwarfIds.clear();
+    promises.push(
+      (async () => {
+        const { error } = await supabase.from("dwarves").upsert(dirtyDwarves);
+        if (error) {
+          console.warn("[flush] failed to upsert dwarves:", error.message);
+        }
+      })(),
+    );
+  }
+
+  // --- Dirty items ---
+  if (state.dirtyItemIds.size > 0) {
+    const dirtyItems = state.items.filter((i) =>
+      state.dirtyItemIds.has(i.id),
+    );
+    state.dirtyItemIds.clear();
+    promises.push(
+      (async () => {
+        const { error } = await supabase.from("items").upsert(dirtyItems);
+        if (error) {
+          console.warn("[flush] failed to upsert items:", error.message);
+        }
+      })(),
+    );
+  }
+
+  // --- Dirty structures ---
+  if (state.dirtyStructureIds.size > 0) {
+    const dirtyStructures = state.structures.filter((s) =>
+      state.dirtyStructureIds.has(s.id),
+    );
+    state.dirtyStructureIds.clear();
+    promises.push(
+      (async () => {
+        const { error } = await supabase
+          .from("structures")
+          .upsert(dirtyStructures);
+        if (error) {
+          console.warn("[flush] failed to upsert structures:", error.message);
+        }
+      })(),
+    );
+  }
+
+  // --- Dirty monsters ---
+  if (state.dirtyMonsterIds.size > 0) {
+    const dirtyMonsters = state.monsters.filter((m) =>
+      state.dirtyMonsterIds.has(m.id),
+    );
+    state.dirtyMonsterIds.clear();
+    promises.push(
+      (async () => {
+        const { error } = await supabase
+          .from("monsters")
+          .upsert(dirtyMonsters);
+        if (error) {
+          console.warn("[flush] failed to upsert monsters:", error.message);
+        }
+      })(),
+    );
+  }
+
+  // --- Pending events ---
+  if (state.pendingEvents.length > 0) {
+    const events = state.pendingEvents;
+    state.pendingEvents = [];
+    promises.push(
+      (async () => {
+        const { error } = await supabase.from("world_events").insert(events);
+        if (error) {
+          console.warn(
+            "[flush] failed to insert world_events:",
+            error.message,
+          );
+        }
+      })(),
+    );
+  }
+
+  await Promise.all(promises);
+}

--- a/sim/src/index.ts
+++ b/sim/src/index.ts
@@ -2,6 +2,7 @@ import { createClient } from "@supabase/supabase-js";
 import { SimRunner } from "./sim-runner.js";
 
 export { loadStateFromSupabase } from "./load-state.js";
+export { flushToSupabase } from "./flush-state.js";
 
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_KEY;

--- a/sim/src/sim-runner.ts
+++ b/sim/src/sim-runner.ts
@@ -2,6 +2,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { STEPS_PER_SECOND, STEPS_PER_YEAR } from "@pwarf/shared";
 import type { SimContext } from "./sim-context.js";
 import { loadStateFromSupabase } from "./load-state.js";
+import { flushToSupabase } from "./flush-state.js";
 import {
   needsDecay,
   taskExecution,
@@ -25,6 +26,7 @@ import {
 export class SimRunner {
   private supabase: SupabaseClient;
   private timer: ReturnType<typeof setInterval> | null = null;
+  private flushTimer: ReturnType<typeof setInterval> | null = null;
   private ctx: SimContext | null = null;
 
   stepCount = 0;
@@ -60,6 +62,13 @@ export class SimRunner {
     this.timer = setInterval(() => {
       void this.tick();
     }, intervalMs);
+
+    // Flush dirty state to Supabase every 1 second
+    this.flushTimer = setInterval(() => {
+      if (this.ctx) {
+        void flushToSupabase(this.ctx);
+      }
+    }, 1000);
   }
 
   /** Pause the loop and persist state. */
@@ -68,6 +77,16 @@ export class SimRunner {
       clearInterval(this.timer);
       this.timer = null;
     }
+    if (this.flushTimer) {
+      clearInterval(this.flushTimer);
+      this.flushTimer = null;
+    }
+
+    // Final flush to ensure no dirty data is lost
+    if (this.ctx) {
+      await flushToSupabase(this.ctx);
+    }
+
     console.log(`[sim] stopped at step ${this.stepCount}`);
   }
 


### PR DESCRIPTION
## Summary
- Add `sim/src/flush-state.ts` with `flushToSupabase(ctx)` — batched upserts for dirty dwarves, items, structures, monsters, and inserts for pending events
- All 5 flushes run in parallel via `Promise.all`
- Non-throwing: logs warnings on failure, sim keeps running
- Dirty sets cleared immediately to prevent double-flushing
- `sim-runner.ts` now runs flush on a 1-second `setInterval` timer
- Final flush on `stop()` before shutdown to prevent data loss

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Integration test with Supabase (covered by #136)

🤖 Generated with [Claude Code](https://claude.com/claude-code)