### PR TITLE
test: add vitest setup and overworld generation tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,10 @@
         "app",
         "sim",
         "shared"
-      ]
+      ],
+      "devDependencies": {
+        "vitest": "^4.1.0"
+      }
     },
     "app": {
       "name": "@pwarf/app",
@@ -328,6 +331,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -345,6 +349,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -362,6 +367,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -379,6 +385,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -396,6 +403,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -413,6 +421,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -430,6 +439,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -447,6 +457,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -464,6 +475,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -481,6 +493,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -498,6 +511,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -515,6 +529,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -532,6 +547,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -549,6 +565,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -566,6 +583,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -583,6 +601,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -600,6 +619,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -617,6 +637,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -634,6 +655,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -651,6 +673,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -668,6 +691,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -685,6 +709,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -702,6 +727,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -719,6 +745,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -736,6 +763,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -753,6 +781,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1176,6 +1205,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@supabase/auth-helpers-react": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-react/-/auth-helpers-react-0.5.0.tgz",
@@ -1583,6 +1619,24 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1655,6 +1709,129 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
+      "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
+      "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
+      "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
+      "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.0",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
+      "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
+      "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
+      "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.8",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.8.tgz",
@@ -1723,6 +1900,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1786,6 +1973,13 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.27.4",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
@@ -1836,6 +2030,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -1996,6 +2210,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -2017,6 +2232,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -2038,6 +2254,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -2059,6 +2276,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -2080,6 +2298,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -2101,6 +2320,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -2122,6 +2342,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -2143,6 +2364,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -2164,6 +2386,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -2185,6 +2408,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -2206,6 +2430,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -2264,6 +2489,24 @@
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -2418,6 +2661,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/simplex-noise": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/simplex-noise/-/simplex-noise-4.0.3.tgz",
@@ -2433,6 +2683,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.2.1",
@@ -2455,6 +2719,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2470,6 +2751,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -3106,6 +3397,105 @@
         "@esbuild/win32-arm64": "0.25.12",
         "@esbuild/win32-ia32": "0.25.12",
         "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
+      "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.0",
+        "@vitest/mocker": "4.1.0",
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/runner": "4.1.0",
+        "@vitest/snapshot": "4.1.0",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.0",
+        "@vitest/browser-preview": "4.1.0",
+        "@vitest/browser-webdriverio": "4.1.0",
+        "@vitest/ui": "4.1.0",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
   "scripts": {
     "dev:app": "npm run dev --workspace=app",
     "dev:sim": "npm run dev --workspace=sim",
-    "build": "npm run build --workspaces"
+    "build": "npm run build --workspaces",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.0"
   }
 }

--- a/sim/package.json
+++ b/sim/package.json
@@ -6,7 +6,8 @@
   "main": "dist/index.js",
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "build": "tsc"
+    "build": "tsc",
+    "test": "vitest run"
   },
   "dependencies": {
     "@pwarf/shared": "*",

--- a/sim/src/world-gen/index.ts
+++ b/sim/src/world-gen/index.ts
@@ -1,1 +1,11 @@
 export { generateOverworld } from "./overworld.js";
+export {
+  createAleaRng,
+  fbm,
+  deriveTerrain,
+  deriveBiomeTags,
+  deriveSpecialOverlay,
+  elevationToMeters,
+  SPECIAL_TERRAINS,
+} from "./overworld-helpers.js";
+export type { SpecialTerrain } from "./overworld-helpers.js";

--- a/sim/src/world-gen/overworld-helpers.test.ts
+++ b/sim/src/world-gen/overworld-helpers.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect } from "vitest";
+import { createNoise2D, type NoiseFunction2D } from "simplex-noise";
+import {
+  createAleaRng,
+  fbm,
+  deriveTerrain,
+  deriveBiomeTags,
+  deriveSpecialOverlay,
+  elevationToMeters,
+} from "./overworld-helpers.js";
+
+// ============================================================
+// createAleaRng
+// ============================================================
+
+describe("createAleaRng", () => {
+  it("returns numbers in [0, 1)", () => {
+    const rng = createAleaRng(12345n);
+    for (let i = 0; i < 1000; i++) {
+      const val = rng();
+      expect(val).toBeGreaterThanOrEqual(0);
+      expect(val).toBeLessThan(1);
+    }
+  });
+
+  it("same seed produces same sequence (determinism)", () => {
+    const rng1 = createAleaRng(42n);
+    const rng2 = createAleaRng(42n);
+    for (let i = 0; i < 100; i++) {
+      expect(rng1()).toBe(rng2());
+    }
+  });
+
+  it("different seeds produce different sequences", () => {
+    const rng1 = createAleaRng(1n);
+    const rng2 = createAleaRng(2n);
+    // At least one of the first 10 values should differ
+    let allSame = true;
+    for (let i = 0; i < 10; i++) {
+      if (rng1() !== rng2()) {
+        allSame = false;
+        break;
+      }
+    }
+    expect(allSame).toBe(false);
+  });
+});
+
+// ============================================================
+// fbm
+// ============================================================
+
+describe("fbm", () => {
+  it("returns values in [0, 1] range", () => {
+    const rng = createAleaRng(99n);
+    const noise = createNoise2D(rng);
+    for (let x = 0; x < 50; x++) {
+      for (let y = 0; y < 50; y++) {
+        const val = fbm(noise, x, y, 6, 0.005, 1.0);
+        expect(val).toBeGreaterThanOrEqual(0);
+        expect(val).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+
+  it("same inputs produce same output (determinism)", () => {
+    const rng1 = createAleaRng(55n);
+    const noise1 = createNoise2D(rng1);
+    const rng2 = createAleaRng(55n);
+    const noise2 = createNoise2D(rng2);
+
+    const val1 = fbm(noise1, 10, 20, 6, 0.005, 1.0);
+    const val2 = fbm(noise2, 10, 20, 6, 0.005, 1.0);
+    expect(val1).toBe(val2);
+  });
+
+  it("different coordinates produce different values", () => {
+    const rng = createAleaRng(77n);
+    const noise = createNoise2D(rng);
+    const val1 = fbm(noise, 0, 0, 6, 0.005, 1.0);
+    const val2 = fbm(noise, 100, 200, 6, 0.005, 1.0);
+    expect(val1).not.toBe(val2);
+  });
+});
+
+// ============================================================
+// deriveTerrain — all 10 priority rules
+// ============================================================
+
+describe("deriveTerrain", () => {
+  it("elevation < 0.25 → ocean", () => {
+    expect(deriveTerrain(0.1, 0.5, 0.5)).toBe("ocean");
+    expect(deriveTerrain(0.0, 0.9, 0.1)).toBe("ocean");
+    expect(deriveTerrain(0.24, 0.5, 0.5)).toBe("ocean");
+  });
+
+  it("elevation > 0.85 and temperature < 0.3 → tundra", () => {
+    expect(deriveTerrain(0.9, 0.5, 0.2)).toBe("tundra");
+    expect(deriveTerrain(0.86, 0.1, 0.1)).toBe("tundra");
+  });
+
+  it("elevation > 0.85 (temp >= 0.3) → mountain", () => {
+    expect(deriveTerrain(0.9, 0.5, 0.5)).toBe("mountain");
+    expect(deriveTerrain(0.86, 0.5, 0.3)).toBe("mountain");
+  });
+
+  it("elevation > 0.75, moisture < 0.2, temp > 0.7 → volcano", () => {
+    expect(deriveTerrain(0.8, 0.1, 0.8)).toBe("volcano");
+    expect(deriveTerrain(0.76, 0.19, 0.71)).toBe("volcano");
+  });
+
+  it("temperature < 0.15 (non-ocean, non-mountain) → tundra", () => {
+    // elevation in mid-range, temp below 0.15
+    expect(deriveTerrain(0.5, 0.5, 0.1)).toBe("tundra");
+    expect(deriveTerrain(0.3, 0.8, 0.0)).toBe("tundra");
+  });
+
+  it("moisture > 0.7 and temperature > 0.6 → swamp", () => {
+    expect(deriveTerrain(0.5, 0.8, 0.7)).toBe("swamp");
+    expect(deriveTerrain(0.4, 0.71, 0.61)).toBe("swamp");
+  });
+
+  it("moisture < 0.2 and temperature > 0.6 → desert", () => {
+    expect(deriveTerrain(0.5, 0.1, 0.7)).toBe("desert");
+    expect(deriveTerrain(0.3, 0.19, 0.61)).toBe("desert");
+  });
+
+  it("moisture > 0.5 and temperature > 0.3 → forest", () => {
+    expect(deriveTerrain(0.5, 0.6, 0.4)).toBe("forest");
+    expect(deriveTerrain(0.4, 0.51, 0.31)).toBe("forest");
+  });
+
+  it("elevation > 0.6 (nothing else matches) → mountain", () => {
+    // Need: elev > 0.6 but <= 0.85, moisture 0.2-0.5, temp 0.15-0.3
+    expect(deriveTerrain(0.65, 0.3, 0.2)).toBe("mountain");
+    expect(deriveTerrain(0.7, 0.4, 0.25)).toBe("mountain");
+  });
+
+  it("default → plains", () => {
+    // Need: elev 0.25-0.6, moisture 0.2-0.5, temp 0.15-0.3
+    expect(deriveTerrain(0.4, 0.3, 0.2)).toBe("plains");
+    expect(deriveTerrain(0.5, 0.4, 0.25)).toBe("plains");
+  });
+});
+
+// ============================================================
+// deriveBiomeTags
+// ============================================================
+
+describe("deriveBiomeTags", () => {
+  it("returns correct temperature tags", () => {
+    expect(deriveBiomeTags(0.5, 0.5, 0.1)).toContain("freezing");
+    expect(deriveBiomeTags(0.5, 0.5, 0.3)).toContain("cold");
+    expect(deriveBiomeTags(0.5, 0.5, 0.5)).toContain("temperate");
+    expect(deriveBiomeTags(0.5, 0.5, 0.7)).toContain("warm");
+    expect(deriveBiomeTags(0.5, 0.5, 0.9)).toContain("hot");
+  });
+
+  it("returns correct moisture tags", () => {
+    expect(deriveBiomeTags(0.5, 0.1, 0.5)).toContain("arid");
+    expect(deriveBiomeTags(0.5, 0.3, 0.5)).toContain("dry");
+    expect(deriveBiomeTags(0.5, 0.5, 0.5)).toContain("moderate");
+    expect(deriveBiomeTags(0.5, 0.7, 0.5)).toContain("humid");
+    expect(deriveBiomeTags(0.5, 0.9, 0.5)).toContain("drenched");
+  });
+
+  it("returns correct elevation tags", () => {
+    expect(deriveBiomeTags(0.1, 0.5, 0.5)).toContain("submerged");
+    expect(deriveBiomeTags(0.3, 0.5, 0.5)).toContain("lowland");
+    expect(deriveBiomeTags(0.5, 0.5, 0.5)).toContain("midland");
+    expect(deriveBiomeTags(0.7, 0.5, 0.5)).toContain("highland");
+    expect(deriveBiomeTags(0.9, 0.5, 0.5)).toContain("alpine");
+  });
+
+  it("always returns exactly 3 tags", () => {
+    const cases = [
+      [0.0, 0.0, 0.0],
+      [0.5, 0.5, 0.5],
+      [1.0, 1.0, 1.0],
+      [0.1, 0.9, 0.4],
+    ];
+    for (const [e, m, t] of cases) {
+      expect(deriveBiomeTags(e, m, t)).toHaveLength(3);
+    }
+  });
+});
+
+// ============================================================
+// elevationToMeters
+// ============================================================
+
+describe("elevationToMeters", () => {
+  it("0.0 → -200", () => {
+    expect(elevationToMeters(0.0)).toBe(-200);
+  });
+
+  it("1.0 → 2000", () => {
+    expect(elevationToMeters(1.0)).toBe(2000);
+  });
+
+  it("ocean range (0.25) maps to reasonable values", () => {
+    const meters = elevationToMeters(0.25);
+    expect(meters).toBe(350);
+    expect(meters).toBeLessThan(500);
+    expect(meters).toBeGreaterThan(-200);
+  });
+
+  it("mountain range (0.85+) maps to high values", () => {
+    const meters85 = elevationToMeters(0.85);
+    const meters95 = elevationToMeters(0.95);
+    expect(meters85).toBeGreaterThan(1500);
+    expect(meters95).toBeGreaterThan(1800);
+  });
+});
+
+// ============================================================
+// deriveSpecialOverlay
+// ============================================================
+
+describe("deriveSpecialOverlay", () => {
+  it("returns null when no noise exceeds threshold", () => {
+    // Noise function that always returns 0 → normalized to 0.5 (below 0.95)
+    const lowNoise: NoiseFunction2D = () => 0;
+    const result = deriveSpecialOverlay([lowNoise, lowNoise, lowNoise, lowNoise], 10, 10, 0.003);
+    expect(result).toBeNull();
+  });
+
+  it("returns a special terrain when noise > 0.95", () => {
+    // Noise function returning 0.95 → normalized: (0.95 + 1) / 2 = 0.975 > 0.95
+    const highNoise: NoiseFunction2D = () => 0.95;
+    const lowNoise: NoiseFunction2D = () => 0;
+    const result = deriveSpecialOverlay([lowNoise, lowNoise, lowNoise, highNoise], 10, 10, 0.003);
+    expect(result).toBe("evil");
+  });
+
+  it("first matching special terrain wins (priority order)", () => {
+    // All noises are high — first one ("underground") should win
+    const highNoise: NoiseFunction2D = () => 0.95;
+    const result = deriveSpecialOverlay([highNoise, highNoise, highNoise, highNoise], 10, 10, 0.003);
+    expect(result).toBe("underground");
+  });
+});

--- a/sim/src/world-gen/overworld-helpers.ts
+++ b/sim/src/world-gen/overworld-helpers.ts
@@ -1,0 +1,176 @@
+import type { NoiseFunction2D } from "simplex-noise";
+import type { TerrainType } from "@pwarf/shared";
+
+// ============================================================
+// Seeded PRNG (Alea algorithm by Johannes Baagoe)
+// ============================================================
+
+export function createAleaRng(seed: bigint): () => number {
+  // Mix seed into three state variables using a simple hash
+  let s0 = 0;
+  let s1 = 0;
+  let s2 = 0;
+  let c = 1;
+
+  const seedStr = seed.toString();
+
+  // Mash function to initialize state from string
+  function mash(data: string): number {
+    let n = 0xefc8249d;
+    for (let i = 0; i < data.length; i++) {
+      n += data.charCodeAt(i);
+      let h = 0.02519603282416938 * n;
+      n = h >>> 0;
+      h -= n;
+      h *= n;
+      n = h >>> 0;
+      h -= n;
+      n += h * 0x100000000;
+    }
+    return (n >>> 0) * 2.3283064365386963e-10;
+  }
+
+  s0 = mash(" ");
+  s1 = mash(" ");
+  s2 = mash(" ");
+
+  s0 -= mash(seedStr);
+  if (s0 < 0) s0 += 1;
+  s1 -= mash(seedStr);
+  if (s1 < 0) s1 += 1;
+  s2 -= mash(seedStr);
+  if (s2 < 0) s2 += 1;
+
+  return function () {
+    const t = 2091639 * s0 + c * 2.3283064365386963e-10;
+    s0 = s1;
+    s1 = s2;
+    c = t | 0;
+    s2 = t - c;
+    return s2;
+  };
+}
+
+// ============================================================
+// Fractal Brownian Motion
+// ============================================================
+
+export function fbm(
+  noise2D: NoiseFunction2D,
+  x: number,
+  y: number,
+  octaves: number,
+  frequency: number,
+  amplitude: number
+): number {
+  let value = 0;
+  let freq = frequency;
+  let amp = amplitude;
+  let maxAmp = 0;
+
+  for (let i = 0; i < octaves; i++) {
+    value += noise2D(x * freq, y * freq) * amp;
+    maxAmp += amp;
+    freq *= 2;
+    amp *= 0.5;
+  }
+
+  // Normalize to [0, 1] — noise2D returns [-1, 1]
+  return (value / maxAmp + 1) / 2;
+}
+
+// ============================================================
+// Terrain derivation
+// ============================================================
+
+export function deriveTerrain(
+  elevation: number,
+  moisture: number,
+  temperature: number
+): TerrainType {
+  // Priority-ordered rules from design spec
+  if (elevation < 0.25) return "ocean";
+  if (elevation > 0.85 && temperature < 0.3) return "tundra";
+  if (elevation > 0.85) return "mountain";
+  if (elevation > 0.75 && moisture < 0.2 && temperature > 0.7) return "volcano";
+  if (temperature < 0.15) return "tundra";
+  if (moisture > 0.7 && temperature > 0.6) return "swamp";
+  if (moisture < 0.2 && temperature > 0.6) return "desert";
+  if (moisture > 0.5 && temperature > 0.3) return "forest";
+  if (elevation > 0.6) return "mountain";
+  return "plains";
+}
+
+// ============================================================
+// Biome tags derivation
+// ============================================================
+
+export function deriveBiomeTags(
+  elevation: number,
+  moisture: number,
+  temperature: number
+): string[] {
+  const tags: string[] = [];
+
+  // Temperature tags
+  if (temperature < 0.2) tags.push("freezing");
+  else if (temperature < 0.4) tags.push("cold");
+  else if (temperature < 0.6) tags.push("temperate");
+  else if (temperature < 0.8) tags.push("warm");
+  else tags.push("hot");
+
+  // Moisture tags
+  if (moisture < 0.2) tags.push("arid");
+  else if (moisture < 0.4) tags.push("dry");
+  else if (moisture < 0.6) tags.push("moderate");
+  else if (moisture < 0.8) tags.push("humid");
+  else tags.push("drenched");
+
+  // Elevation tags
+  if (elevation < 0.25) tags.push("submerged");
+  else if (elevation < 0.4) tags.push("lowland");
+  else if (elevation < 0.6) tags.push("midland");
+  else if (elevation < 0.8) tags.push("highland");
+  else tags.push("alpine");
+
+  return tags;
+}
+
+// ============================================================
+// Special terrain overlay
+// ============================================================
+
+export type SpecialTerrain = "underground" | "haunted" | "savage" | "evil";
+
+export const SPECIAL_TERRAINS: SpecialTerrain[] = [
+  "underground",
+  "haunted",
+  "savage",
+  "evil",
+];
+
+export function deriveSpecialOverlay(
+  specialNoises: NoiseFunction2D[],
+  x: number,
+  y: number,
+  frequency: number
+): TerrainType | null {
+  for (let i = 0; i < specialNoises.length; i++) {
+    const value = (specialNoises[i](x * frequency, y * frequency) + 1) / 2;
+    if (value > 0.95) {
+      return SPECIAL_TERRAINS[i];
+    }
+  }
+  return null;
+}
+
+// ============================================================
+// Elevation to meters conversion
+// ============================================================
+
+export function elevationToMeters(normalizedElevation: number): number {
+  // Map [0, 1] to [-200, 2000] meters
+  // Ocean (< 0.25) maps to roughly [-200, 300]
+  // Mountains (> 0.85) maps to roughly [1700, 2000]
+  return Math.round(normalizedElevation * 2200 - 200);
+}

--- a/sim/src/world-gen/overworld.ts
+++ b/sim/src/world-gen/overworld.ts
@@ -1,185 +1,19 @@
-import { createNoise2D, type NoiseFunction2D } from "simplex-noise";
+import { createNoise2D } from "simplex-noise";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import {
   WORLD_WIDTH,
   WORLD_HEIGHT,
-  type TerrainType,
   type WorldTile,
 } from "@pwarf/shared";
-
-// ============================================================
-// Seeded PRNG (Alea algorithm by Johannes Baagøe)
-// ============================================================
-
-function createAleaRng(seed: bigint): () => number {
-  // Mix seed into three state variables using a simple hash
-  let s0 = 0;
-  let s1 = 0;
-  let s2 = 0;
-  let c = 1;
-
-  const seedStr = seed.toString();
-
-  // Mash function to initialize state from string
-  function mash(data: string): number {
-    let n = 0xefc8249d;
-    for (let i = 0; i < data.length; i++) {
-      n += data.charCodeAt(i);
-      let h = 0.02519603282416938 * n;
-      n = h >>> 0;
-      h -= n;
-      h *= n;
-      n = h >>> 0;
-      h -= n;
-      n += h * 0x100000000;
-    }
-    return (n >>> 0) * 2.3283064365386963e-10;
-  }
-
-  s0 = mash(" ");
-  s1 = mash(" ");
-  s2 = mash(" ");
-
-  s0 -= mash(seedStr);
-  if (s0 < 0) s0 += 1;
-  s1 -= mash(seedStr);
-  if (s1 < 0) s1 += 1;
-  s2 -= mash(seedStr);
-  if (s2 < 0) s2 += 1;
-
-  return function () {
-    const t = 2091639 * s0 + c * 2.3283064365386963e-10;
-    s0 = s1;
-    s1 = s2;
-    c = t | 0;
-    s2 = t - c;
-    return s2;
-  };
-}
-
-// ============================================================
-// Fractal Brownian Motion
-// ============================================================
-
-function fbm(
-  noise2D: NoiseFunction2D,
-  x: number,
-  y: number,
-  octaves: number,
-  frequency: number,
-  amplitude: number
-): number {
-  let value = 0;
-  let freq = frequency;
-  let amp = amplitude;
-  let maxAmp = 0;
-
-  for (let i = 0; i < octaves; i++) {
-    value += noise2D(x * freq, y * freq) * amp;
-    maxAmp += amp;
-    freq *= 2;
-    amp *= 0.5;
-  }
-
-  // Normalize to [0, 1] — noise2D returns [-1, 1]
-  return (value / maxAmp + 1) / 2;
-}
-
-// ============================================================
-// Terrain derivation
-// ============================================================
-
-function deriveTerrain(
-  elevation: number,
-  moisture: number,
-  temperature: number
-): TerrainType {
-  // Priority-ordered rules from design spec
-  if (elevation < 0.25) return "ocean";
-  if (elevation > 0.85 && temperature < 0.3) return "tundra";
-  if (elevation > 0.85) return "mountain";
-  if (elevation > 0.75 && moisture < 0.2 && temperature > 0.7) return "volcano";
-  if (temperature < 0.15) return "tundra";
-  if (moisture > 0.7 && temperature > 0.6) return "swamp";
-  if (moisture < 0.2 && temperature > 0.6) return "desert";
-  if (moisture > 0.5 && temperature > 0.3) return "forest";
-  if (elevation > 0.6) return "mountain";
-  return "plains";
-}
-
-// ============================================================
-// Biome tags derivation
-// ============================================================
-
-function deriveBiomeTags(
-  elevation: number,
-  moisture: number,
-  temperature: number
-): string[] {
-  const tags: string[] = [];
-
-  // Temperature tags
-  if (temperature < 0.2) tags.push("freezing");
-  else if (temperature < 0.4) tags.push("cold");
-  else if (temperature < 0.6) tags.push("temperate");
-  else if (temperature < 0.8) tags.push("warm");
-  else tags.push("hot");
-
-  // Moisture tags
-  if (moisture < 0.2) tags.push("arid");
-  else if (moisture < 0.4) tags.push("dry");
-  else if (moisture < 0.6) tags.push("moderate");
-  else if (moisture < 0.8) tags.push("humid");
-  else tags.push("drenched");
-
-  // Elevation tags
-  if (elevation < 0.25) tags.push("submerged");
-  else if (elevation < 0.4) tags.push("lowland");
-  else if (elevation < 0.6) tags.push("midland");
-  else if (elevation < 0.8) tags.push("highland");
-  else tags.push("alpine");
-
-  return tags;
-}
-
-// ============================================================
-// Special terrain overlay
-// ============================================================
-
-type SpecialTerrain = "underground" | "haunted" | "savage" | "evil";
-
-const SPECIAL_TERRAINS: SpecialTerrain[] = [
-  "underground",
-  "haunted",
-  "savage",
-  "evil",
-];
-
-function deriveSpecialOverlay(
-  specialNoises: NoiseFunction2D[],
-  x: number,
-  y: number,
-  frequency: number
-): TerrainType | null {
-  for (let i = 0; i < specialNoises.length; i++) {
-    const value = (specialNoises[i](x * frequency, y * frequency) + 1) / 2;
-    if (value > 0.95) {
-      return SPECIAL_TERRAINS[i];
-    }
-  }
-  return null;
-}
-
-// ============================================================
-// Elevation to meters conversion
-// ============================================================
-
-function elevationToMeters(normalizedElevation: number): number {
-  // Map [0, 1] to [-200, 2000] meters
-  // Ocean (< 0.25) maps to roughly [-200, 300]
-  // Mountains (> 0.85) maps to roughly [1700, 2000]
-  return Math.round(normalizedElevation * 2200 - 200);
-}
+import {
+  createAleaRng,
+  fbm,
+  deriveTerrain,
+  deriveBiomeTags,
+  deriveSpecialOverlay,
+  elevationToMeters,
+  SPECIAL_TERRAINS,
+} from "./overworld-helpers.js";
 
 // ============================================================
 // Batch insert helper

--- a/sim/vitest.config.ts
+++ b/sim/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary
- Set up Vitest as the test framework across the monorepo
- Extract pure functions from `overworld.ts` into `overworld-helpers.ts` for testability
- Add 27 unit tests covering all overworld generation helpers: PRNG, fBm noise, terrain derivation (all 10 priority rules), biome tags, elevation conversion, special overlays

## Test plan
- [x] `npm test --workspace=sim` passes (27 tests)
- [x] TypeScript compiles cleanly
- [x] No logic changes to generation code — only extracted into separate module

🤖 Generated with [Claude Code](https://claude.com/claude-code)