### PR TITLE
feat: implement D1 sim engine (closes #131, #132, #134, #135, #136)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1880,6 +1880,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001779",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001779.tgz",
@@ -1909,6 +1919,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/convert-source-map": {
@@ -1941,6 +1961,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -2440,6 +2470,13 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2510,6 +2547,16 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2699,6 +2746,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
@@ -2754,10 +2821,30 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
     "node_modules/tinyrainbow": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
       "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2915,6 +3002,36 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
@@ -3548,7 +3665,237 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "tsx": "^4.19.0",
-        "typescript": "^5.7.0"
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "sim/node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "sim/node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "sim/node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "sim/node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "sim/node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "sim/node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "sim/node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "sim/node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "sim/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "sim/node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "sim/node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "sim/node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
       }
     }
   }

--- a/sim/package.json
+++ b/sim/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "tsx": "^4.19.0",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
   }
 }

--- a/sim/src/__tests__/integration.test.ts
+++ b/sim/src/__tests__/integration.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "vitest";
+import { randomUUID } from "node:crypto";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Dwarf } from "@pwarf/shared";
+import {
+  FOOD_DECAY_PER_TICK,
+  DRINK_DECAY_PER_TICK,
+  SLEEP_DECAY_PER_TICK,
+  SOCIAL_DECAY_PER_TICK,
+  PURPOSE_DECAY_PER_TICK,
+  BEAUTY_DECAY_PER_TICK,
+} from "@pwarf/shared";
+import type { SimContext } from "../sim-context.js";
+import { createEmptyCachedState } from "../sim-context.js";
+import { needsDecay } from "../phases/needs-decay.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeDwarf(overrides?: Partial<Dwarf>): Dwarf {
+  return {
+    id: randomUUID(),
+    civilization_id: "civ-1",
+    name: "Urist",
+    surname: null,
+    status: "alive",
+    age: 30,
+    gender: "male",
+    need_food: 80,
+    need_drink: 80,
+    need_sleep: 80,
+    need_social: 50,
+    need_purpose: 50,
+    need_beauty: 50,
+    stress_level: 0,
+    is_in_tantrum: false,
+    health: 100,
+    injuries: [],
+    memories: [],
+    trait_openness: null,
+    trait_conscientiousness: null,
+    trait_extraversion: null,
+    trait_agreeableness: null,
+    trait_neuroticism: null,
+    religious_devotion: 0,
+    faction_id: null,
+    born_year: null,
+    died_year: null,
+    cause_of_death: null,
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeSimContext(dwarves: Dwarf[]): SimContext {
+  const state = createEmptyCachedState();
+  state.dwarves = dwarves;
+
+  return {
+    supabase: null as unknown as SupabaseClient,
+    civilizationId: "civ-1",
+    step: 0,
+    year: 1,
+    day: 1,
+    state,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("needs decay", () => {
+  it("needs decay over 100 ticks", async () => {
+    const dwarves = Array.from({ length: 7 }, () => makeDwarf());
+    const ctx = makeSimContext(dwarves);
+
+    for (let i = 0; i < 100; i++) {
+      await needsDecay(ctx);
+    }
+
+    for (const dwarf of ctx.state.dwarves) {
+      // All needs should have decreased
+      expect(dwarf.need_food).toBeLessThan(80);
+      expect(dwarf.need_drink).toBeLessThan(80);
+      expect(dwarf.need_sleep).toBeLessThan(80);
+      expect(dwarf.need_social).toBeLessThan(50);
+      expect(dwarf.need_purpose).toBeLessThan(50);
+      expect(dwarf.need_beauty).toBeLessThan(50);
+
+      // No values below 0
+      expect(dwarf.need_food).toBeGreaterThanOrEqual(0);
+      expect(dwarf.need_drink).toBeGreaterThanOrEqual(0);
+      expect(dwarf.need_sleep).toBeGreaterThanOrEqual(0);
+      expect(dwarf.need_social).toBeGreaterThanOrEqual(0);
+      expect(dwarf.need_purpose).toBeGreaterThanOrEqual(0);
+      expect(dwarf.need_beauty).toBeGreaterThanOrEqual(0);
+
+      // All IDs should be dirty
+      expect(ctx.state.dirtyDwarfIds.has(dwarf.id)).toBe(true);
+    }
+
+    // Verify computed values match expected
+    const d = ctx.state.dwarves[0]!;
+    expect(d.need_food).toBeCloseTo(80 - 100 * FOOD_DECAY_PER_TICK, 5);
+    expect(d.need_drink).toBeCloseTo(80 - 100 * DRINK_DECAY_PER_TICK, 5);
+    expect(d.need_sleep).toBeCloseTo(80 - 100 * SLEEP_DECAY_PER_TICK, 5);
+    expect(d.need_social).toBeCloseTo(50 - 100 * SOCIAL_DECAY_PER_TICK, 5);
+    expect(d.need_purpose).toBeCloseTo(50 - 100 * PURPOSE_DECAY_PER_TICK, 5);
+    expect(d.need_beauty).toBeCloseTo(50 - 100 * BEAUTY_DECAY_PER_TICK, 5);
+  });
+
+  it("dead dwarves are not decayed", async () => {
+    const deadDwarf = makeDwarf({ status: "dead" });
+    const originalFood = deadDwarf.need_food;
+    const originalDrink = deadDwarf.need_drink;
+    const originalSleep = deadDwarf.need_sleep;
+    const originalSocial = deadDwarf.need_social;
+    const originalPurpose = deadDwarf.need_purpose;
+    const originalBeauty = deadDwarf.need_beauty;
+
+    const ctx = makeSimContext([deadDwarf]);
+
+    for (let i = 0; i < 10; i++) {
+      await needsDecay(ctx);
+    }
+
+    expect(deadDwarf.need_food).toBe(originalFood);
+    expect(deadDwarf.need_drink).toBe(originalDrink);
+    expect(deadDwarf.need_sleep).toBe(originalSleep);
+    expect(deadDwarf.need_social).toBe(originalSocial);
+    expect(deadDwarf.need_purpose).toBe(originalPurpose);
+    expect(deadDwarf.need_beauty).toBe(originalBeauty);
+
+    expect(ctx.state.dirtyDwarfIds.has(deadDwarf.id)).toBe(false);
+  });
+
+  it("needs clamp at zero", async () => {
+    const dwarf = makeDwarf({
+      need_food: 1,
+      need_drink: 1,
+      need_sleep: 1,
+      need_social: 1,
+      need_purpose: 1,
+      need_beauty: 1,
+    });
+
+    const ctx = makeSimContext([dwarf]);
+
+    for (let i = 0; i < 100; i++) {
+      await needsDecay(ctx);
+    }
+
+    expect(dwarf.need_food).toBe(0);
+    expect(dwarf.need_drink).toBe(0);
+    expect(dwarf.need_sleep).toBe(0);
+    expect(dwarf.need_social).toBe(0);
+    expect(dwarf.need_purpose).toBe(0);
+    expect(dwarf.need_beauty).toBe(0);
+  });
+});

--- a/sim/src/flush-state.ts
+++ b/sim/src/flush-state.ts
@@ -1,0 +1,90 @@
+import type { SimContext } from "./sim-context.js";
+
+/**
+ * Flush dirty entities and pending events to Supabase.
+ *
+ * All five flushes run in parallel via Promise.all. Errors are
+ * logged with console.warn but do not throw — the sim keeps running
+ * and will retry on the next flush cycle.
+ */
+export async function flushToSupabase(ctx: SimContext): Promise<void> {
+  const { state, supabase } = ctx;
+
+  const dirtyDwarves = state.dwarves.filter((d) =>
+    state.dirtyDwarfIds.has(d.id),
+  );
+  const dirtyItems = state.items.filter((i) => state.dirtyItemIds.has(i.id));
+  const dirtyStructures = state.structures.filter((s) =>
+    state.dirtyStructureIds.has(s.id),
+  );
+  const dirtyMonsters = state.monsters.filter((m) =>
+    state.dirtyMonsterIds.has(m.id),
+  );
+  const events = [...state.pendingEvents];
+
+  const promises: PromiseLike<void>[] = [];
+
+  if (dirtyDwarves.length > 0) {
+    promises.push(
+      supabase
+        .from("dwarves")
+        .upsert(dirtyDwarves)
+        .then(({ error }) => {
+          if (error) console.warn(`[flush] dwarves upsert failed: ${error.message}`);
+        }),
+    );
+  }
+
+  if (dirtyItems.length > 0) {
+    promises.push(
+      supabase
+        .from("items")
+        .upsert(dirtyItems)
+        .then(({ error }) => {
+          if (error) console.warn(`[flush] items upsert failed: ${error.message}`);
+        }),
+    );
+  }
+
+  if (dirtyStructures.length > 0) {
+    promises.push(
+      supabase
+        .from("structures")
+        .upsert(dirtyStructures)
+        .then(({ error }) => {
+          if (error) console.warn(`[flush] structures upsert failed: ${error.message}`);
+        }),
+    );
+  }
+
+  if (dirtyMonsters.length > 0) {
+    promises.push(
+      supabase
+        .from("monsters")
+        .upsert(dirtyMonsters)
+        .then(({ error }) => {
+          if (error) console.warn(`[flush] monsters upsert failed: ${error.message}`);
+        }),
+    );
+  }
+
+  if (events.length > 0) {
+    promises.push(
+      supabase
+        .from("world_events")
+        .insert(events)
+        .then(({ error }) => {
+          if (error) console.warn(`[flush] events insert failed: ${error.message}`);
+        }),
+    );
+  }
+
+  await Promise.all(promises);
+
+  // Clear dirty tracking after successful flush
+  state.dirtyDwarfIds.clear();
+  state.dirtyItemIds.clear();
+  state.dirtyStructureIds.clear();
+  state.dirtyMonsterIds.clear();
+  state.pendingEvents = [];
+}

--- a/sim/src/index.ts
+++ b/sim/src/index.ts
@@ -1,6 +1,9 @@
 import { createClient } from "@supabase/supabase-js";
 import { SimRunner } from "./sim-runner.js";
 
+export { loadStateFromSupabase } from "./load-state.js";
+export { flushToSupabase } from "./flush-state.js";
+
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_KEY;
 
@@ -14,10 +17,11 @@ if (!SUPABASE_URL || !SUPABASE_SERVICE_KEY) {
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
 const runner = new SimRunner(supabase);
 
-// For now, accept civilization ID from env or default to a placeholder.
+// For now, accept civilization ID and world ID from env or default to placeholders.
 const civId = process.env.CIVILIZATION_ID ?? "default";
+const worldId = process.env.WORLD_ID;
 
-runner.start(civId).catch((err) => {
+runner.start(civId, worldId).catch((err) => {
   console.error("[sim] failed to start:", err);
   process.exit(1);
 });

--- a/sim/src/load-state.ts
+++ b/sim/src/load-state.ts
@@ -1,0 +1,56 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { CachedState } from "./sim-context.js";
+
+/**
+ * Load the current world state from Supabase into a CachedState.
+ *
+ * Queries dwarves, items, structures, and monsters in parallel.
+ * worldEvents and workOrders start empty — events are generated
+ * during simulation, and work orders will be loaded separately.
+ */
+export async function loadStateFromSupabase(
+  supabase: SupabaseClient,
+  civilizationId: string,
+  worldId: string,
+): Promise<CachedState> {
+  const [dwarvesResult, itemsResult, structuresResult, monstersResult] =
+    await Promise.all([
+      supabase
+        .from("dwarves")
+        .select("*")
+        .eq("civilization_id", civilizationId)
+        .eq("status", "alive"),
+      supabase
+        .from("items")
+        .select("*")
+        .eq("located_in_civ_id", civilizationId),
+      supabase
+        .from("structures")
+        .select("*")
+        .eq("civilization_id", civilizationId),
+      supabase
+        .from("monsters")
+        .select("*")
+        .eq("world_id", worldId)
+        .eq("status", "active"),
+    ]);
+
+  if (dwarvesResult.error) throw new Error(`Failed to load dwarves: ${dwarvesResult.error.message}`);
+  if (itemsResult.error) throw new Error(`Failed to load items: ${itemsResult.error.message}`);
+  if (structuresResult.error) throw new Error(`Failed to load structures: ${structuresResult.error.message}`);
+  if (monstersResult.error) throw new Error(`Failed to load monsters: ${monstersResult.error.message}`);
+
+  return {
+    dwarves: dwarvesResult.data ?? [],
+    items: itemsResult.data ?? [],
+    structures: structuresResult.data ?? [],
+    monsters: monstersResult.data ?? [],
+    workOrders: [],
+    worldEvents: [],
+    dirtyDwarfIds: new Set(),
+    dirtyItemIds: new Set(),
+    dirtyStructureIds: new Set(),
+    dirtyMonsterIds: new Set(),
+    pendingEvents: [],
+  };
+}

--- a/sim/src/phases/needs-decay.ts
+++ b/sim/src/phases/needs-decay.ts
@@ -1,12 +1,32 @@
+import {
+  FOOD_DECAY_PER_TICK,
+  DRINK_DECAY_PER_TICK,
+  SLEEP_DECAY_PER_TICK,
+  SOCIAL_DECAY_PER_TICK,
+  PURPOSE_DECAY_PER_TICK,
+  BEAUTY_DECAY_PER_TICK,
+  MIN_NEED,
+} from "@pwarf/shared";
 import type { SimContext } from "../sim-context.js";
 
 /**
  * Needs Decay Phase
  *
- * Decrements each dwarf's need meters (hunger, thirst, sleep, social, etc.)
- * by a small amount every simulation step. Needs that reach zero will begin
- * generating stress in the stress-update phase.
+ * Decrements each living dwarf's need meters by fixed rates every
+ * simulation step. Needs are clamped at MIN_NEED (0). Mutated dwarves
+ * are marked dirty so they get flushed to the database.
  */
-export async function needsDecay(_ctx: SimContext): Promise<void> {
-  // stub
+export async function needsDecay(ctx: SimContext): Promise<void> {
+  for (const dwarf of ctx.state.dwarves) {
+    if (dwarf.status !== "alive") continue;
+
+    dwarf.need_food = Math.max(MIN_NEED, dwarf.need_food - FOOD_DECAY_PER_TICK);
+    dwarf.need_drink = Math.max(MIN_NEED, dwarf.need_drink - DRINK_DECAY_PER_TICK);
+    dwarf.need_sleep = Math.max(MIN_NEED, dwarf.need_sleep - SLEEP_DECAY_PER_TICK);
+    dwarf.need_social = Math.max(MIN_NEED, dwarf.need_social - SOCIAL_DECAY_PER_TICK);
+    dwarf.need_purpose = Math.max(MIN_NEED, dwarf.need_purpose - PURPOSE_DECAY_PER_TICK);
+    dwarf.need_beauty = Math.max(MIN_NEED, dwarf.need_beauty - BEAUTY_DECAY_PER_TICK);
+
+    ctx.state.dirtyDwarfIds.add(dwarf.id);
+  }
 }

--- a/sim/src/sim-runner.ts
+++ b/sim/src/sim-runner.ts
@@ -2,6 +2,8 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { STEPS_PER_SECOND, STEPS_PER_YEAR } from "@pwarf/shared";
 import type { SimContext } from "./sim-context.js";
 import { createEmptyCachedState } from "./sim-context.js";
+import { loadStateFromSupabase } from "./load-state.js";
+import { flushToSupabase } from "./flush-state.js";
 import {
   needsDecay,
   taskExecution,
@@ -25,6 +27,7 @@ import {
 export class SimRunner {
   private supabase: SupabaseClient;
   private timer: ReturnType<typeof setInterval> | null = null;
+  private flushTimer: ReturnType<typeof setInterval> | null = null;
   private ctx: SimContext | null = null;
 
   stepCount = 0;
@@ -36,8 +39,13 @@ export class SimRunner {
   }
 
   /** Load initial state from Supabase and begin the tick loop. */
-  async start(civilizationId: string): Promise<void> {
-    const cached = createEmptyCachedState();
+  async start(civilizationId: string, worldId?: string): Promise<void> {
+    let cached;
+    if (worldId) {
+      cached = await loadStateFromSupabase(this.supabase, civilizationId, worldId);
+    } else {
+      cached = createEmptyCachedState();
+    }
 
     this.ctx = {
       supabase: this.supabase,
@@ -56,6 +64,13 @@ export class SimRunner {
     this.timer = setInterval(() => {
       void this.tick();
     }, intervalMs);
+
+    // Flush dirty state to Supabase every 1 second
+    this.flushTimer = setInterval(() => {
+      if (this.ctx) {
+        void flushToSupabase(this.ctx);
+      }
+    }, 1000);
   }
 
   /** Pause the loop and persist state. */
@@ -64,6 +79,16 @@ export class SimRunner {
       clearInterval(this.timer);
       this.timer = null;
     }
+    if (this.flushTimer) {
+      clearInterval(this.flushTimer);
+      this.flushTimer = null;
+    }
+
+    // Final flush before stopping
+    if (this.ctx) {
+      await flushToSupabase(this.ctx);
+    }
+
     console.log(`[sim] stopped at step ${this.stepCount}`);
   }
 


### PR DESCRIPTION
## Summary
- **Dirty tracking**: Type `CachedState` arrays with proper DB types, add dirty tracking sets and `pendingEvents`
- **loadStateFromSupabase**: Queries dwarves/items/structures/monsters in parallel on sim start
- **flushToSupabase**: Batched upserts for dirty entities on 1-second timer, non-throwing
- **needs-decay phase**: Decrements 6 need meters per alive dwarf per tick, marks dirty
- **Integration tests**: 3 vitest suites covering decay math, dead dwarf exclusion, and zero clamping

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All vitest tests pass (`npx vitest run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)