### PR TITLE
feat: add GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,38 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build --workspace=shared
+      - run: npm run build --workspace=app
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: app/dist
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -3,5 +3,6 @@ import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
+  base: process.env.GITHUB_ACTIONS ? "/pwarf/" : "/",
   plugins: [react(), tailwindcss()],
 });


### PR DESCRIPTION
## Summary
- Add `.github/workflows/deploy.yml` — builds `shared` then `app` and deploys to GitHub Pages on push to `main`
- Set conditional `base` in `app/vite.config.ts` so GitHub Pages serves from `/pwarf/` while local dev stays at `/`

## Before merging
1. Add repo secrets: `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` (Settings > Secrets > Actions)
2. Enable GitHub Pages with source "GitHub Actions" (Settings > Pages)

## Test plan
- [ ] Push to main and confirm the Actions workflow runs green
- [ ] Visit `https://psoren.github.io/pwarf/` and verify the app loads
- [ ] Confirm Supabase calls work (generate a world, embark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)