### PR TITLE
fix: remove deprecated @supabase/auth-helpers-react (closes #164)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@pwarf/shared": "*",
-    "@supabase/auth-helpers-react": "^0.5.0",
     "@supabase/supabase-js": "^2.49.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
       "version": "0.0.1",
       "dependencies": {
         "@pwarf/shared": "*",
-        "@supabase/auth-helpers-react": "^0.5.0",
         "@supabase/supabase-js": "^2.49.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -1467,16 +1466,6 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@supabase/auth-helpers-react": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-react/-/auth-helpers-react-0.5.0.tgz",
-      "integrity": "sha512-5QSaV2CGuhDhd7RlQCoviVEAYsP7XnrFMReOcBazDvVmqSIyjKcDwhLhWvnrxMOq5qjOaA44MHo7wXqDiF0puQ==",
-      "deprecated": "This package is now deprecated - please use the @supabase/ssr package instead.",
-      "license": "MIT",
-      "peerDependencies": {
-        "@supabase/supabase-js": "^2.39.8"
-      }
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.99.1",


### PR DESCRIPTION
## Summary
- Remove unused `@supabase/auth-helpers-react` (deprecated, replaced by `@supabase/ssr`)
- Nothing imports it — auth uses our custom `useAuth` hook

## Test plan
- [x] No imports reference this package
- [x] `npm install` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)