### PR TITLE
feat: persist and restore game session after login (closes #166)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@pwarf/shared": "*",
@@ -26,6 +27,7 @@
     "jsdom": "^29.0.0",
     "tailwindcss": "^4.1.3",
     "typescript": "^5.8.3",
-    "vite": "^6.3.1"
+    "vite": "^6.3.1",
+    "vitest": "^4.1.0"
   }
 }

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -12,6 +12,7 @@ import { useAuth } from "./hooks/useAuth";
 import { createAndGenerateWorld } from "./lib/world-gen";
 import { embark } from "./lib/embark";
 import { ensurePlayer } from "./lib/ensure-player";
+import { loadSession } from "./lib/load-session";
 import { supabase } from "./lib/supabase";
 
 type Mode = "fortress" | "world";
@@ -48,16 +49,25 @@ export default function App() {
 
   const cursorTile = worldId ? getTile(viewport.cursorX, viewport.cursorY) : null;
 
-  // Ensure player profile exists after auth
+  // Ensure player profile exists after auth, then restore any existing session
   useEffect(() => {
     if (user && !playerEnsured) {
-      ensurePlayer(supabase, user.id, user.email ?? "unknown").then(
-        () => setPlayerEnsured(true),
-        (err) => console.error("Failed to ensure player:", err),
-      );
+      ensurePlayer(supabase, user.id, user.email ?? "unknown")
+        .then(() => loadSession(user.id))
+        .then((session) => {
+          if (session.worldId) setWorldId(session.worldId);
+          if (session.civId) {
+            setCivId(session.civId);
+            setMode("fortress");
+          }
+          setPlayerEnsured(true);
+        })
+        .catch((err) => console.error("Failed to ensure player:", err));
     }
     if (!user) {
       setPlayerEnsured(false);
+      setWorldId(null);
+      setCivId(null);
     }
   }, [user, playerEnsured]);
 
@@ -133,6 +143,16 @@ export default function App() {
   // Auth screen
   if (!session) {
     return <AuthScreen onSignIn={signIn} onSignUp={signUp} />;
+  }
+
+  // Restoring session
+  if (user && !playerEnsured) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full w-full bg-[var(--bg-panel)] gap-4">
+        <h1 className="text-[var(--amber)] text-2xl font-bold tracking-wider">pWarf</h1>
+        <p className="text-[var(--text)] text-sm">Restoring session...</p>
+      </div>
+    );
   }
 
   // Pre-world screen: generate button

--- a/app/src/lib/__tests__/load-session.test.ts
+++ b/app/src/lib/__tests__/load-session.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockSingle = vi.fn();
+const mockLimit = vi.fn();
+const mockEq = vi.fn();
+const mockSelect = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock("../supabase", () => {
+  return {
+    supabase: {
+      get from() {
+        return mockFrom;
+      },
+    },
+  };
+});
+
+function setupChain() {
+  mockFrom.mockReturnValue({ select: mockSelect });
+  mockSelect.mockReturnValue({ eq: mockEq });
+  mockEq.mockReturnValue({ eq: mockEq, limit: mockLimit, single: mockSingle });
+  mockLimit.mockReturnValue({ single: mockSingle });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setupChain();
+});
+
+// Need to import after mock setup
+const { loadSession } = await import("../load-session");
+
+describe("loadSession", () => {
+  it("returns null worldId/civId when player has no world", async () => {
+    mockSingle.mockResolvedValueOnce({ data: { world_id: null }, error: null });
+
+    const result = await loadSession("user-1");
+
+    expect(result).toEqual({ worldId: null, civId: null });
+    expect(mockFrom).toHaveBeenCalledWith("players");
+  });
+
+  it("returns null worldId when player row not found", async () => {
+    mockSingle.mockResolvedValueOnce({ data: null, error: null });
+
+    const result = await loadSession("user-1");
+
+    expect(result).toEqual({ worldId: null, civId: null });
+  });
+
+  it("returns worldId and civId when player has an active civilization", async () => {
+    mockSingle.mockResolvedValueOnce({
+      data: { world_id: "world-abc" },
+      error: null,
+    });
+    mockSingle.mockResolvedValueOnce({
+      data: { id: "civ-xyz" },
+      error: null,
+    });
+
+    const result = await loadSession("user-1");
+
+    expect(result).toEqual({ worldId: "world-abc", civId: "civ-xyz" });
+    expect(mockFrom).toHaveBeenCalledWith("civilizations");
+  });
+
+  it("returns worldId with null civId when no active civilization", async () => {
+    mockSingle.mockResolvedValueOnce({
+      data: { world_id: "world-abc" },
+      error: null,
+    });
+    mockSingle.mockResolvedValueOnce({ data: null, error: null });
+
+    const result = await loadSession("user-1");
+
+    expect(result).toEqual({ worldId: "world-abc", civId: null });
+  });
+});

--- a/app/src/lib/embark.ts
+++ b/app/src/lib/embark.ts
@@ -2,11 +2,15 @@ import { supabase } from './supabase';
 import { pickUniqueNames, SURNAMES } from './dwarf-names';
 
 export async function embark(worldId: string, tileX: number, tileY: number) {
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error('Not authenticated');
+
   // Create civilization
   const { data: civ, error: civError } = await supabase
     .from('civilizations')
     .insert({
       world_id: worldId,
+      player_id: user.id,
       name: 'Boatmurdered',
       tile_x: tileX,
       tile_y: tileY,

--- a/app/src/lib/load-session.ts
+++ b/app/src/lib/load-session.ts
@@ -1,0 +1,32 @@
+import { supabase } from "./supabase";
+
+export interface GameSession {
+  worldId: string | null;
+  civId: string | null;
+}
+
+/**
+ * Load an existing game session for the current user.
+ * Reads the player's world_id and looks up their active civilization.
+ */
+export async function loadSession(userId: string): Promise<GameSession> {
+  const { data: player } = await supabase
+    .from("players")
+    .select("world_id")
+    .eq("id", userId)
+    .single();
+
+  const worldId = player?.world_id ?? null;
+  if (!worldId) return { worldId: null, civId: null };
+
+  const { data: civ } = await supabase
+    .from("civilizations")
+    .select("id")
+    .eq("world_id", worldId)
+    .eq("player_id", userId)
+    .eq("status", "active")
+    .limit(1)
+    .single();
+
+  return { worldId, civId: civ?.id ?? null };
+}

--- a/app/src/lib/world-gen.ts
+++ b/app/src/lib/world-gen.ts
@@ -82,5 +82,11 @@ export async function createAndGenerateWorld(
     onProgress?.(100);
   }
 
+  // Link world to the current player
+  const { data: { user } } = await supabase.auth.getUser();
+  if (user) {
+    await supabase.from('players').update({ world_id: worldId }).eq('id', user.id);
+  }
+
   return { worldId, seed };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,8 @@
         "jsdom": "^29.0.0",
         "tailwindcss": "^4.1.3",
         "typescript": "^5.8.3",
-        "vite": "^6.3.1"
+        "vite": "^6.3.1",
+        "vitest": "^4.1.0"
       }
     },
     "node_modules/@adobe/css-tools": {


### PR DESCRIPTION
## Summary
- Adds `loadSession()` that queries `players.world_id` and the player's active civilization after auth
- Updates `createAndGenerateWorld` to set `players.world_id` so the world persists across sessions
- Updates `embark()` to set `player_id` on the civilization insert (required by RLS policy)
- App.tsx restores `worldId`/`civId` state after `ensurePlayer` completes, with a "Restoring session..." loading screen

## Test plan
- [x] 4 unit tests for `loadSession` (no world, no player, world+civ, world without civ)
- [ ] Manual: generate world → close tab → reopen → world map should load automatically
- [ ] Manual: embark → close tab → reopen → fortress mode should restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)