### PR TITLE
fix: paginate tile fetches and improve terrain generation

### DIFF
--- a/app/src/hooks/useWorldTiles.ts
+++ b/app/src/hooks/useWorldTiles.ts
@@ -10,40 +10,57 @@ interface UseWorldTilesOptions {
   viewportRows: number;
 }
 
+const BUFFER = 10; // extra tiles around viewport for smooth panning
+const PAGE_SIZE = 1000; // Supabase default row limit
+
 export function useWorldTiles({ worldId, offsetX, offsetY, viewportCols, viewportRows }: UseWorldTilesOptions) {
   const [tileMap, setTileMap] = useState<Map<string, WorldTile>>(new Map());
   const fetchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastFetchKey = useRef<string>('');
 
-  // Fetch with a buffer around the viewport for smooth panning
+  // Fetch with a small buffer around the viewport, paginating to get all rows
   const fetchTiles = useCallback(async (wId: string, ox: number, oy: number, cols: number, rows: number) => {
-    const buffer = Math.max(cols, rows); // fetch extra tiles around viewport
-    const x0 = Math.max(0, ox - buffer);
-    const y0 = Math.max(0, oy - buffer);
-    const x1 = ox + cols + buffer;
-    const y1 = oy + rows + buffer;
+    const x0 = Math.max(0, ox - BUFFER);
+    const y0 = Math.max(0, oy - BUFFER);
+    const x1 = ox + cols + BUFFER;
+    const y1 = oy + rows + BUFFER;
 
-    const { data, error } = await supabase
-      .from('world_tiles')
-      .select('id, world_id, x, y, terrain, elevation, biome_tags, explored')
-      .eq('world_id', wId)
-      .gte('x', x0)
-      .lt('x', x1)
-      .gte('y', y0)
-      .lt('y', y1);
+    const allTiles: WorldTile[] = [];
+    let from = 0;
+    let hasMore = true;
 
-    if (error) {
-      console.error('[useWorldTiles] fetch error:', error.message);
-      return;
-    }
+    while (hasMore) {
+      const { data, error } = await supabase
+        .from('world_tiles')
+        .select('id, world_id, x, y, terrain, elevation, biome_tags, explored')
+        .eq('world_id', wId)
+        .gte('x', x0)
+        .lt('x', x1)
+        .gte('y', y0)
+        .lt('y', y1)
+        .range(from, from + PAGE_SIZE - 1);
 
-    if (data) {
-      const newMap = new Map<string, WorldTile>();
-      for (const tile of data as WorldTile[]) {
-        newMap.set(`${tile.x},${tile.y}`, tile);
+      if (error) {
+        console.error('[useWorldTiles] fetch error:', error.message);
+        return;
       }
-      setTileMap(newMap);
+
+      if (data) {
+        allTiles.push(...(data as WorldTile[]));
+      }
+
+      hasMore = data !== null && data.length === PAGE_SIZE;
+      from += PAGE_SIZE;
     }
+
+    // Merge into existing map so tiles outside the new range aren't lost
+    setTileMap((prev) => {
+      const merged = new Map(prev);
+      for (const tile of allTiles) {
+        merged.set(`${tile.x},${tile.y}`, tile);
+      }
+      return merged;
+    });
   }, []);
 
   useEffect(() => {

--- a/app/src/lib/world-gen.ts
+++ b/app/src/lib/world-gen.ts
@@ -44,9 +44,9 @@ export async function createAndGenerateWorld(
 
   for (let y = 0; y < WORLD_HEIGHT; y++) {
     for (let x = 0; x < WORLD_WIDTH; x++) {
-      const elevation = fbm(elevationNoise, x, y, 6, 0.005, 1.0);
-      const moisture = fbm(moistureNoise, x, y, 4, 0.008, 1.0);
-      const temperature = fbm(temperatureNoise, x, y, 3, 0.004, 1.0);
+      const elevation = fbm(elevationNoise, x, y, 6, 0.003, 1.0);
+      const moisture = fbm(moistureNoise, x, y, 4, 0.005, 1.0);
+      const temperature = fbm(temperatureNoise, x, y, 3, 0.002, 1.0);
 
       let terrain = deriveTerrain(elevation, moisture, temperature);
       const special = deriveSpecialOverlay(specialNoises, x, y, 0.003);

--- a/sim/src/world-gen/overworld.ts
+++ b/sim/src/world-gen/overworld.ts
@@ -76,9 +76,9 @@ export async function generateOverworld(
 
   for (let y = 0; y < WORLD_HEIGHT; y++) {
     for (let x = 0; x < WORLD_WIDTH; x++) {
-      const elevation = fbm(elevationNoise, x, y, 6, 0.005, 1.0);
-      const moisture = fbm(moistureNoise, x, y, 4, 0.008, 1.0);
-      const temperature = fbm(temperatureNoise, x, y, 3, 0.004, 1.0);
+      const elevation = fbm(elevationNoise, x, y, 6, 0.003, 1.0);
+      const moisture = fbm(moistureNoise, x, y, 4, 0.005, 1.0);
+      const temperature = fbm(temperatureNoise, x, y, 3, 0.002, 1.0);
 
       let terrain = deriveTerrain(elevation, moisture, temperature);
 


### PR DESCRIPTION
## Summary
- Fixes tile fetching to paginate past Supabase's 1000-row default limit, which was causing most of the world map to render with the fallback hash pattern instead of actual terrain data
- Reduces tile fetch buffer from viewport-sized (~130 tiles) to 10 tiles, and merges tiles into existing map instead of replacing wholesale
- Lowers terrain noise frequencies for larger, more natural continent shapes

Closes #170, closes #171

## Test plan
- [ ] Generate a new world and verify all tiles render with proper terrain glyphs (no repeating T/=/,/. fallback pattern)
- [ ] Hover over tiles and verify Tile Info panel consistently shows terrain/elevation/biome data
- [ ] Pan with WASD and verify tiles load smoothly for the new viewport area
- [ ] Embark and verify fortress mode works

🤖 Generated with [Claude Code](https://claude.com/claude-code)