### PR TITLE
fix: build shared before starting app dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "shared"
   ],
   "scripts": {
-    "dev:app": "npm run dev --workspace=app",
+    "dev:app": "npm run build --workspace=shared && npm run dev --workspace=app",
     "dev:sim": "npm run dev --workspace=sim",
     "build": "npm run build --workspaces",
     "test": "vitest run"


### PR DESCRIPTION
## Summary
- Prepends `npm run build --workspace=shared &&` to the `dev:app` script so `shared/dist/` is always rebuilt before the Vite dev server starts
- Fixes the blank white page (zero console errors) that occurs when `shared/dist/` is stale and Vite can't resolve the export

Closes #177

## Test plan
- [ ] Delete `shared/dist/`, run `npm run dev:app`, verify the app loads without a blank page
- [ ] Run `npm run dev:app` normally and confirm no regression in startup time

🤖 Generated with [Claude Code](https://claude.com/claude-code)