### PR TITLE
fix: allow re-embarking after first fortress (closes #179)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -199,7 +199,7 @@ export default function App() {
           collapsed={!leftOpen}
           onToggle={() => setLeftOpen((o) => !o)}
           cursorTile={cursorTile}
-          onEmbark={mode === "world" && !civId ? handleEmbark : undefined}
+          onEmbark={mode === "world" ? handleEmbark : undefined}
         />
 
         <MainViewport


### PR DESCRIPTION
## Summary
- Remove the `!civId` guard from the embark button condition in `App.tsx` so players can embark on a new tile even after creating their first fortress.

## Test plan
- [ ] Start a game and embark on a tile to create a fortress
- [ ] Switch back to world mode and verify the "Embark Here" button still appears
- [ ] Embark on a different tile and confirm a new civ is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)