### PR TITLE
fix: render dwarves on fortress map (closes #178)

### DIFF
--- a/app/src/components/LeftPanel.tsx
+++ b/app/src/components/LeftPanel.tsx
@@ -1,4 +1,5 @@
 import type { WorldTile } from "@pwarf/shared";
+import { FORTRESS_DWARVES } from "./fortressDwarves";
 
 interface LeftPanelProps {
   mode: "fortress" | "world";
@@ -7,16 +8,6 @@ interface LeftPanelProps {
   cursorTile?: WorldTile | null;
   onEmbark?: () => void;
 }
-
-const PLACEHOLDER_DWARVES = [
-  { name: "Urist", job: "Miner" },
-  { name: "Doren", job: "Mason" },
-  { name: "Kadol", job: "Brewer" },
-  { name: "Aban", job: "Woodcutter" },
-  { name: "Likot", job: "Farmer" },
-  { name: "Morul", job: "Idle" },
-  { name: "Fikod", job: "Hauling" },
-];
 
 export default function LeftPanel({ mode, collapsed, onToggle, cursorTile, onEmbark }: LeftPanelProps) {
   const isOcean = cursorTile?.terrain === "ocean";
@@ -42,7 +33,7 @@ export default function LeftPanel({ mode, collapsed, onToggle, cursorTile, onEmb
 
           {mode === "fortress" ? (
             <ul className="space-y-0.5">
-              {PLACEHOLDER_DWARVES.map((d) => (
+              {FORTRESS_DWARVES.map((d) => (
                 <li
                   key={d.name}
                   className="flex justify-between hover:bg-[var(--bg-hover)] px-1"

--- a/app/src/components/MainViewport.tsx
+++ b/app/src/components/MainViewport.tsx
@@ -1,5 +1,6 @@
 import { useRef, useEffect, useCallback } from "react";
 import type { WorldTile, TerrainType } from "@pwarf/shared";
+import { DWARF_POSITION_MAP } from "./fortressDwarves";
 
 interface MainViewportProps {
   mode: "fortress" | "world";
@@ -32,6 +33,11 @@ function fortressTile(wx: number, wy: number): { ch: string; fg: string } {
     (wy >= 1 && wy <= 9 && wx === 13);
 
   if (isWall) return { ch: "#", fg: "#888" };
+
+  // Dwarf at this position?
+  const dwarf = DWARF_POSITION_MAP.get(`${wx},${wy}`);
+  if (dwarf) return { ch: "\u263A", fg: "#00cccc" };
+
   if (inRoom) return { ch: ".", fg: "#555" };
 
   // Ore vein

--- a/app/src/components/fortressDwarves.test.ts
+++ b/app/src/components/fortressDwarves.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { FORTRESS_DWARVES, DWARF_POSITION_MAP } from "./fortressDwarves";
+
+describe("fortress dwarves", () => {
+  it("all dwarves are inside the fortress room (2–12, 2–8)", () => {
+    for (const d of FORTRESS_DWARVES) {
+      expect(d.x).toBeGreaterThanOrEqual(2);
+      expect(d.x).toBeLessThanOrEqual(12);
+      expect(d.y).toBeGreaterThanOrEqual(2);
+      expect(d.y).toBeLessThanOrEqual(8);
+    }
+  });
+
+  it("no two dwarves share the same position", () => {
+    const keys = FORTRESS_DWARVES.map((d) => `${d.x},${d.y}`);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it("no dwarf occupies the stairs at (7,5)", () => {
+    expect(DWARF_POSITION_MAP.has("7,5")).toBe(false);
+  });
+
+  it("no dwarf occupies the door gap at (7,2)", () => {
+    expect(DWARF_POSITION_MAP.has("7,2")).toBe(false);
+  });
+
+  it("position map has same count as array", () => {
+    expect(DWARF_POSITION_MAP.size).toBe(FORTRESS_DWARVES.length);
+  });
+
+  it("each dwarf has a non-empty name and job", () => {
+    for (const d of FORTRESS_DWARVES) {
+      expect(d.name.length).toBeGreaterThan(0);
+      expect(d.job.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/app/src/components/fortressDwarves.ts
+++ b/app/src/components/fortressDwarves.ts
@@ -1,0 +1,29 @@
+/** Placeholder dwarf roster with positions inside the fortress room. */
+export interface FortressDwarf {
+  name: string;
+  job: string;
+  /** Fortress-local x coordinate (inside the room: 2–12) */
+  x: number;
+  /** Fortress-local y coordinate (inside the room: 2–8) */
+  y: number;
+}
+
+/**
+ * Placeholder dwarves placed inside the fortress room.
+ * Positions are spread around the interior (wx 2–12, wy 2–8)
+ * avoiding the stairs at (7, 5) and the door gap at (7, 2).
+ */
+export const FORTRESS_DWARVES: readonly FortressDwarf[] = [
+  { name: "Urist",  job: "Miner",      x: 3,  y: 3 },
+  { name: "Doren",  job: "Mason",       x: 5,  y: 4 },
+  { name: "Kadol",  job: "Brewer",      x: 9,  y: 3 },
+  { name: "Aban",   job: "Woodcutter",  x: 4,  y: 6 },
+  { name: "Likot",  job: "Farmer",      x: 10, y: 7 },
+  { name: "Morul",  job: "Idle",        x: 6,  y: 5 },
+  { name: "Fikod",  job: "Hauling",     x: 11, y: 4 },
+];
+
+/** Build a lookup map keyed by "x,y" for O(1) checks during rendering. */
+export const DWARF_POSITION_MAP: ReadonlyMap<string, FortressDwarf> = new Map(
+  FORTRESS_DWARVES.map((d) => [`${d.x},${d.y}`, d]),
+);


### PR DESCRIPTION
## Summary
- Extract placeholder dwarf roster (with x/y positions) into `app/src/components/fortressDwarves.ts` so both the left panel and the canvas renderer share the same data
- Render each dwarf as a cyan `☺` character at their assigned position inside the fortress room walls
- Replace the hardcoded `PLACEHOLDER_DWARVES` array in `LeftPanel.tsx` with the shared `FORTRESS_DWARVES` import
- Add unit tests verifying dwarf positions are inside the room, unique, and avoid stairs/door

## Test plan
- [ ] Open fortress view and verify cyan ☺ characters appear inside the room walls
- [ ] Confirm left panel roster still lists all 7 dwarves with names and jobs
- [ ] Run `npm test` — new fortressDwarves tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)