### PR TITLE
fix: session restore opens fortress view at correct location

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -63,6 +63,9 @@ export default function App() {
           if (session.civId) {
             setCivId(session.civId);
             setMode("fortress");
+            if (session.fortressX != null && session.fortressY != null) {
+              viewport.setOffset(session.fortressX, session.fortressY);
+            }
           }
           setPlayerEnsured(true);
         })
@@ -74,7 +77,7 @@ export default function App() {
       setWorldSeed(null);
       setCivId(null);
     }
-  }, [user, playerEnsured]);
+  }, [user, playerEnsured, viewport.setOffset]);
 
   const handleKeyAction = useCallback(
     (action: KeyAction) => {

--- a/app/src/hooks/useViewport.ts
+++ b/app/src/hooks/useViewport.ts
@@ -29,6 +29,11 @@ export function useViewport() {
     }));
   }, []);
 
+  /** Jump viewport to an absolute offset (and optionally set cursor) */
+  const setOffset = useCallback((x: number, y: number) => {
+    setState((prev) => ({ ...prev, offsetX: x, offsetY: y, cursorX: x, cursorY: y }));
+  }, []);
+
   /** Set cursor position in world tile coords */
   const setCursor = useCallback((x: number, y: number) => {
     setState((prev) => ({ ...prev, cursorX: x, cursorY: y }));
@@ -69,5 +74,5 @@ export function useViewport() {
     dragRef.current = null;
   }, []);
 
-  return { ...state, pan, setCursor, onDragStart, onDragMove, onDragEnd };
+  return { ...state, pan, setOffset, setCursor, onDragStart, onDragMove, onDragEnd };
 }

--- a/app/src/lib/__tests__/load-session.test.ts
+++ b/app/src/lib/__tests__/load-session.test.ts
@@ -36,7 +36,7 @@ describe("loadSession", () => {
 
     const result = await loadSession("user-1");
 
-    expect(result).toEqual({ worldId: null, worldSeed: null, civId: null });
+    expect(result).toEqual({ worldId: null, worldSeed: null, civId: null, fortressX: null, fortressY: null });
     expect(mockFrom).toHaveBeenCalledWith("players");
   });
 
@@ -45,7 +45,7 @@ describe("loadSession", () => {
 
     const result = await loadSession("user-1");
 
-    expect(result).toEqual({ worldId: null, worldSeed: null, civId: null });
+    expect(result).toEqual({ worldId: null, worldSeed: null, civId: null, fortressX: null, fortressY: null });
   });
 
   it("returns worldId, seed, and civId when player has an active civilization", async () => {
@@ -60,13 +60,13 @@ describe("loadSession", () => {
       error: null,
     });
     mockSingle.mockResolvedValueOnce({
-      data: { id: "civ-xyz" },
+      data: { id: "civ-xyz", tile_x: 100, tile_y: 200 },
       error: null,
     });
 
     const result = await loadSession("user-1");
 
-    expect(result).toEqual({ worldId: "world-abc", worldSeed: 12345n, civId: "civ-xyz" });
+    expect(result).toEqual({ worldId: "world-abc", worldSeed: 12345n, civId: "civ-xyz", fortressX: 100, fortressY: 200 });
     expect(mockFrom).toHaveBeenCalledWith("worlds");
     expect(mockFrom).toHaveBeenCalledWith("civilizations");
   });
@@ -84,6 +84,6 @@ describe("loadSession", () => {
 
     const result = await loadSession("user-1");
 
-    expect(result).toEqual({ worldId: "world-abc", worldSeed: 99999n, civId: null });
+    expect(result).toEqual({ worldId: "world-abc", worldSeed: 99999n, civId: null, fortressX: null, fortressY: null });
   });
 });

--- a/app/src/lib/load-session.ts
+++ b/app/src/lib/load-session.ts
@@ -4,6 +4,8 @@ export interface GameSession {
   worldId: string | null;
   worldSeed: bigint | null;
   civId: string | null;
+  fortressX: number | null;
+  fortressY: number | null;
 }
 
 /**
@@ -18,14 +20,14 @@ export async function loadSession(userId: string): Promise<GameSession> {
     .single();
 
   const worldId = player?.world_id ?? null;
-  if (!worldId) return { worldId: null, worldSeed: null, civId: null };
+  if (!worldId) return { worldId: null, worldSeed: null, civId: null, fortressX: null, fortressY: null };
 
   // Fetch world seed and active civilization in parallel
   const [worldResult, civResult] = await Promise.all([
     supabase.from("worlds").select("seed").eq("id", worldId).single(),
     supabase
       .from("civilizations")
-      .select("id")
+      .select("id, tile_x, tile_y")
       .eq("world_id", worldId)
       .eq("player_id", userId)
       .eq("status", "active")
@@ -37,5 +39,11 @@ export async function loadSession(userId: string): Promise<GameSession> {
     ? BigInt(worldResult.data.seed)
     : null;
 
-  return { worldId, worldSeed, civId: civResult.data?.id ?? null };
+  return {
+    worldId,
+    worldSeed,
+    civId: civResult.data?.id ?? null,
+    fortressX: civResult.data?.tile_x ?? null,
+    fortressY: civResult.data?.tile_y ?? null,
+  };
 }


### PR DESCRIPTION
## Summary
- `loadSession` now fetches `tile_x`/`tile_y` from the civilizations table and returns them as `fortressX`/`fortressY`
- `useViewport` exposes a new `setOffset(x, y)` method to jump the viewport to absolute coordinates
- Session restore in `App.tsx` calls `viewport.setOffset` with the fortress coordinates when a `civId` exists, so the player reliably lands in fortress mode centered on their fortress

Closes #180

## Test plan
- [x] Existing `loadSession` tests updated to assert `fortressX`/`fortressY` fields
- [x] `npm run build` passes (typecheck clean)
- [ ] Manual: log in with an existing session that has a civilization; verify fortress view opens at the correct map location

🤖 Generated with [Claude Code](https://claude.com/claude-code)