### PR TITLE
fix: clamp world map viewport to 512x512 bounds

### DIFF
--- a/app/src/hooks/useViewport.test.ts
+++ b/app/src/hooks/useViewport.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { WORLD_WIDTH, WORLD_HEIGHT } from "@pwarf/shared";
+import { clampCoord } from "./useViewport";
+
+describe("clampCoord", () => {
+  it("returns value unchanged when within bounds", () => {
+    expect(clampCoord(100, WORLD_WIDTH - 1)).toBe(100);
+    expect(clampCoord(0, WORLD_WIDTH - 1)).toBe(0);
+    expect(clampCoord(WORLD_WIDTH - 1, WORLD_WIDTH - 1)).toBe(WORLD_WIDTH - 1);
+  });
+
+  it("clamps negative values to 0", () => {
+    expect(clampCoord(-1, WORLD_WIDTH - 1)).toBe(0);
+    expect(clampCoord(-999, WORLD_HEIGHT - 1)).toBe(0);
+  });
+
+  it("clamps values exceeding WORLD_WIDTH - 1", () => {
+    expect(clampCoord(WORLD_WIDTH, WORLD_WIDTH - 1)).toBe(WORLD_WIDTH - 1);
+    expect(clampCoord(9999, WORLD_WIDTH - 1)).toBe(WORLD_WIDTH - 1);
+  });
+
+  it("clamps values exceeding WORLD_HEIGHT - 1", () => {
+    expect(clampCoord(WORLD_HEIGHT, WORLD_HEIGHT - 1)).toBe(WORLD_HEIGHT - 1);
+    expect(clampCoord(9999, WORLD_HEIGHT - 1)).toBe(WORLD_HEIGHT - 1);
+  });
+});
+
+describe("viewport clamping (pan)", () => {
+  it("pan does not produce offsets below 0", () => {
+    // Simulate: starting at (0,0) and panning left/up
+    const offsetX = 0;
+    const offsetY = 0;
+    expect(clampCoord(offsetX + -5, WORLD_WIDTH - 1)).toBe(0);
+    expect(clampCoord(offsetY + -10, WORLD_HEIGHT - 1)).toBe(0);
+  });
+
+  it("pan does not exceed WORLD_WIDTH/HEIGHT - 1", () => {
+    const offsetX = WORLD_WIDTH - 2;
+    const offsetY = WORLD_HEIGHT - 2;
+    expect(clampCoord(offsetX + 5, WORLD_WIDTH - 1)).toBe(WORLD_WIDTH - 1);
+    expect(clampCoord(offsetY + 10, WORLD_HEIGHT - 1)).toBe(WORLD_HEIGHT - 1);
+  });
+});
+
+describe("viewport clamping (cursor)", () => {
+  it("cursor is clamped to valid range", () => {
+    expect(clampCoord(-1, WORLD_WIDTH - 1)).toBe(0);
+    expect(clampCoord(WORLD_WIDTH, WORLD_WIDTH - 1)).toBe(WORLD_WIDTH - 1);
+    expect(clampCoord(-1, WORLD_HEIGHT - 1)).toBe(0);
+    expect(clampCoord(WORLD_HEIGHT, WORLD_HEIGHT - 1)).toBe(WORLD_HEIGHT - 1);
+  });
+
+  it("cursor at boundary values is unchanged", () => {
+    expect(clampCoord(0, WORLD_WIDTH - 1)).toBe(0);
+    expect(clampCoord(WORLD_WIDTH - 1, WORLD_WIDTH - 1)).toBe(WORLD_WIDTH - 1);
+  });
+});

--- a/app/src/hooks/useViewport.ts
+++ b/app/src/hooks/useViewport.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback, useRef } from "react";
+import { WORLD_WIDTH, WORLD_HEIGHT } from "@pwarf/shared";
 
 export interface ViewportState {
   /** Top-left tile X coordinate */
@@ -8,6 +9,11 @@ export interface ViewportState {
   /** Cursor tile position (relative to world) */
   cursorX: number;
   cursorY: number;
+}
+
+/** Clamp a value to [0, max] (inclusive). Exported for testing. */
+export function clampCoord(value: number, max: number): number {
+  return Math.max(0, Math.min(max, value));
 }
 
 export function useViewport() {
@@ -24,14 +30,18 @@ export function useViewport() {
   const pan = useCallback((dx: number, dy: number) => {
     setState((prev) => ({
       ...prev,
-      offsetX: prev.offsetX + dx,
-      offsetY: prev.offsetY + dy,
+      offsetX: clampCoord(prev.offsetX + dx, WORLD_WIDTH - 1),
+      offsetY: clampCoord(prev.offsetY + dy, WORLD_HEIGHT - 1),
     }));
   }, []);
 
   /** Set cursor position in world tile coords */
   const setCursor = useCallback((x: number, y: number) => {
-    setState((prev) => ({ ...prev, cursorX: x, cursorY: y }));
+    setState((prev) => ({
+      ...prev,
+      cursorX: clampCoord(x, WORLD_WIDTH - 1),
+      cursorY: clampCoord(y, WORLD_HEIGHT - 1),
+    }));
   }, []);
 
   /** Mouse drag handlers — snapped to whole tile offsets */
@@ -58,8 +68,8 @@ export function useViewport() {
       const dy = Math.round((drag.startY - clientY) / charH);
       setState((prev) => ({
         ...prev,
-        offsetX: drag.origOffsetX + dx,
-        offsetY: drag.origOffsetY + dy,
+        offsetX: clampCoord(drag.origOffsetX + dx, WORLD_WIDTH - 1),
+        offsetY: clampCoord(drag.origOffsetY + dy, WORLD_HEIGHT - 1),
       }));
     },
     [],


### PR DESCRIPTION
## Summary
- Import `WORLD_WIDTH` and `WORLD_HEIGHT` from `@pwarf/shared` and clamp viewport offsets and cursor coordinates to `[0, WORLD_SIZE - 1]` in `pan()`, `setCursor()`, and `onDragMove()`
- Extract a pure `clampCoord()` helper function for testability
- Add unit tests verifying clamping at both lower and upper bounds

Closes #196

## Test plan
- [x] `npm test --workspace=app` passes (27 tests including new viewport clamp tests)
- [x] `npm run build` typechecks cleanly
- [ ] Manual: open world map, pan to edges — viewport should stop at map boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)