### PR TITLE
fix: upsert embark tiles before creating civilization

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -126,15 +126,15 @@ export default function App() {
   }, []);
 
   const handleEmbark = useCallback(async () => {
-    if (!worldId || !cursorTile || cursorTile.terrain === "ocean") return;
+    if (!worldId || !worldSeed || !cursorTile || cursorTile.terrain === "ocean") return;
     try {
-      const id = await embark(worldId, viewport.cursorX, viewport.cursorY);
+      const id = await embark(worldId, viewport.cursorX, viewport.cursorY, worldSeed);
       setCivId(id);
       setMode("fortress");
     } catch (err) {
       console.error("Embark failed:", err);
     }
-  }, [worldId, cursorTile, viewport.cursorX, viewport.cursorY]);
+  }, [worldId, worldSeed, cursorTile, viewport.cursorX, viewport.cursorY]);
 
   // Loading state
   if (loading) {

--- a/app/src/lib/embark.ts
+++ b/app/src/lib/embark.ts
@@ -1,9 +1,40 @@
 import { supabase } from './supabase';
 import { pickUniqueNames, SURNAMES } from './dwarf-names';
+import { createWorldDeriver } from '@pwarf/shared';
 
-export async function embark(worldId: string, tileX: number, tileY: number) {
+export async function embark(worldId: string, tileX: number, tileY: number, worldSeed: bigint) {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) throw new Error('Not authenticated');
+
+  // Derive and upsert embark tile + neighbors into world_tiles.
+  // With lazy world gen, tiles aren't stored until needed. The civilizations
+  // table has a FK on (world_id, tile_x, tile_y) -> world_tiles, so the
+  // embark tile must exist before we can create the civilization.
+  const deriver = createWorldDeriver(worldSeed);
+  const tilesToUpsert = [];
+  for (let dy = -1; dy <= 1; dy++) {
+    for (let dx = -1; dx <= 1; dx++) {
+      const x = tileX + dx;
+      const y = tileY + dy;
+      const derived = deriver.deriveTile(x, y);
+      tilesToUpsert.push({
+        world_id: worldId,
+        x,
+        y,
+        coord: `SRID=4326;POINT(${x} ${y})`,
+        terrain: derived.terrain,
+        elevation: derived.elevation,
+        biome_tags: derived.biome_tags,
+        explored: true,
+      });
+    }
+  }
+
+  const { error: tileError } = await supabase
+    .from('world_tiles')
+    .upsert(tilesToUpsert, { onConflict: 'world_id,x,y' });
+
+  if (tileError) throw new Error(`Failed to upsert embark tiles: ${tileError.message}`);
 
   // Create civilization
   const { data: civ, error: civError } = await supabase
@@ -48,18 +79,6 @@ export async function embark(worldId: string, tileX: number, tileY: number) {
 
   const { error: dwarfError } = await supabase.from('dwarves').insert(dwarves);
   if (dwarfError) throw new Error(`Failed to create dwarves: ${dwarfError.message}`);
-
-  // Mark embark tile and neighbors as explored
-  for (let dy = -1; dy <= 1; dy++) {
-    for (let dx = -1; dx <= 1; dx++) {
-      await supabase
-        .from('world_tiles')
-        .update({ explored: true })
-        .eq('world_id', worldId)
-        .eq('x', tileX + dx)
-        .eq('y', tileY + dy);
-    }
-  }
 
   return civ.id;
 }


### PR DESCRIPTION
## Summary
- Embark was broken on lazy-gen worlds (#175) because `civilizations` has a FK on `(world_id, tile_x, tile_y)` → `world_tiles`, but lazy gen doesn't store tiles in the DB
- `embark()` now derives tile data from the world seed and upserts the embark tile + 8 neighbors into `world_tiles` before creating the civilization
- Passes `worldSeed` from `App.tsx` to `embark()` to enable tile derivation

Closes #204

## Test plan
- [x] Playtested: generated a new world, clicked Embark Here on a forest tile — fortress mode loaded successfully with 7 dwarves
- [x] No console errors after the fix
- [x] `npm run build` passes (typecheck clean)
- [x] `npm test` — no new test failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)