### PR TITLE
fix: fortress viewport offset and tile query limit

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -79,9 +79,9 @@ export default function App() {
           if (session.civId) {
             setCivId(session.civId);
             setMode("fortress");
-            if (session.fortressX != null && session.fortressY != null) {
-              viewport.setOffset(session.fortressX, session.fortressY);
-            }
+            // Fortress uses local coordinates starting at (0,0),
+            // not the world embark coordinates.
+            viewport.setOffset(0, 0);
           }
           setPlayerEnsured(true);
         })
@@ -153,6 +153,7 @@ export default function App() {
       const id = await embark(worldId, viewport.cursorX, viewport.cursorY, worldSeed);
       setCivId(id);
       setMode("fortress");
+      viewport.setOffset(0, 0);
     } catch (err) {
       console.error("Embark failed:", err);
     }

--- a/app/src/hooks/useFortressTiles.ts
+++ b/app/src/hooks/useFortressTiles.ts
@@ -71,7 +71,8 @@ export function useFortressTiles({
         .gte('x', x0)
         .lt('x', x1)
         .gte('y', y0)
-        .lt('y', y1);
+        .lt('y', y1)
+        .limit(5000);
 
       if (error) {
         console.error('[useFortressTiles] fetch error:', error.message);


### PR DESCRIPTION
## Summary
- Fix session restore: use fortress-local `(0,0)` viewport offset instead of world embark coordinates, which caused the fortress view to start outside the visible area after page refresh
- Fix embark: reset viewport to `(0,0)` when switching to fortress mode
- Add `.limit(5000)` to `fortress_tiles` Supabase query to prevent PostgREST 206 Partial Content truncation when tile count exceeds the default 1000 row limit

Closes #198

## Playtest Report

### Tested Flows
1. **Embark** — Clicked "Embark Here" on a swamp tile. Fortress rendered immediately at (0,0) with room walls, floors, staircase, ore, and gems visible.
2. **Session Restore** — Refreshed page. Fortress restored at correct (0,0) position with all tiles loading properly.
3. **Mode Switching** — Toggled between World and Fortress views — both render correctly.

### Bugs Found & Fixed
- **Session restore viewport offset** — After refresh, fortress viewport jumped to world embark coordinates (e.g., 25,17) instead of fortress origin (0,0). Fixed by always using `viewport.setOffset(0, 0)`.
- **PostgREST 206 truncation** — Supabase query returned 0 tiles when tile count exceeded the default 1000-row limit (HTTP 206 Partial Content). Fixed by adding `.limit(5000)`.

## Test plan
- [x] Full build passes (`npm run build`)
- [x] 146/149 tests pass (3 pre-existing AuthScreen failures)
- [x] End-to-end playtest: embark → fortress renders → session restore works

🤖 Generated with [Claude Code](https://claude.com/claude-code)