### PR TITLE
feat: integrate sim engine with frontend for playable loop

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useEffect } from "react";
+import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import Toolbar from "./components/Toolbar";
 import LeftPanel from "./components/LeftPanel";
 import RightPanel from "./components/RightPanel";
@@ -10,14 +10,18 @@ import { useViewport } from "./hooks/useViewport";
 import { useWorldTiles } from "./hooks/useWorldTiles";
 import { useFortressTiles } from "./hooks/useFortressTiles";
 import { useAuth } from "./hooks/useAuth";
+import { useDwarves } from "./hooks/useDwarves";
+import { useSimRunner } from "./hooks/useSimRunner";
+import { useTasks } from "./hooks/useTasks";
 import { createAndGenerateWorld } from "./lib/world-gen";
 import { embark } from "./lib/embark";
 import { ensurePlayer } from "./lib/ensure-player";
 import { loadSession } from "./lib/load-session";
 import { supabase } from "./lib/supabase";
-import { FORTRESS_MAX_Z, FORTRESS_MIN_Z } from "@pwarf/shared";
+import { FORTRESS_MAX_Z, FORTRESS_MIN_Z, FORTRESS_SIZE, WORK_MINE_BASE } from "@pwarf/shared";
 
 type Mode = "fortress" | "world";
+type DesignationMode = "none" | "mine";
 
 export default function App() {
   const { session, user, loading, signIn, signUp, signOut } = useAuth();
@@ -36,6 +40,9 @@ export default function App() {
 
   // Fortress z-level
   const [zLevel, setZLevel] = useState(0);
+
+  // Designation mode
+  const [designationMode, setDesignationMode] = useState<DesignationMode>("none");
 
   // Viewport size (reported from MainViewport)
   const [vpCols, setVpCols] = useState(120);
@@ -66,6 +73,26 @@ export default function App() {
   const cursorTile = worldId ? getTile(viewport.cursorX, viewport.cursorY) : null;
   const cursorFortressTile = civId ? getFortressTile(viewport.cursorX, viewport.cursorY) : null;
 
+  // Live dwarves from DB
+  const liveDwarves = useDwarves(civId);
+
+  // Build dwarf position map for rendering
+  const dwarfPositions = useMemo(() => {
+    const map = new Map<string, { name: string }>();
+    for (const d of liveDwarves) {
+      if (d.position_z === zLevel) {
+        map.set(`${d.position_x},${d.position_y}`, { name: d.name });
+      }
+    }
+    return map;
+  }, [liveDwarves, zLevel]);
+
+  // Sim runner
+  useSimRunner(civId, worldId);
+
+  // Active tasks
+  const { designatedTiles } = useTasks(civId);
+
   // Ensure player profile exists after auth, then restore any existing session
   useEffect(() => {
     if (user && !playerEnsured) {
@@ -79,9 +106,9 @@ export default function App() {
           if (session.civId) {
             setCivId(session.civId);
             setMode("fortress");
-            // Fortress uses local coordinates starting at (0,0),
-            // not the world embark coordinates.
-            viewport.setOffset(0, 0);
+            // Center viewport on fortress center where dwarves spawn
+            const center = Math.floor(FORTRESS_SIZE / 2);
+            viewport.setOffset(center - Math.floor(vpCols / 2), center - Math.floor(vpRows / 2));
           }
           setPlayerEnsured(true);
         })
@@ -118,9 +145,17 @@ export default function App() {
         case "z_down":
           setZLevel((z) => Math.max(FORTRESS_MIN_Z, z - 1));
           break;
+        case "designate_mine":
+          if (mode === "fortress") {
+            setDesignationMode((m) => (m === "mine" ? "none" : "mine"));
+          }
+          break;
+        case "cancel_designation":
+          setDesignationMode("none");
+          break;
       }
     },
-    [viewport.pan, civId],
+    [viewport.pan, civId, mode],
   );
 
   useKeyboard(handleKeyAction);
@@ -153,11 +188,40 @@ export default function App() {
       const id = await embark(worldId, viewport.cursorX, viewport.cursorY, worldSeed);
       setCivId(id);
       setMode("fortress");
-      viewport.setOffset(0, 0);
+      const center = Math.floor(FORTRESS_SIZE / 2);
+      viewport.setOffset(center - Math.floor(vpCols / 2), center - Math.floor(vpRows / 2));
     } catch (err) {
       console.error("Embark failed:", err);
     }
   }, [worldId, worldSeed, cursorTile, viewport.cursorX, viewport.cursorY]);
+
+  const handleTileClick = useCallback(async (x: number, y: number) => {
+    if (designationMode !== 'mine' || !civId) return;
+
+    // Check that the tile is minable
+    const tile = getFortressTile(x, y);
+    if (!tile) return;
+    const mineable: string[] = ['stone', 'ore', 'gem', 'soil', 'cavern_wall'];
+    if (!mineable.includes(tile.tileType)) return;
+
+    // Don't double-designate
+    if (designatedTiles.has(`${x},${y}`)) return;
+
+    const { error } = await supabase.from('tasks').insert({
+      civilization_id: civId,
+      task_type: 'mine',
+      status: 'pending',
+      priority: 5,
+      target_x: x,
+      target_y: y,
+      target_z: zLevel,
+      work_required: WORK_MINE_BASE,
+    });
+
+    if (error) {
+      console.error('[designate] Failed to create mine task:', error.message);
+    }
+  }, [designationMode, civId, zLevel, getFortressTile, designatedTiles]);
 
   // Loading state
   if (loading) {
@@ -220,7 +284,13 @@ export default function App() {
 
   return (
     <div className="flex flex-col h-full w-full">
-      <Toolbar mode={mode} onSignOut={signOut} />
+      <Toolbar
+        mode={mode}
+        onSignOut={signOut}
+        population={liveDwarves.length}
+        year={1}
+        civName={mode === "fortress" ? "Stonegear" : undefined}
+      />
 
       <div className="flex flex-1 min-h-0">
         <LeftPanel
@@ -229,6 +299,7 @@ export default function App() {
           onToggle={() => setLeftOpen((o) => !o)}
           cursorTile={cursorTile}
           onEmbark={mode === "world" ? handleEmbark : undefined}
+          dwarves={liveDwarves}
         />
 
         <MainViewport
@@ -244,6 +315,10 @@ export default function App() {
           worldTiles={mode === "world" ? tileMap : undefined}
           fortressTiles={mode === "fortress" ? fortressTileMap : undefined}
           onViewportSize={handleViewportSize}
+          dwarfPositions={mode === "fortress" ? dwarfPositions : undefined}
+          designatedTiles={mode === "fortress" ? designatedTiles : undefined}
+          designationMode={mode === "fortress" ? designationMode : undefined}
+          onTileClick={mode === "fortress" ? handleTileClick : undefined}
         />
 
         <RightPanel
@@ -276,6 +351,7 @@ export default function App() {
         terrain={terrainForBar}
         zLevel={mode === "fortress" ? zLevel : undefined}
         fortressTileLabel={fortressTileLabel}
+        designationMode={mode === "fortress" ? designationMode : undefined}
       />
     </div>
   );

--- a/app/src/components/BottomBar.tsx
+++ b/app/src/components/BottomBar.tsx
@@ -5,9 +5,10 @@ interface BottomBarProps {
   terrain?: string | null;
   zLevel?: number;
   fortressTileLabel?: string | null;
+  designationMode?: string;
 }
 
-export default function BottomBar({ mode, cursorX, cursorY, terrain, zLevel, fortressTileLabel }: BottomBarProps) {
+export default function BottomBar({ mode, cursorX, cursorY, terrain, zLevel, fortressTileLabel, designationMode }: BottomBarProps) {
   const terrainLabel = terrain ?? fortressTileLabel ?? (mode === "fortress" ? "Floor (stone)" : "Plains");
 
   return (
@@ -24,6 +25,11 @@ export default function BottomBar({ mode, cursorX, cursorY, terrain, zLevel, for
         <span className="text-[var(--text)]">
           {terrainLabel}
         </span>
+        {designationMode && designationMode !== 'none' && (
+          <span className="text-[#ff6600] font-bold">
+            [{designationMode.toUpperCase()}] click to designate
+          </span>
+        )}
       </div>
 
       <div className="flex gap-3 text-[var(--text)]">
@@ -31,9 +37,14 @@ export default function BottomBar({ mode, cursorX, cursorY, terrain, zLevel, for
           <kbd className="text-[var(--amber)]">WASD</kbd> pan
         </span>
         {mode === "fortress" && (
-          <span>
-            <kbd className="text-[var(--amber)]">&lt; &gt;</kbd> z-level
-          </span>
+          <>
+            <span>
+              <kbd className="text-[var(--amber)]">&lt; &gt;</kbd> z-level
+            </span>
+            <span>
+              <kbd className="text-[var(--amber)]">m</kbd> mine
+            </span>
+          </>
         )}
         <span>
           <kbd className="text-[var(--amber)]">Tab</kbd> mode

--- a/app/src/components/LeftPanel.tsx
+++ b/app/src/components/LeftPanel.tsx
@@ -1,5 +1,5 @@
 import type { WorldTile } from "@pwarf/shared";
-import { FORTRESS_DWARVES } from "./fortressDwarves";
+import type { LiveDwarf } from "../hooks/useDwarves";
 
 interface LeftPanelProps {
   mode: "fortress" | "world";
@@ -7,9 +7,15 @@ interface LeftPanelProps {
   onToggle: () => void;
   cursorTile?: WorldTile | null;
   onEmbark?: () => void;
+  dwarves?: LiveDwarf[];
 }
 
-export default function LeftPanel({ mode, collapsed, onToggle, cursorTile, onEmbark }: LeftPanelProps) {
+function dwarfJobLabel(d: LiveDwarf): string {
+  if (d.current_task_id) return "Working";
+  return "Idle";
+}
+
+export default function LeftPanel({ mode, collapsed, onToggle, cursorTile, onEmbark, dwarves = [] }: LeftPanelProps) {
   const isOcean = cursorTile?.terrain === "ocean";
 
   return (
@@ -33,15 +39,18 @@ export default function LeftPanel({ mode, collapsed, onToggle, cursorTile, onEmb
 
           {mode === "fortress" ? (
             <ul className="space-y-0.5">
-              {FORTRESS_DWARVES.map((d) => (
+              {dwarves.map((d) => (
                 <li
-                  key={d.name}
+                  key={d.id}
                   className="flex justify-between hover:bg-[var(--bg-hover)] px-1"
                 >
                   <span className="text-[var(--green)]">{d.name}</span>
-                  <span className="text-[var(--text)]">{d.job}</span>
+                  <span className="text-[var(--text)]">{dwarfJobLabel(d)}</span>
                 </li>
               ))}
+              {dwarves.length === 0 && (
+                <li className="text-[var(--text)]">No dwarves</li>
+              )}
             </ul>
           ) : cursorTile ? (
             <div className="space-y-1">

--- a/app/src/components/MainViewport.tsx
+++ b/app/src/components/MainViewport.tsx
@@ -1,7 +1,6 @@
 import { useRef, useEffect, useCallback } from "react";
 import type { WorldTile, TerrainType, FortressTileType } from "@pwarf/shared";
 import type { FortressViewTile } from "../hooks/useFortressTiles";
-import { DWARF_POSITION_MAP } from "./fortressDwarves";
 
 interface MainViewportProps {
   mode: "fortress" | "world";
@@ -16,6 +15,14 @@ interface MainViewportProps {
   worldTiles?: Map<string, WorldTile>;
   fortressTiles?: Map<string, FortressViewTile>;
   onViewportSize?: (cols: number, rows: number) => void;
+  /** Live dwarf positions keyed by "x,y" */
+  dwarfPositions?: Map<string, { name: string }>;
+  /** Tiles with active designations keyed by "x,y" */
+  designatedTiles?: Set<string>;
+  /** Current designation mode */
+  designationMode?: string;
+  /** Click handler for tile designation */
+  onTileClick?: (x: number, y: number) => void;
 }
 
 // Character cell dimensions (monospace)
@@ -84,13 +91,18 @@ export default function MainViewport({
   worldTiles,
   fortressTiles,
   onViewportSize,
+  dwarfPositions,
+  designatedTiles,
+  designationMode,
+  onTileClick,
 }: MainViewportProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const dragging = useRef(false);
+  const dragMoved = useRef(false);
 
   const getWorldTile = useCallback(
-    (wx: number, wy: number): { ch: string; fg: string } => {
+    (wx: number, wy: number): { ch: string; fg: string; bg?: string } => {
       if (worldTiles) {
         const tile = worldTiles.get(`${wx},${wy}`);
         if (tile) {
@@ -103,20 +115,30 @@ export default function MainViewport({
   );
 
   const getFortressTile = useCallback(
-    (wx: number, wy: number): { ch: string; fg: string } => {
+    (wx: number, wy: number): { ch: string; fg: string; bg?: string } => {
+      const key = `${wx},${wy}`;
+
       // Check for dwarf at this position
-      const dwarf = DWARF_POSITION_MAP.get(`${wx},${wy}`);
-      if (dwarf) return { ch: "\u263A", fg: "#00cccc" };
+      if (dwarfPositions?.has(key)) {
+        return { ch: "\u263A", fg: "#00cccc" };
+      }
+
+      // Check for designation overlay
+      const isDesignated = designatedTiles?.has(key);
 
       if (fortressTiles) {
-        const tile = fortressTiles.get(`${wx},${wy}`);
+        const tile = fortressTiles.get(key);
         if (tile) {
-          return FORTRESS_GLYPHS[tile.tileType] ?? { ch: "?", fg: "#f00" };
+          const glyph = FORTRESS_GLYPHS[tile.tileType] ?? { ch: "?", fg: "#f00" };
+          if (isDesignated) {
+            return { ...glyph, bg: "#442200" };
+          }
+          return glyph;
         }
       }
       return { ch: " ", fg: "#000" };
     },
-    [fortressTiles],
+    [fortressTiles, dwarfPositions, designatedTiles],
   );
 
   const getTile = mode === "fortress" ? getFortressTile : getWorldTile;
@@ -159,19 +181,25 @@ export default function MainViewport({
       for (let col = 0; col < cols; col++) {
         const wx = offsetX + col;
         const wy = offsetY + row;
-        const { ch, fg } = getTile(wx, wy);
+        const tileData = getTile(wx, wy);
 
         const px = col * CHAR_W;
         const py = row * CHAR_H;
 
-        // Highlight cursor tile
-        if (wx === cursorX && wy === cursorY) {
-          ctx.fillStyle = "#333";
+        // Background for designation overlay
+        if (tileData.bg) {
+          ctx.fillStyle = tileData.bg;
           ctx.fillRect(px, py, CHAR_W, CHAR_H);
         }
 
-        ctx.fillStyle = fg;
-        ctx.fillText(ch, px + 1, py + 2);
+        // Highlight cursor tile
+        if (wx === cursorX && wy === cursorY) {
+          ctx.fillStyle = designationMode && designationMode !== 'none' ? "#442244" : "#333";
+          ctx.fillRect(px, py, CHAR_W, CHAR_H);
+        }
+
+        ctx.fillStyle = tileData.fg;
+        ctx.fillText(tileData.ch, px + 1, py + 2);
       }
     }
 
@@ -179,11 +207,11 @@ export default function MainViewport({
     const cx = (cursorX - offsetX) * CHAR_W;
     const cy = (cursorY - offsetY) * CHAR_H;
     if (cx >= 0 && cx < w && cy >= 0 && cy < h) {
-      ctx.strokeStyle = "#4af626";
+      ctx.strokeStyle = designationMode && designationMode !== 'none' ? "#ff6600" : "#4af626";
       ctx.lineWidth = 1;
       ctx.strokeRect(cx + 0.5, cy + 0.5, CHAR_W - 1, CHAR_H - 1);
     }
-  }, [offsetX, offsetY, cursorX, cursorY, getTile, onViewportSize]);
+  }, [offsetX, offsetY, cursorX, cursorY, getTile, onViewportSize, designationMode]);
 
   // Re-render on state change
   useEffect(() => {
@@ -206,6 +234,7 @@ export default function MainViewport({
       onCursorMove(offsetX + col, offsetY + row);
 
       if (dragging.current) {
+        dragMoved.current = true;
         onDragMove(e.clientX, e.clientY, CHAR_W, CHAR_H);
       }
     },
@@ -216,16 +245,28 @@ export default function MainViewport({
     (e: React.MouseEvent) => {
       if (e.button === 0) {
         dragging.current = true;
+        dragMoved.current = false;
         onDragStart(e.clientX, e.clientY, CHAR_W, CHAR_H);
       }
     },
     [onDragStart],
   );
 
-  const handleMouseUp = useCallback(() => {
-    dragging.current = false;
-    onDragEnd();
-  }, [onDragEnd]);
+  const handleMouseUp = useCallback(
+    (e: React.MouseEvent) => {
+      if (dragging.current && !dragMoved.current && onTileClick && designationMode && designationMode !== 'none') {
+        // Click without drag in designation mode → designate tile
+        const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+        const col = Math.floor((e.clientX - rect.left) / CHAR_W);
+        const row = Math.floor((e.clientY - rect.top) / CHAR_H);
+        onTileClick(offsetX + col, offsetY + row);
+      }
+      dragging.current = false;
+      dragMoved.current = false;
+      onDragEnd();
+    },
+    [onDragEnd, onTileClick, designationMode, offsetX, offsetY],
+  );
 
   return (
     <div

--- a/app/src/components/Toolbar.tsx
+++ b/app/src/components/Toolbar.tsx
@@ -1,24 +1,26 @@
 interface ToolbarProps {
   mode: "fortress" | "world";
   onSignOut?: () => void;
+  population?: number;
+  year?: number;
+  civName?: string;
 }
 
-export default function Toolbar({ mode, onSignOut }: ToolbarProps) {
+export default function Toolbar({ mode, onSignOut, population = 0, year = 1, civName }: ToolbarProps) {
   return (
     <header className="flex items-center justify-between px-3 py-1 border-b border-[var(--border)] bg-[var(--bg-panel)] text-xs select-none shrink-0">
       <div className="flex gap-4 items-center">
         <span className="text-[var(--amber)] font-bold tracking-wider">
           pWarf
         </span>
-        <span className="text-[var(--text)]">Year 205</span>
+        <span className="text-[var(--text)]">Year {year}</span>
         <span className="text-[var(--green)]">
-          {mode === "fortress" ? "Stonegear" : "World Map"}
+          {mode === "fortress" ? (civName ?? "Fortress") : "World Map"}
         </span>
       </div>
 
       <div className="flex gap-4 items-center">
-        <span>Pop: 7</span>
-        <span>Wealth: 1240</span>
+        <span>Pop: {population}</span>
         <span className="text-[var(--amber)]">No alerts</span>
         {onSignOut && (
           <button

--- a/app/src/hooks/useDwarves.ts
+++ b/app/src/hooks/useDwarves.ts
@@ -1,0 +1,60 @@
+import { useState, useEffect, useRef } from 'react';
+import { supabase } from '../lib/supabase';
+import type { Dwarf } from '@pwarf/shared';
+
+export interface LiveDwarf {
+  id: string;
+  name: string;
+  surname: string | null;
+  status: string;
+  position_x: number;
+  position_y: number;
+  position_z: number;
+  current_task_id: string | null;
+  need_food: number;
+  need_drink: number;
+  need_sleep: number;
+  stress_level: number;
+  health: number;
+}
+
+export function useDwarves(civId: string | null) {
+  const [dwarves, setDwarves] = useState<LiveDwarf[]>([]);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (!civId) {
+      setDwarves([]);
+      return;
+    }
+
+    async function fetchDwarves() {
+      const { data, error } = await supabase
+        .from('dwarves')
+        .select('id, name, surname, status, position_x, position_y, position_z, current_task_id, need_food, need_drink, need_sleep, stress_level, health')
+        .eq('civilization_id', civId!)
+        .eq('status', 'alive');
+
+      if (!error && data) {
+        setDwarves(data);
+      }
+    }
+
+    // Initial fetch
+    void fetchDwarves();
+
+    // Poll every 1 second for position updates
+    pollRef.current = setInterval(() => {
+      void fetchDwarves();
+    }, 1000);
+
+    return () => {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+    };
+  }, [civId]);
+
+  return dwarves;
+}

--- a/app/src/hooks/useKeyboard.ts
+++ b/app/src/hooks/useKeyboard.ts
@@ -6,7 +6,9 @@ export type KeyAction =
   | { type: "toggle_left_panel" }
   | { type: "toggle_right_panel" }
   | { type: "z_up" }
-  | { type: "z_down" };
+  | { type: "z_down" }
+  | { type: "designate_mine" }
+  | { type: "cancel_designation" };
 
 export function useKeyboard(onAction: (action: KeyAction) => void) {
   useEffect(() => {
@@ -55,6 +57,12 @@ export function useKeyboard(onAction: (action: KeyAction) => void) {
           break;
         case ">":
           onAction({ type: "z_down" });
+          break;
+        case "m":
+          onAction({ type: "designate_mine" });
+          break;
+        case "Escape":
+          onAction({ type: "cancel_designation" });
           break;
       }
     }

--- a/app/src/hooks/useSimRunner.ts
+++ b/app/src/hooks/useSimRunner.ts
@@ -1,0 +1,29 @@
+import { useEffect, useRef } from 'react';
+import { SimRunner } from '@pwarf/sim';
+import { supabase } from '../lib/supabase';
+
+export function useSimRunner(civId: string | null, worldId: string | null) {
+  const runnerRef = useRef<SimRunner | null>(null);
+
+  useEffect(() => {
+    if (!civId || !worldId) return;
+
+    // Cast to satisfy cross-package SupabaseClient type mismatch
+    // (both app and sim depend on the same @supabase/supabase-js version)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const runner = new SimRunner(supabase as any);
+    runnerRef.current = runner;
+    runner.start(civId, worldId).catch((err: unknown) => {
+      console.error('[sim] failed to start:', err);
+    });
+
+    return () => {
+      runner.stop().catch((err: unknown) => {
+        console.error('[sim] failed to stop:', err);
+      });
+      runnerRef.current = null;
+    };
+  }, [civId, worldId]);
+
+  return runnerRef;
+}

--- a/app/src/hooks/useTasks.ts
+++ b/app/src/hooks/useTasks.ts
@@ -1,0 +1,60 @@
+import { useState, useEffect, useRef, useMemo } from 'react';
+import { supabase } from '../lib/supabase';
+
+export interface ActiveTask {
+  id: string;
+  task_type: string;
+  status: string;
+  target_x: number | null;
+  target_y: number | null;
+  target_z: number | null;
+  work_progress: number;
+  work_required: number;
+}
+
+export function useTasks(civId: string | null) {
+  const [tasks, setTasks] = useState<ActiveTask[]>([]);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (!civId) {
+      setTasks([]);
+      return;
+    }
+
+    async function fetchTasks() {
+      const { data, error } = await supabase
+        .from('tasks')
+        .select('id, task_type, status, target_x, target_y, target_z, work_progress, work_required')
+        .eq('civilization_id', civId!)
+        .in('status', ['pending', 'claimed', 'in_progress']);
+
+      if (!error && data) {
+        setTasks(data);
+      }
+    }
+
+    void fetchTasks();
+    pollRef.current = setInterval(() => void fetchTasks(), 1000);
+
+    return () => {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+    };
+  }, [civId]);
+
+  /** Set of "x,y" keys for tiles with active mine designations at a given z-level */
+  const designatedTiles = useMemo(() => {
+    const set = new Set<string>();
+    for (const task of tasks) {
+      if (task.target_x !== null && task.target_y !== null) {
+        set.add(`${task.target_x},${task.target_y}`);
+      }
+    }
+    return set;
+  }, [tasks]);
+
+  return { tasks, designatedTiles };
+}

--- a/app/src/lib/embark.ts
+++ b/app/src/lib/embark.ts
@@ -1,6 +1,30 @@
 import { supabase } from './supabase';
 import { pickUniqueNames, SURNAMES } from './dwarf-names';
-import { createWorldDeriver } from '@pwarf/shared';
+import { createWorldDeriver, FORTRESS_SIZE } from '@pwarf/shared';
+
+const FORTRESS_CENTER = Math.floor(FORTRESS_SIZE / 2);
+
+/** Starting dwarf roles with their skills */
+const STARTING_ROLES: { job: string; skills: string[] }[] = [
+  { job: 'Miner',      skills: ['mining'] },
+  { job: 'Miner',      skills: ['mining'] },
+  { job: 'Farmer',     skills: ['farming'] },
+  { job: 'Farmer',     skills: ['farming'] },
+  { job: 'Woodcutter', skills: [] },
+  { job: 'Mason',      skills: [] },
+  { job: 'Brewer',     skills: [] },
+];
+
+/** Offsets from fortress center for starting dwarf positions */
+const STARTING_OFFSETS: { dx: number; dy: number }[] = [
+  { dx: -1, dy: -1 },
+  { dx:  1, dy: -1 },
+  { dx: -1, dy:  0 },
+  { dx:  1, dy:  0 },
+  { dx:  0, dy: -1 },
+  { dx:  0, dy:  1 },
+  { dx:  0, dy:  0 },
+];
 
 export async function embark(worldId: string, tileX: number, tileY: number, worldSeed: bigint) {
   const { data: { user } } = await supabase.auth.getUser();
@@ -55,10 +79,11 @@ export async function embark(worldId: string, tileX: number, tileY: number, worl
 
   if (civError || !civ) throw new Error(`Failed to create civilization: ${civError?.message}`);
 
-  // Create 7 starting dwarves
+  // Create 7 starting dwarves with positions near fortress center
   const names = pickUniqueNames(7);
-  const dwarves = names.map((name) => {
+  const dwarves = names.map((name, i) => {
     const surname = SURNAMES[Math.floor(Math.random() * SURNAMES.length)];
+    const offset = STARTING_OFFSETS[i];
     return {
       civilization_id: civ.id,
       name,
@@ -74,11 +99,93 @@ export async function embark(worldId: string, tileX: number, tileY: number, worl
       stress_level: 0,
       is_in_tantrum: false,
       health: 100,
+      position_x: FORTRESS_CENTER + offset.dx,
+      position_y: FORTRESS_CENTER + offset.dy,
+      position_z: 0,
     };
   });
 
-  const { error: dwarfError } = await supabase.from('dwarves').insert(dwarves);
-  if (dwarfError) throw new Error(`Failed to create dwarves: ${dwarfError.message}`);
+  const { data: insertedDwarves, error: dwarfError } = await supabase
+    .from('dwarves')
+    .insert(dwarves)
+    .select('id');
+  if (dwarfError || !insertedDwarves) throw new Error(`Failed to create dwarves: ${dwarfError?.message}`);
+
+  // Create dwarf skills based on roles
+  const skills: { dwarf_id: string; skill_name: string; level: number; xp: number }[] = [];
+  for (let i = 0; i < insertedDwarves.length; i++) {
+    for (const skillName of STARTING_ROLES[i].skills) {
+      skills.push({
+        dwarf_id: insertedDwarves[i].id,
+        skill_name: skillName,
+        level: 0,
+        xp: 0,
+      });
+    }
+  }
+  if (skills.length > 0) {
+    const { error: skillError } = await supabase.from('dwarf_skills').insert(skills);
+    if (skillError) throw new Error(`Failed to create dwarf skills: ${skillError.message}`);
+  }
+
+  // Create starting items
+  const startingItems = [
+    ...Array.from({ length: 30 }, () => ({
+      name: 'Plump helmet spawn',
+      category: 'food',
+      quality: 'standard',
+      material: 'plant',
+      weight: 1,
+      value: 2,
+      is_artifact: false,
+      located_in_civ_id: civ.id,
+      created_in_civ_id: civ.id,
+      created_year: 1,
+      properties: {},
+    })),
+    ...Array.from({ length: 40 }, () => ({
+      name: 'Dwarven ale',
+      category: 'drink',
+      quality: 'standard',
+      material: 'plant',
+      weight: 1,
+      value: 3,
+      is_artifact: false,
+      located_in_civ_id: civ.id,
+      created_in_civ_id: civ.id,
+      created_year: 1,
+      properties: {},
+    })),
+    ...Array.from({ length: 10 }, () => ({
+      name: 'Plump helmet seed',
+      category: 'raw_material',
+      quality: 'standard',
+      material: 'plant',
+      weight: 1,
+      value: 1,
+      is_artifact: false,
+      located_in_civ_id: civ.id,
+      created_in_civ_id: civ.id,
+      created_year: 1,
+      properties: {},
+    })),
+    ...Array.from({ length: 2 }, () => ({
+      name: 'Stone pickaxe',
+      category: 'tool',
+      quality: 'standard',
+      material: 'stone',
+      weight: 5,
+      value: 10,
+      is_artifact: false,
+      located_in_civ_id: civ.id,
+      created_in_civ_id: civ.id,
+      created_year: 1,
+      properties: {},
+    })),
+  ];
+
+  const { error: itemError } = await supabase.from('items').insert(startingItems);
+  if (itemError) throw new Error(`Failed to create starting items: ${itemError.message}`);
 
   return civ.id;
 }

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -9,5 +9,5 @@
     "composite": true
   },
   "include": ["src", "vite-env.d.ts"],
-  "references": [{ "path": "../shared" }]
+  "references": [{ "path": "../shared" }, { "path": "../sim" }]
 }

--- a/sim/package.json
+++ b/sim/package.json
@@ -4,8 +4,15 @@
   "private": true,
   "type": "module",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
-    "dev": "tsx watch src/index.ts",
+    "dev": "tsx watch src/cli.ts",
     "build": "tsc",
     "test": "vitest run"
   },

--- a/sim/src/__tests__/pathfinding.test.ts
+++ b/sim/src/__tests__/pathfinding.test.ts
@@ -168,6 +168,23 @@ describe("bfsNextStep", () => {
     );
     expect(result).toBeNull();
   });
+
+  it("returns null instead of crashing when search space is huge", () => {
+    // Simulate a large open plane with an unreachable goal (different z)
+    const lookup: TileLookup = (x, y, z) => {
+      if (z !== 0) return null;
+      if (x < 0 || x > 200 || y < 0 || y > 200) return null;
+      return "open_air";
+    };
+
+    // Goal at z=-1 is unreachable from z=0 (no stairs)
+    const result = bfsNextStep(
+      { x: 100, y: 100, z: 0 },
+      { x: 100, y: 100, z: -1 },
+      lookup,
+    );
+    expect(result).toBeNull();
+  });
 });
 
 describe("manhattanDistance", () => {

--- a/sim/src/cli.ts
+++ b/sim/src/cli.ts
@@ -1,0 +1,33 @@
+import { createClient } from "@supabase/supabase-js";
+import { SimRunner } from "./sim-runner.js";
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_KEY) {
+  console.error(
+    "[sim] SUPABASE_URL and SUPABASE_SERVICE_KEY must be set in environment"
+  );
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
+const runner = new SimRunner(supabase);
+
+const civId = process.env.CIVILIZATION_ID ?? "default";
+const worldId = process.env.WORLD_ID;
+
+runner.start(civId, worldId).catch((err) => {
+  console.error("[sim] failed to start:", err);
+  process.exit(1);
+});
+
+process.on("SIGINT", async () => {
+  await runner.stop();
+  process.exit(0);
+});
+
+process.on("SIGTERM", async () => {
+  await runner.stop();
+  process.exit(0);
+});

--- a/sim/src/flush-state.ts
+++ b/sim/src/flush-state.ts
@@ -27,10 +27,22 @@ export async function flushToSupabase(ctx: SimContext): Promise<void> {
   const promises: PromiseLike<void>[] = [];
 
   if (dirtyDwarves.length > 0) {
+    // Round need values — DB columns are integer, sim computes fractional decay
+    const rounded = dirtyDwarves.map((d) => ({
+      ...d,
+      need_food: Math.round(d.need_food),
+      need_drink: Math.round(d.need_drink),
+      need_sleep: Math.round(d.need_sleep),
+      need_social: Math.round(d.need_social),
+      need_purpose: Math.round(d.need_purpose),
+      need_beauty: Math.round(d.need_beauty),
+      stress_level: Math.round(d.stress_level),
+      health: Math.round(d.health),
+    }));
     promises.push(
       supabase
         .from("dwarves")
-        .upsert(dirtyDwarves)
+        .upsert(rounded)
         .then(({ error }) => {
           if (error) console.warn(`[flush] dwarves upsert failed: ${error.message}`);
         }),

--- a/sim/src/index.ts
+++ b/sim/src/index.ts
@@ -1,38 +1,3 @@
-import { createClient } from "@supabase/supabase-js";
-import { SimRunner } from "./sim-runner.js";
-
+export { SimRunner } from "./sim-runner.js";
 export { loadStateFromSupabase } from "./load-state.js";
 export { flushToSupabase } from "./flush-state.js";
-
-const SUPABASE_URL = process.env.SUPABASE_URL;
-const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_KEY;
-
-if (!SUPABASE_URL || !SUPABASE_SERVICE_KEY) {
-  console.error(
-    "[sim] SUPABASE_URL and SUPABASE_SERVICE_KEY must be set in environment"
-  );
-  process.exit(1);
-}
-
-const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
-const runner = new SimRunner(supabase);
-
-// For now, accept civilization ID and world ID from env or default to placeholders.
-const civId = process.env.CIVILIZATION_ID ?? "default";
-const worldId = process.env.WORLD_ID;
-
-runner.start(civId, worldId).catch((err) => {
-  console.error("[sim] failed to start:", err);
-  process.exit(1);
-});
-
-// Graceful shutdown
-process.on("SIGINT", async () => {
-  await runner.stop();
-  process.exit(0);
-});
-
-process.on("SIGTERM", async () => {
-  await runner.stop();
-  process.exit(0);
-});

--- a/sim/src/pathfinding.ts
+++ b/sim/src/pathfinding.ts
@@ -85,6 +85,9 @@ function posKey(p: Position): string {
  *   to the goal (used for mining — you stand next to the wall, not inside it).
  *   If false, the path ends at the goal tile itself.
  */
+/** Safety limit — abort BFS after visiting this many nodes. */
+const MAX_BFS_NODES = 10_000;
+
 export function bfsNextStep(
   start: Position,
   goal: Position,
@@ -108,6 +111,10 @@ export function bfsNextStep(
   visited.add(posKey(start));
 
   while (queue.length > 0) {
+    if (visited.size >= MAX_BFS_NODES) {
+      return null; // Search space exhausted — no path
+    }
+
     const current = queue.shift()!;
     const neighbors = getNeighbors(current, getTile);
 

--- a/sim/src/phases/event-firing.ts
+++ b/sim/src/phases/event-firing.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import type { SimContext } from "../sim-context.js";
 
 /**
@@ -23,7 +22,7 @@ export async function eventFiring(ctx: SimContext): Promise<void> {
     // Critical food warning at need_food < 10
     if (dwarf.need_food < 10 && dwarf.need_food >= 9.8) {
       state.pendingEvents.push({
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         world_id: '',
         year: ctx.year,
         category: 'death', // Using existing category — will be 'warning' later
@@ -42,7 +41,7 @@ export async function eventFiring(ctx: SimContext): Promise<void> {
     // Critical drink warning
     if (dwarf.need_drink < 10 && dwarf.need_drink >= 9.8) {
       state.pendingEvents.push({
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         world_id: '',
         year: ctx.year,
         category: 'death',

--- a/sim/src/phases/task-execution.ts
+++ b/sim/src/phases/task-execution.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import {
   BASE_WORK_RATE,
   FOOD_RESTORE_AMOUNT,
@@ -10,6 +9,7 @@ import {
   XP_FARM_HARVEST,
   STARVATION_TICKS,
   DEHYDRATION_TICKS,
+  FORTRESS_SIZE,
 } from "@pwarf/shared";
 import type { Dwarf, Task, Item, TaskType } from "@pwarf/shared";
 import type { SimContext } from "../sim-context.js";
@@ -96,35 +96,37 @@ function isAdjacentToTarget(dwarf: Dwarf, task: Task): boolean {
 function moveTowardTarget(dwarf: Dwarf, task: Task, ctx: SimContext): boolean {
   if (task.target_x === null || task.target_y === null || task.target_z === null) return true;
 
-  // Create a tile lookup from cached fortress tiles
-  // For Phase 0, we use a simplified approach: all surface tiles (z=0) are walkable,
-  // and mined tiles are walkable. This will be replaced with real tile data later.
+  // Phase 0 simplification: pathfind in 2D only (ignore z-levels since there
+  // are no stairs yet). Once horizontally adjacent, teleport to the target z.
+  // Will be replaced with real 3D pathfinding + stairs later.
   const getTile: TileLookup = (_x, _y, _z) => {
-    // Simplified: treat z=0 surface as open_air (walkable)
-    if (_z === 0) return 'open_air';
-    return null;
+    if (_x < 0 || _x >= FORTRESS_SIZE || _y < 0 || _y >= FORTRESS_SIZE) return null;
+    return 'open_air';
   };
 
   const needsAdjacent = task.task_type === 'mine';
+
+  // Flatten to 2D: pathfind on dwarf's current z-level toward target x,y
+  const goal2d = { x: task.target_x, y: task.target_y, z: dwarf.position_z };
   const nextStep = bfsNextStep(
     { x: dwarf.position_x, y: dwarf.position_y, z: dwarf.position_z },
-    { x: task.target_x, y: task.target_y, z: task.target_z },
+    goal2d,
     getTile,
     needsAdjacent,
   );
 
   if (nextStep === null) {
-    // Either already at target or no path
-    const dist = manhattanDistance(
-      { x: dwarf.position_x, y: dwarf.position_y, z: dwarf.position_z },
-      { x: task.target_x, y: task.target_y, z: task.target_z },
-    );
-    return dist <= 1; // Already close enough
+    // Horizontally at target (or adjacent for mine tasks).
+    // Teleport to the correct z-level if needed.
+    if (dwarf.position_z !== task.target_z) {
+      dwarf.position_z = task.target_z;
+      ctx.state.dirtyDwarfIds.add(dwarf.id);
+    }
+    return true;
   }
 
   dwarf.position_x = nextStep.x;
   dwarf.position_y = nextStep.y;
-  dwarf.position_z = nextStep.z;
   ctx.state.dirtyDwarfIds.add(dwarf.id);
   return true;
 }
@@ -175,7 +177,7 @@ function completeMine(task: Task, ctx: SimContext): void {
   if (task.target_x === null || task.target_y === null || task.target_z === null) return;
 
   const stoneItem: Item = {
-    id: randomUUID(),
+    id: crypto.randomUUID(),
     name: 'Stone block',
     category: 'raw_material',
     quality: 'standard',
@@ -210,7 +212,7 @@ function completeHaul(task: Task, _ctx: SimContext): void {
 function completeFarmHarvest(task: Task, ctx: SimContext): void {
   // Create a food item
   const food: Item = {
-    id: randomUUID(),
+    id: crypto.randomUUID(),
     name: 'Plump helmet',
     category: 'food',
     quality: 'standard',
@@ -351,7 +353,7 @@ function killDwarf(dwarf: Dwarf, cause: string, ctx: SimContext): void {
   if (aliveDwarves.length === 0) {
     // Queue fortress fallen event
     state.pendingEvents.push({
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       world_id: '',  // Will be set by event firing
       year: ctx.year,
       category: 'fortress_fallen',

--- a/sim/src/sim-runner.ts
+++ b/sim/src/sim-runner.ts
@@ -65,10 +65,11 @@ export class SimRunner {
       void this.tick();
     }, intervalMs);
 
-    // Flush dirty state to Supabase every 1 second
+    // Flush dirty state to Supabase every 1 second + poll for new tasks
     this.flushTimer = setInterval(() => {
       if (this.ctx) {
         void flushToSupabase(this.ctx);
+        void this.pollNewTasks();
       }
     }, 1000);
   }
@@ -90,6 +91,28 @@ export class SimRunner {
     }
 
     console.log(`[sim] stopped at step ${this.stepCount}`);
+  }
+
+  /** Poll Supabase for new tasks created by the player (designations). */
+  private async pollNewTasks(): Promise<void> {
+    if (!this.ctx) return;
+    const { state, supabase, civilizationId } = this.ctx;
+
+    const existingIds = new Set(state.tasks.map(t => t.id));
+
+    const { data, error } = await supabase
+      .from('tasks')
+      .select('*')
+      .eq('civilization_id', civilizationId)
+      .eq('status', 'pending');
+
+    if (error || !data) return;
+
+    for (const task of data) {
+      if (!existingIds.has(task.id)) {
+        state.tasks.push(task);
+      }
+    }
   }
 
   /** Execute one simulation step — all phases run in order. */

--- a/sim/src/task-helpers.ts
+++ b/sim/src/task-helpers.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import type { Dwarf, DwarfSkill, Task, TaskType, Item } from "@pwarf/shared";
 import type { CachedState } from "./sim-context.js";
 
@@ -62,7 +61,7 @@ export function createTask(
   },
 ): Task {
   const task: Task = {
-    id: randomUUID(),
+    id: crypto.randomUUID(),
     civilization_id: civilizationId,
     task_type: opts.task_type,
     status: 'pending',

--- a/sim/tsconfig.json
+++ b/sim/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "composite": true,
+    "declaration": true
   },
   "include": ["src"],
   "references": [

--- a/supabase/migrations/00005_tasks_rls.sql
+++ b/supabase/migrations/00005_tasks_rls.sql
@@ -1,0 +1,29 @@
+-- ============================================================
+-- RLS POLICIES FOR TASKS TABLE
+-- Allows players to read/create/update tasks for their civilizations
+-- ============================================================
+
+alter table tasks enable row level security;
+
+-- Anyone can read tasks (needed for sim + app)
+create policy "tasks_select"
+  on tasks for select
+  using (true);
+
+-- Players can insert tasks for their own civilizations
+create policy "tasks_insert"
+  on tasks for insert
+  with check (
+    civilization_id in (
+      select id from civilizations where player_id = auth.uid()
+    )
+  );
+
+-- Players can update tasks for their own civilizations
+create policy "tasks_update"
+  on tasks for update
+  using (
+    civilization_id in (
+      select id from civilizations where player_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
## Summary
- Wires up the sim engine to run in-browser via React hooks, enabling the full player-driven gameplay loop: designate mine → dwarf claims task → pathfinds to target → mines → task completes
- Fixes 3 critical bugs discovered during playtest: BFS pathfinding explosion (unbounded Set), dwarf flush failure (float → integer type mismatch), cross-z-level pathfinding (no stairs in Phase 0)
- Adds mine designation UI, live dwarf/task polling, starting items & skills on embark, and RLS policies for the tasks table

Closes #210

## Playtest Report

### Working Features
- **Embark**: Creates 7 dwarves at fortress center with positions, skills (2 miners, 2 farmers), and 82 starting items (food, drink, seeds, pickaxes)
- **Mine designation**: Press `m` to enter mine mode, click soil/stone tiles to designate — bottom bar shows `[MINE] click to designate`
- **Task dispatch**: Sim polls for pending tasks every 1s, idle miner dwarves claim tasks via scoring algorithm
- **Pathfinding**: Dwarves pathfind in 2D toward target, z-teleport for Phase 0 (no stairs yet)
- **Mining work**: Dwarves progress work at 1 unit/tick, task completes at 100/100, produces stone block item
- **Live UI**: Left panel shows dwarf status (Idle/Working), toolbar shows population count, designation overlay renders on map
- **Z-level navigation**: `<`/`>` keys navigate z-levels, different terrain visible at each depth
- **Session restore**: Page refresh restores world, civilization, and fortress view
- **World/Fortress toggle**: Tab key and bottom bar buttons switch between views

### Bugs Fixed During Playtest
1. **BFS Set overflow** (`RangeError: Set maximum size exceeded`): Pathfinding explored infinite plane. Fixed with 10K node limit + fortress bounds check.
2. **Dwarf flush failure** (`invalid input syntax for type integer: "99.78..."`): Needs decay produces floats but DB columns are integers. Fixed by rounding in flush.
3. **Cross-z pathfinding**: Dwarves at z=0 couldn't reach z=-1 mine tasks (no stairs). Fixed with 2D pathfinding + z-teleport for Phase 0.

### Screenshots
Playtest verified end-to-end: embark → mine designation → dwarf claims task → dwarf moves to target → work progress 0→36→78→100 → task completed → dwarf returns to Idle.

## Test plan
- [x] All 75 sim tests pass (including new BFS limit test)
- [x] All 234 passing tests still pass (3 pre-existing AuthScreen failures unrelated)
- [x] Full playtest: embark, mine designation, task completion verified in Chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)