### PR TITLE
feat: live activity log showing real-time sim events (closes #212)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -13,6 +13,7 @@ import { useAuth } from "./hooks/useAuth";
 import { useDwarves } from "./hooks/useDwarves";
 import { useSimRunner } from "./hooks/useSimRunner";
 import { useTasks } from "./hooks/useTasks";
+import { useEvents } from "./hooks/useEvents";
 import { createAndGenerateWorld } from "./lib/world-gen";
 import { embark } from "./lib/embark";
 import { ensurePlayer } from "./lib/ensure-player";
@@ -92,6 +93,9 @@ export default function App() {
 
   // Active tasks
   const { designatedTiles } = useTasks(civId);
+
+  // Live activity log
+  const events = useEvents(civId);
 
   // Ensure player profile exists after auth, then restore any existing session
   useEffect(() => {
@@ -324,6 +328,7 @@ export default function App() {
         <RightPanel
           collapsed={!rightOpen}
           onToggle={() => setRightOpen((o) => !o)}
+          events={events}
         />
       </div>
 

--- a/app/src/components/RightPanel.tsx
+++ b/app/src/components/RightPanel.tsx
@@ -1,22 +1,14 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
+import type { LiveEvent } from "../hooks/useEvents";
 
 interface RightPanelProps {
   collapsed: boolean;
   onToggle: () => void;
+  events: LiveEvent[];
 }
 
 const TABS = ["Log", "Legends"] as const;
 type Tab = (typeof TABS)[number];
-
-const PLACEHOLDER_LOG = [
-  "Urist cancels Mine: tired.",
-  "Kadol has brewed ale.",
-  "Doren constructed a wall.",
-  "Migrants have arrived!",
-  "Aban felled a tree.",
-  "A caravan has arrived.",
-  "Likot harvested plump helmets.",
-];
 
 const PLACEHOLDER_LEGENDS = [
   "Year 201 — Stonegear founded",
@@ -25,8 +17,34 @@ const PLACEHOLDER_LEGENDS = [
   "Year 204 — Great flood",
 ];
 
-export default function RightPanel({ collapsed, onToggle }: RightPanelProps) {
+/** Map event category to a CSS color variable. */
+function categoryColor(category: string): string {
+  switch (category) {
+    case 'death':
+      return 'var(--red, #f87171)';
+    case 'fortress_fallen':
+      return 'var(--red, #f87171)';
+    case 'discovery':
+      return 'var(--green)';
+    case 'migration':
+      return 'var(--cyan)';
+    default:
+      return 'var(--amber)';
+  }
+}
+
+export default function RightPanel({ collapsed, onToggle, events }: RightPanelProps) {
   const [tab, setTab] = useState<Tab>("Log");
+  const logRef = useRef<HTMLDivElement>(null);
+  const prevCountRef = useRef(0);
+
+  // Auto-scroll when new events arrive
+  useEffect(() => {
+    if (events.length > prevCountRef.current && logRef.current) {
+      logRef.current.scrollTop = 0;
+    }
+    prevCountRef.current = events.length;
+  }, [events.length]);
 
   return (
     <aside
@@ -59,16 +77,20 @@ export default function RightPanel({ collapsed, onToggle }: RightPanelProps) {
             ))}
           </div>
 
-          <div className="px-2 py-1 overflow-y-auto text-xs flex-1">
+          <div ref={logRef} className="px-2 py-1 overflow-y-auto text-xs flex-1">
             {tab === "Log" ? (
-              <ul className="space-y-0.5">
-                {PLACEHOLDER_LOG.map((entry, i) => (
-                  <li key={i} className="text-[var(--text)]">
-                    <span className="text-[var(--cyan)] mr-1">*</span>
-                    {entry}
-                  </li>
-                ))}
-              </ul>
+              events.length === 0 ? (
+                <p className="text-[var(--text)] opacity-50 italic">No events yet.</p>
+              ) : (
+                <ul className="space-y-0.5">
+                  {events.map((event) => (
+                    <li key={event.id} className="text-[var(--text)]">
+                      <span style={{ color: categoryColor(event.category) }} className="mr-1">*</span>
+                      {event.description}
+                    </li>
+                  ))}
+                </ul>
+              )
             ) : (
               <ul className="space-y-0.5">
                 {PLACEHOLDER_LEGENDS.map((entry, i) => (

--- a/app/src/hooks/useEvents.ts
+++ b/app/src/hooks/useEvents.ts
@@ -1,0 +1,66 @@
+import { useState, useEffect, useRef } from 'react';
+import { supabase } from '../lib/supabase';
+
+export interface LiveEvent {
+  id: string;
+  description: string;
+  category: string;
+  created_at: string;
+}
+
+const POLL_INTERVAL = 2000;
+const MAX_EVENTS = 50;
+
+export function useEvents(civId: string | null): LiveEvent[] {
+  const [events, setEvents] = useState<LiveEvent[]>([]);
+  const newestRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!civId) {
+      setEvents([]);
+      newestRef.current = null;
+      return;
+    }
+
+    let cancelled = false;
+
+    async function poll() {
+      const query = supabase
+        .from('world_events')
+        .select('id, description, category, created_at')
+        .eq('civilization_id', civId)
+        .order('created_at', { ascending: false })
+        .limit(MAX_EVENTS);
+
+      // Only fetch events newer than what we already have
+      if (newestRef.current) {
+        query.gt('created_at', newestRef.current);
+      }
+
+      const { data, error } = await query;
+      if (cancelled || error || !data || data.length === 0) return;
+
+      // Update newest timestamp
+      newestRef.current = data[0]!.created_at;
+
+      setEvents((prev) => {
+        const existingIds = new Set(prev.map((e) => e.id));
+        const newEvents = data.filter((e) => !existingIds.has(e.id));
+        if (newEvents.length === 0) return prev;
+        // Newest first, cap at MAX_EVENTS
+        return [...newEvents, ...prev].slice(0, MAX_EVENTS);
+      });
+    }
+
+    // Initial fetch (no filter — get recent history)
+    void poll();
+    const timer = setInterval(() => void poll(), POLL_INTERVAL);
+
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [civId]);
+
+  return events;
+}

--- a/sim/src/__tests__/integration.test.ts
+++ b/sim/src/__tests__/integration.test.ts
@@ -64,6 +64,7 @@ function makeSimContext(dwarves: Dwarf[]): SimContext {
   return {
     supabase: null as unknown as SupabaseClient,
     civilizationId: "civ-1",
+    worldId: "world-1",
     step: 0,
     year: 1,
     day: 1,

--- a/sim/src/__tests__/task-dispatch.test.ts
+++ b/sim/src/__tests__/task-dispatch.test.ts
@@ -116,6 +116,7 @@ function makeContext(opts?: {
   return {
     supabase: null as unknown as SupabaseClient,
     civilizationId: "civ-1",
+    worldId: "world-1",
     step: 0,
     year: 1,
     day: 1,

--- a/sim/src/flush-state.ts
+++ b/sim/src/flush-state.ts
@@ -105,10 +105,13 @@ export async function flushToSupabase(ctx: SimContext): Promise<void> {
   }
 
   if (events.length > 0) {
+    // Stamp world_id on events (phases leave it empty)
+    const worldId = ctx.worldId;
+    const stamped = events.map((e) => ({ ...e, world_id: worldId }));
     promises.push(
       supabase
         .from("world_events")
-        .insert(events)
+        .insert(stamped)
         .then(({ error }) => {
           if (error) console.warn(`[flush] events insert failed: ${error.message}`);
         }),

--- a/sim/src/phases/job-claiming.ts
+++ b/sim/src/phases/job-claiming.ts
@@ -57,7 +57,7 @@ export async function jobClaiming(ctx: SimContext): Promise<void> {
     }
 
     if (bestTask) {
-      claimTask(dwarf, bestTask, state);
+      claimTask(dwarf, bestTask, ctx);
       claimedTaskIds.add(bestTask.id);
     }
   }
@@ -79,11 +79,33 @@ function scoreTask(dwarf: Dwarf, task: Task, skills: SimContext['state']['dwarfS
     - (distance * SCORE_DISTANCE_WEIGHT);
 }
 
-function claimTask(dwarf: Dwarf, task: Task, state: SimContext['state']): void {
+function claimTask(dwarf: Dwarf, task: Task, ctx: SimContext): void {
+  const { state } = ctx;
   task.status = 'claimed';
   task.assigned_dwarf_id = dwarf.id;
   dwarf.current_task_id = task.id;
 
   state.dirtyDwarfIds.add(dwarf.id);
   state.dirtyTaskIds.add(task.id);
+
+  // Only fire events for player-created tasks (not autonomous eat/drink/sleep)
+  if (!isAutonomousTask(task.task_type)) {
+    const dwarfLabel = `${dwarf.name}${dwarf.surname ? ' ' + dwarf.surname : ''}`;
+    const taskLabel = task.task_type.replace(/_/g, ' ');
+    state.pendingEvents.push({
+      id: crypto.randomUUID(),
+      world_id: '',
+      year: ctx.year,
+      category: 'discovery',
+      civilization_id: ctx.civilizationId,
+      ruin_id: null,
+      dwarf_id: dwarf.id,
+      item_id: null,
+      faction_id: null,
+      monster_id: null,
+      description: `${dwarfLabel} begins ${taskLabel}.`,
+      event_data: { task_type: task.task_type, task_id: task.id },
+      created_at: new Date().toISOString(),
+    });
+  }
 }

--- a/sim/src/phases/task-execution.ts
+++ b/sim/src/phases/task-execution.ts
@@ -141,6 +141,28 @@ function completeTask(dwarf: Dwarf, task: Task, ctx: SimContext): void {
   dwarf.current_task_id = null;
   state.dirtyDwarfIds.add(dwarf.id);
 
+  // Fire completion event for player-created tasks
+  const autonomousTypes: string[] = ['eat', 'drink', 'sleep'];
+  if (!autonomousTypes.includes(task.task_type)) {
+    const dwarfLabel = `${dwarf.name}${dwarf.surname ? ' ' + dwarf.surname : ''}`;
+    const taskLabel = task.task_type.replace(/_/g, ' ');
+    state.pendingEvents.push({
+      id: crypto.randomUUID(),
+      world_id: '',
+      year: ctx.year,
+      category: 'discovery',
+      civilization_id: ctx.civilizationId,
+      ruin_id: null,
+      dwarf_id: dwarf.id,
+      item_id: null,
+      faction_id: null,
+      monster_id: null,
+      description: `${dwarfLabel} has finished ${taskLabel}.`,
+      event_data: { task_type: task.task_type, task_id: task.id },
+      created_at: new Date().toISOString(),
+    });
+  }
+
   // Apply completion effects based on task type
   switch (task.task_type) {
     case 'mine':

--- a/sim/src/sim-context.ts
+++ b/sim/src/sim-context.ts
@@ -71,6 +71,9 @@ export interface SimContext {
   /** The civilization this sim instance is driving. */
   civilizationId: string;
 
+  /** The world this civilization belongs to. */
+  worldId: string;
+
   /** Monotonically increasing step counter since sim start. */
   step: number;
 

--- a/sim/src/sim-runner.ts
+++ b/sim/src/sim-runner.ts
@@ -50,6 +50,7 @@ export class SimRunner {
     this.ctx = {
       supabase: this.supabase,
       civilizationId,
+      worldId: worldId ?? '',
       step: this.stepCount,
       year: this.currentYear,
       day: this.currentDay,


### PR DESCRIPTION
## Summary
- Sim phases now fire `world_events` for non-autonomous task claims ("begins mine") and completions ("has finished mine")
- New `useEvents` hook polls `world_events` table every 2s, returns up to 50 newest events
- `RightPanel` rewritten to display live events color-coded by category (green=discovery, red=death, cyan=migration, amber=default) with auto-scroll
- Added `worldId` to `SimContext` so flush can stamp `world_id` on events

## Test plan
- [x] Build passes (`npm run build`)
- [x] All sim/shared tests pass (236/236)
- [x] Playtest: login → restore session → fortress view loads
- [x] Playtest: designate mine tiles at z=-1 → dwarves claim and complete tasks
- [x] Playtest: log panel shows "begins mine" and "has finished mine" events in real-time
- [x] Playtest: events are green-starred (discovery category)
- [x] Playtest: no console errors during gameplay

## Playtest report

Logged in with test account, session restored to existing fortress with 7 dwarves. Navigated to z=-1, entered mine designation mode (`m`), and clicked several soil tiles. Within seconds, the right panel's Log tab populated with live events showing dwarves claiming and completing mine tasks. Events display correctly with green category markers and auto-scroll to newest. Amber starvation events also appear as needs decay kicks in. All dwarves returned to Idle after completing their tasks. No console errors observed.

Screenshots need to be manually attached — see `~/Downloads/playtest-screenshot.png` and `~/Downloads/live-activity-log-playtest.gif`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)