### PR TITLE
feat: add build menu for walls, floors, and stairs (#201)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -19,10 +19,28 @@ import { embark } from "./lib/embark";
 import { ensurePlayer } from "./lib/ensure-player";
 import { loadSession } from "./lib/load-session";
 import { supabase } from "./lib/supabase";
-import { FORTRESS_MAX_Z, FORTRESS_MIN_Z, FORTRESS_SIZE, WORK_MINE_BASE } from "@pwarf/shared";
+import BuildMenu, { BUILD_OPTIONS } from "./components/BuildMenu";
+import type { TaskType } from "@pwarf/shared";
+import {
+  FORTRESS_MAX_Z,
+  FORTRESS_MIN_Z,
+  FORTRESS_SIZE,
+  WORK_MINE_BASE,
+  WORK_BUILD_WALL,
+  WORK_BUILD_FLOOR,
+  WORK_BUILD_STAIRS,
+} from "@pwarf/shared";
 
 type Mode = "fortress" | "world";
-type DesignationMode = "none" | "mine";
+type DesignationMode = "none" | "mine" | "build_wall" | "build_floor" | "build_stairs_up" | "build_stairs_down" | "build_stairs_both";
+
+const BUILD_WORK: Record<string, number> = {
+  build_wall: WORK_BUILD_WALL,
+  build_floor: WORK_BUILD_FLOOR,
+  build_stairs_up: WORK_BUILD_STAIRS,
+  build_stairs_down: WORK_BUILD_STAIRS,
+  build_stairs_both: WORK_BUILD_STAIRS,
+};
 
 export default function App() {
   const { session, user, loading, signIn, signUp, signOut } = useAuth();
@@ -44,6 +62,7 @@ export default function App() {
 
   // Designation mode
   const [designationMode, setDesignationMode] = useState<DesignationMode>("none");
+  const [buildMenuOpen, setBuildMenuOpen] = useState(false);
 
   // Viewport size (reported from MainViewport)
   const [vpCols, setVpCols] = useState(120);
@@ -151,11 +170,19 @@ export default function App() {
           break;
         case "designate_mine":
           if (mode === "fortress") {
+            setBuildMenuOpen(false);
             setDesignationMode((m) => (m === "mine" ? "none" : "mine"));
+          }
+          break;
+        case "open_build_menu":
+          if (mode === "fortress") {
+            setDesignationMode("none");
+            setBuildMenuOpen((o) => !o);
           }
           break;
         case "cancel_designation":
           setDesignationMode("none");
+          setBuildMenuOpen(false);
           break;
       }
     },
@@ -200,9 +227,14 @@ export default function App() {
   }, [worldId, worldSeed, cursorTile, viewport.cursorX, viewport.cursorY]);
 
   const handleDesignateArea = useCallback(async (x1: number, y1: number, x2: number, y2: number) => {
-    if (designationMode !== 'mine' || !civId) return;
+    if (designationMode === 'none' || !civId) return;
 
     const mineable: string[] = ['stone', 'ore', 'gem', 'soil', 'cavern_wall'];
+    const buildable: string[] = ['open_air', 'constructed_floor', 'cavern_floor'];
+    const isMine = designationMode === 'mine';
+    const taskType = designationMode as TaskType;
+    const workRequired = isMine ? WORK_MINE_BASE : (BUILD_WORK[designationMode] ?? WORK_BUILD_WALL);
+
     const tasks: Array<{
       civilization_id: string;
       task_type: string;
@@ -216,22 +248,26 @@ export default function App() {
 
     for (let y = y1; y <= y2; y++) {
       for (let x = x1; x <= x2; x++) {
-        // Skip already designated tiles
         if (designatedTiles.has(`${x},${y}`)) continue;
 
-        // Check that the tile is minable
         const tile = getFortressTile(x, y);
-        if (!tile || !mineable.includes(tile.tileType)) continue;
+        if (!tile) continue;
+
+        if (isMine) {
+          if (!mineable.includes(tile.tileType)) continue;
+        } else {
+          if (!buildable.includes(tile.tileType)) continue;
+        }
 
         tasks.push({
           civilization_id: civId,
-          task_type: 'mine',
+          task_type: taskType,
           status: 'pending',
           priority: 5,
           target_x: x,
           target_y: y,
           target_z: zLevel,
-          work_required: WORK_MINE_BASE,
+          work_required: workRequired,
         });
       }
     }
@@ -240,9 +276,30 @@ export default function App() {
 
     const { error } = await supabase.from('tasks').insert(tasks);
     if (error) {
-      console.error('[designate] Failed to create mine tasks:', error.message);
+      console.error('[designate] Failed to create tasks:', error.message);
     }
   }, [designationMode, civId, zLevel, getFortressTile, designatedTiles]);
+
+  const handleBuildSelect = useCallback((taskType: TaskType) => {
+    setBuildMenuOpen(false);
+    setDesignationMode(taskType as DesignationMode);
+  }, []);
+
+  // Keyboard shortcuts for build menu items when the menu is open
+  useEffect(() => {
+    if (!buildMenuOpen) return;
+    function handleBuildKey(e: KeyboardEvent) {
+      const opt = BUILD_OPTIONS.find((o) => o.key === e.key);
+      if (opt) {
+        e.preventDefault();
+        e.stopPropagation();
+        setBuildMenuOpen(false);
+        setDesignationMode(opt.taskType as DesignationMode);
+      }
+    }
+    window.addEventListener("keydown", handleBuildKey, true);
+    return () => window.removeEventListener("keydown", handleBuildKey, true);
+  }, [buildMenuOpen]);
 
   // Loading state
   if (loading) {
@@ -299,8 +356,10 @@ export default function App() {
   }
 
   const terrainForBar = mode === "world" ? (cursorTile?.terrain ?? null) : null;
+  const cursorKey = `${viewport.cursorX},${viewport.cursorY}`;
+  const cursorDesignation = mode === "fortress" ? designatedTiles.get(cursorKey) : undefined;
   const fortressTileLabel = mode === "fortress" && cursorFortressTile
-    ? formatFortressTileLabel(cursorFortressTile.tileType, cursorFortressTile.material)
+    ? formatFortressTileLabel(cursorFortressTile.tileType, cursorFortressTile.material, cursorDesignation)
     : null;
 
   return (
@@ -313,7 +372,13 @@ export default function App() {
         civName={mode === "fortress" ? "Stonegear" : undefined}
       />
 
-      <div className="flex flex-1 min-h-0">
+      <div className="flex flex-1 min-h-0 relative">
+        {buildMenuOpen && (
+          <BuildMenu
+            onSelect={handleBuildSelect}
+            onClose={() => setBuildMenuOpen(false)}
+          />
+        )}
         <LeftPanel
           mode={mode}
           collapsed={!leftOpen}
@@ -379,8 +444,12 @@ export default function App() {
   );
 }
 
-function formatFortressTileLabel(tileType: string, material: string | null): string {
+function formatFortressTileLabel(tileType: string, material: string | null, designation?: string): string {
   const label = tileType.replace(/_/g, " ");
-  if (material) return `${label} (${material})`;
-  return label;
+  const base = material ? `${label} (${material})` : label;
+  if (designation) {
+    const desLabel = designation.replace(/_/g, " ");
+    return `${base} [designated: ${desLabel}]`;
+  }
+  return base;
 }

--- a/app/src/components/BottomBar.tsx
+++ b/app/src/components/BottomBar.tsx
@@ -44,6 +44,9 @@ export default function BottomBar({ mode, cursorX, cursorY, terrain, zLevel, for
             <span>
               <kbd className="text-[var(--amber)]">m</kbd> mine
             </span>
+            <span>
+              <kbd className="text-[var(--amber)]">b</kbd> build
+            </span>
           </>
         )}
         <span>

--- a/app/src/components/BuildMenu.tsx
+++ b/app/src/components/BuildMenu.tsx
@@ -1,0 +1,51 @@
+import type { TaskType } from "@pwarf/shared";
+
+export type BuildOption = {
+  label: string;
+  key: string;
+  taskType: TaskType;
+};
+
+const BUILD_OPTIONS: BuildOption[] = [
+  { label: "Wall", key: "w", taskType: "build_wall" },
+  { label: "Floor", key: "f", taskType: "build_floor" },
+  { label: "Stairs Up", key: "u", taskType: "build_stairs_up" },
+  { label: "Stairs Down", key: "d", taskType: "build_stairs_down" },
+  { label: "Stairs Up/Down", key: "x", taskType: "build_stairs_both" },
+];
+
+interface BuildMenuProps {
+  onSelect: (taskType: TaskType) => void;
+  onClose: () => void;
+}
+
+export default function BuildMenu({ onSelect, onClose }: BuildMenuProps) {
+  return (
+    <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-50 bg-[var(--bg-panel)] border border-[var(--amber)] p-3 min-w-[200px]">
+      <div className="flex justify-between items-center mb-2 border-b border-[var(--border)] pb-1">
+        <span className="text-[var(--amber)] font-bold text-sm">Build</span>
+        <button
+          onClick={onClose}
+          className="text-[var(--text)] hover:text-[var(--red,#f87171)] text-xs cursor-pointer"
+        >
+          [Esc]
+        </button>
+      </div>
+      <ul className="space-y-0.5">
+        {BUILD_OPTIONS.map((opt) => (
+          <li key={opt.taskType}>
+            <button
+              onClick={() => onSelect(opt.taskType)}
+              className="w-full text-left px-1 py-0.5 text-xs text-[var(--text)] hover:bg-[var(--bg-hover)] hover:text-[var(--green)] cursor-pointer"
+            >
+              <kbd className="text-[var(--amber)] mr-2">{opt.key}</kbd>
+              {opt.label}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export { BUILD_OPTIONS };

--- a/app/src/components/MainViewport.tsx
+++ b/app/src/components/MainViewport.tsx
@@ -17,8 +17,8 @@ interface MainViewportProps {
   onViewportSize?: (cols: number, rows: number) => void;
   /** Live dwarf positions keyed by "x,y" */
   dwarfPositions?: Map<string, { name: string }>;
-  /** Tiles with active designations keyed by "x,y" */
-  designatedTiles?: Set<string>;
+  /** Tiles with active designations keyed by "x,y" → task_type */
+  designatedTiles?: Map<string, string>;
   /** Current designation mode */
   designationMode?: string;
   /** Area designation handler — called with rectangle bounds */
@@ -47,6 +47,16 @@ const FORTRESS_GLYPHS: Record<FortressTileType, { ch: string; fg: string }> = {
   stair_down:         { ch: ">",  fg: "#4af626" },
   stair_both:         { ch: "X",  fg: "#4af626" },
   empty:              { ch: " ",  fg: "#000" },
+};
+
+// --- Designation preview glyphs (shown on designated tiles before construction) ---
+const DESIGNATION_PREVIEW: Record<string, { ch: string; fg: string }> = {
+  mine:              { ch: "X", fg: "#cc6600" },
+  build_wall:        { ch: "#", fg: "#cc8844" },
+  build_floor:       { ch: "+", fg: "#cc8844" },
+  build_stairs_up:   { ch: "<", fg: "#cc8844" },
+  build_stairs_down: { ch: ">", fg: "#cc8844" },
+  build_stairs_both: { ch: "X", fg: "#cc8844" },
 };
 
 // --- World tile palette (terrain -> glyph + color) ---
@@ -129,13 +139,18 @@ export default function MainViewport({
       }
 
       // Check for designation overlay
-      const isDesignated = designatedTiles?.has(key);
+      const taskType = designatedTiles?.get(key);
 
       if (fortressTiles) {
         const tile = fortressTiles.get(key);
         if (tile) {
           const glyph = FORTRESS_GLYPHS[tile.tileType] ?? { ch: "?", fg: "#f00" };
-          if (isDesignated) {
+          if (taskType) {
+            // Show a preview glyph of what will be built
+            const preview = DESIGNATION_PREVIEW[taskType];
+            if (preview) {
+              return { ch: preview.ch, fg: preview.fg, bg: "#442200" };
+            }
             return { ...glyph, bg: "#442200" };
           }
           return glyph;

--- a/app/src/hooks/useKeyboard.ts
+++ b/app/src/hooks/useKeyboard.ts
@@ -8,6 +8,7 @@ export type KeyAction =
   | { type: "z_up" }
   | { type: "z_down" }
   | { type: "designate_mine" }
+  | { type: "open_build_menu" }
   | { type: "cancel_designation" };
 
 export function useKeyboard(onAction: (action: KeyAction) => void) {
@@ -60,6 +61,9 @@ export function useKeyboard(onAction: (action: KeyAction) => void) {
           break;
         case "m":
           onAction({ type: "designate_mine" });
+          break;
+        case "b":
+          onAction({ type: "open_build_menu" });
           break;
         case "Escape":
           onAction({ type: "cancel_designation" });

--- a/app/src/hooks/useTasks.ts
+++ b/app/src/hooks/useTasks.ts
@@ -45,15 +45,15 @@ export function useTasks(civId: string | null) {
     };
   }, [civId]);
 
-  /** Set of "x,y" keys for tiles with active mine designations at a given z-level */
+  /** Map of "x,y" → task_type for tiles with active designations */
   const designatedTiles = useMemo(() => {
-    const set = new Set<string>();
+    const map = new Map<string, string>();
     for (const task of tasks) {
       if (task.target_x !== null && task.target_y !== null) {
-        set.add(`${task.target_x},${task.target_y}`);
+        map.set(`${task.target_x},${task.target_y}`, task.task_type);
       }
     }
-    return set;
+    return map;
   }, [tasks]);
 
   return { tasks, designatedTiles };

--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -133,6 +133,15 @@ export const WORK_DRINK = 10;
 /** Work required for sleeping */
 export const WORK_SLEEP = 50;
 
+/** Work required to build a wall */
+export const WORK_BUILD_WALL = 80;
+
+/** Work required to build a floor */
+export const WORK_BUILD_FLOOR = 50;
+
+/** Work required to build stairs */
+export const WORK_BUILD_STAIRS = 60;
+
 // ============================================================
 // Material hardness multipliers (for mining)
 // ============================================================
@@ -151,6 +160,7 @@ export const XP_MINE = 15;
 export const XP_FARM_TILL = 10;
 export const XP_FARM_PLANT = 10;
 export const XP_FARM_HARVEST = 10;
+export const XP_BUILD = 12;
 
 // ============================================================
 // Scoring weights (job claiming)

--- a/shared/src/db-types.ts
+++ b/shared/src/db-types.ts
@@ -155,7 +155,12 @@ export type TaskType =
   | 'farm_harvest'
   | 'eat'
   | 'drink'
-  | 'sleep';
+  | 'sleep'
+  | 'build_wall'
+  | 'build_floor'
+  | 'build_stairs_up'
+  | 'build_stairs_down'
+  | 'build_stairs_both';
 
 export type TaskStatus =
   | 'pending'

--- a/sim/src/__tests__/task-dispatch.test.ts
+++ b/sim/src/__tests__/task-dispatch.test.ts
@@ -653,3 +653,200 @@ describe("starvation scenario", () => {
     expect(fallenEvents.length).toBeGreaterThanOrEqual(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Build task tests
+// ---------------------------------------------------------------------------
+
+describe("build tasks", () => {
+  it("completeBuild creates a fortress tile override for build_wall", async () => {
+    const dwarf = makeDwarf({ position_x: 5, position_y: 6, position_z: 0 });
+    const task: Task = {
+      id: randomUUID(),
+      civilization_id: "civ-1",
+      task_type: "build_wall",
+      status: "in_progress",
+      priority: 5,
+      assigned_dwarf_id: dwarf.id,
+      target_x: 5,
+      target_y: 7,
+      target_z: 0,
+      target_item_id: null,
+      work_progress: 79,
+      work_required: 80,
+      created_at: new Date().toISOString(),
+      completed_at: null,
+    };
+    dwarf.current_task_id = task.id;
+
+    const ctx = makeContext({
+      dwarves: [dwarf],
+      tasks: [task],
+      skills: [makeSkill(dwarf.id, "building", 0)],
+    });
+
+    await taskExecution(ctx);
+
+    // Task should be completed
+    expect(task.status).toBe("completed");
+
+    // Fortress tile override should be created
+    const key = "5,7,0";
+    expect(ctx.state.fortressTileOverrides.has(key)).toBe(true);
+    const tile = ctx.state.fortressTileOverrides.get(key)!;
+    expect(tile.tile_type).toBe("constructed_wall");
+    expect(tile.material).toBe("stone");
+    expect(tile.is_mined).toBe(false);
+
+    // Should be marked dirty
+    expect(ctx.state.dirtyFortressTileKeys.has(key)).toBe(true);
+  });
+
+  it("completeBuild creates correct tile type for build_floor", async () => {
+    const dwarf = makeDwarf({ position_x: 10, position_y: 10, position_z: 0 });
+    const task: Task = {
+      id: randomUUID(),
+      civilization_id: "civ-1",
+      task_type: "build_floor",
+      status: "in_progress",
+      priority: 5,
+      assigned_dwarf_id: dwarf.id,
+      target_x: 10,
+      target_y: 10,
+      target_z: 0,
+      target_item_id: null,
+      work_progress: 49,
+      work_required: 50,
+      created_at: new Date().toISOString(),
+      completed_at: null,
+    };
+    dwarf.current_task_id = task.id;
+
+    const ctx = makeContext({
+      dwarves: [dwarf],
+      tasks: [task],
+      skills: [makeSkill(dwarf.id, "building", 0)],
+    });
+
+    await taskExecution(ctx);
+
+    expect(task.status).toBe("completed");
+    const tile = ctx.state.fortressTileOverrides.get("10,10,0")!;
+    expect(tile.tile_type).toBe("constructed_floor");
+  });
+
+  it("completeBuild creates correct tile type for stairs", async () => {
+    const types: Array<{ taskType: "build_stairs_up" | "build_stairs_down" | "build_stairs_both"; expected: string }> = [
+      { taskType: "build_stairs_up", expected: "stair_up" },
+      { taskType: "build_stairs_down", expected: "stair_down" },
+      { taskType: "build_stairs_both", expected: "stair_both" },
+    ];
+
+    for (const { taskType, expected } of types) {
+      const dwarf = makeDwarf({ position_x: 0, position_y: 0, position_z: 0 });
+      const task: Task = {
+        id: randomUUID(),
+        civilization_id: "civ-1",
+        task_type: taskType,
+        status: "in_progress",
+        priority: 5,
+        assigned_dwarf_id: dwarf.id,
+        target_x: 0,
+        target_y: 0,
+        target_z: 0,
+        target_item_id: null,
+        work_progress: 59,
+        work_required: 60,
+        created_at: new Date().toISOString(),
+        completed_at: null,
+      };
+      dwarf.current_task_id = task.id;
+
+      const ctx = makeContext({
+        dwarves: [dwarf],
+        tasks: [task],
+        skills: [makeSkill(dwarf.id, "building", 0)],
+      });
+
+      await taskExecution(ctx);
+
+      expect(task.status).toBe("completed");
+      const tile = ctx.state.fortressTileOverrides.get("0,0,0")!;
+      expect(tile.tile_type).toBe(expected);
+    }
+  });
+
+  it("completeMine creates a fortress tile override with open_air", async () => {
+    const dwarf = makeDwarf({ position_x: 3, position_y: 4, position_z: 0 });
+    const task: Task = {
+      id: randomUUID(),
+      civilization_id: "civ-1",
+      task_type: "mine",
+      status: "in_progress",
+      priority: 5,
+      assigned_dwarf_id: dwarf.id,
+      target_x: 3,
+      target_y: 5,
+      target_z: 0,
+      target_item_id: null,
+      work_progress: 99,
+      work_required: 100,
+      created_at: new Date().toISOString(),
+      completed_at: null,
+    };
+    dwarf.current_task_id = task.id;
+
+    const ctx = makeContext({
+      dwarves: [dwarf],
+      tasks: [task],
+      skills: [makeSkill(dwarf.id, "mining", 0)],
+    });
+
+    await taskExecution(ctx);
+
+    expect(task.status).toBe("completed");
+
+    // Mining should create an open_air tile override
+    const key = "3,5,0";
+    expect(ctx.state.fortressTileOverrides.has(key)).toBe(true);
+    const tile = ctx.state.fortressTileOverrides.get(key)!;
+    expect(tile.tile_type).toBe("open_air");
+    expect(tile.is_mined).toBe(true);
+
+    // Should also create a stone item
+    expect(ctx.state.items.length).toBe(1);
+    expect(ctx.state.items[0]!.category).toBe("raw_material");
+  });
+
+  it("build tasks award building XP", async () => {
+    const dwarf = makeDwarf({ position_x: 1, position_y: 1, position_z: 0 });
+    const skill = makeSkill(dwarf.id, "building", 0, 0);
+    const task: Task = {
+      id: randomUUID(),
+      civilization_id: "civ-1",
+      task_type: "build_floor",
+      status: "in_progress",
+      priority: 5,
+      assigned_dwarf_id: dwarf.id,
+      target_x: 1,
+      target_y: 1,
+      target_z: 0,
+      target_item_id: null,
+      work_progress: 49,
+      work_required: 50,
+      created_at: new Date().toISOString(),
+      completed_at: null,
+    };
+    dwarf.current_task_id = task.id;
+
+    const ctx = makeContext({
+      dwarves: [dwarf],
+      tasks: [task],
+      skills: [skill],
+    });
+
+    await taskExecution(ctx);
+
+    expect(skill.xp).toBe(12); // XP_BUILD = 12
+  });
+});

--- a/sim/src/flush-state.ts
+++ b/sim/src/flush-state.ts
@@ -104,6 +104,22 @@ export async function flushToSupabase(ctx: SimContext): Promise<void> {
     );
   }
 
+  if (state.dirtyFortressTileKeys.size > 0) {
+    const dirtyTiles = [...state.dirtyFortressTileKeys]
+      .map((key) => state.fortressTileOverrides.get(key))
+      .filter(Boolean);
+    if (dirtyTiles.length > 0) {
+      promises.push(
+        supabase
+          .from("fortress_tiles")
+          .upsert(dirtyTiles, { onConflict: "civilization_id,x,y,z" })
+          .then(({ error }) => {
+            if (error) console.warn(`[flush] fortress_tiles upsert failed: ${error.message}`);
+          }),
+      );
+    }
+  }
+
   if (events.length > 0) {
     // Stamp world_id on events (phases leave it empty)
     const worldId = ctx.worldId;
@@ -126,6 +142,7 @@ export async function flushToSupabase(ctx: SimContext): Promise<void> {
   state.dirtyStructureIds.clear();
   state.dirtyMonsterIds.clear();
   state.dirtyTaskIds.clear();
+  state.dirtyFortressTileKeys.clear();
   state.newTasks = [];
   state.pendingEvents = [];
 }

--- a/sim/src/load-state.ts
+++ b/sim/src/load-state.ts
@@ -75,6 +75,8 @@ export async function loadStateFromSupabase(
     dirtyTaskIds: new Set(),
     newTasks: [],
     pendingEvents: [],
+    fortressTileOverrides: new Map(),
+    dirtyFortressTileKeys: new Set(),
     zeroFoodTicks: new Map(),
     zeroDrinkTicks: new Map(),
   };

--- a/sim/src/phases/task-execution.ts
+++ b/sim/src/phases/task-execution.ts
@@ -7,15 +7,28 @@ import {
   XP_FARM_TILL,
   XP_FARM_PLANT,
   XP_FARM_HARVEST,
+  XP_BUILD,
   STARVATION_TICKS,
   DEHYDRATION_TICKS,
   FORTRESS_SIZE,
 } from "@pwarf/shared";
-import type { Dwarf, Task, Item, TaskType } from "@pwarf/shared";
+import type { Dwarf, FortressTile, FortressTileType, Task, Item, TaskType } from "@pwarf/shared";
 import type { SimContext } from "../sim-context.js";
 import { getDwarfSkillLevel, getRequiredSkill } from "../task-helpers.js";
 import { bfsNextStep, manhattanDistance } from "../pathfinding.js";
 import type { TileLookup } from "../pathfinding.js";
+
+/** Task types where the dwarf stands adjacent to (not on) the target tile. */
+const ADJACENT_TASK_TYPES: ReadonlySet<string> = new Set(['mine', 'build_wall']);
+
+/** Build task type → resulting fortress tile type. */
+const BUILD_TILE_MAP: Record<string, FortressTileType> = {
+  build_wall: 'constructed_wall',
+  build_floor: 'constructed_floor',
+  build_stairs_up: 'stair_up',
+  build_stairs_down: 'stair_down',
+  build_stairs_both: 'stair_both',
+};
 
 /**
  * Task Execution Phase
@@ -53,7 +66,7 @@ export async function taskExecution(ctx: SimContext): Promise<void> {
 
     // Check if dwarf needs to move to the task site
     if (task.target_x !== null && task.target_y !== null && task.target_z !== null) {
-      const needsAdjacent = task.task_type === 'mine'; // Stand next to wall, not inside it
+      const needsAdjacent = ADJACENT_TASK_TYPES.has(task.task_type);
       const atSite = needsAdjacent
         ? isAdjacentToTarget(dwarf, task)
         : (dwarf.position_x === task.target_x && dwarf.position_y === task.target_y && dwarf.position_z === task.target_z);
@@ -104,7 +117,7 @@ function moveTowardTarget(dwarf: Dwarf, task: Task, ctx: SimContext): boolean {
     return 'open_air';
   };
 
-  const needsAdjacent = task.task_type === 'mine';
+  const needsAdjacent = ADJACENT_TASK_TYPES.has(task.task_type);
 
   // Flatten to 2D: pathfind on dwarf's current z-level toward target x,y
   const goal2d = { x: task.target_x, y: task.target_y, z: dwarf.position_z };
@@ -191,13 +204,21 @@ function completeTask(dwarf: Dwarf, task: Task, ctx: SimContext): void {
     case 'sleep':
       completeSleep(dwarf, ctx);
       break;
+    case 'build_wall':
+    case 'build_floor':
+    case 'build_stairs_up':
+    case 'build_stairs_down':
+    case 'build_stairs_both':
+      completeBuild(task, ctx);
+      awardXp(dwarf.id, 'building', XP_BUILD, state);
+      break;
   }
 }
 
 function completeMine(task: Task, ctx: SimContext): void {
-  // Create a stone item at the mined tile
   if (task.target_x === null || task.target_y === null || task.target_z === null) return;
 
+  // Create a stone item at the mined tile
   const stoneItem: Item = {
     id: crypto.randomUUID(),
     name: 'Stone block',
@@ -220,6 +241,49 @@ function completeMine(task: Task, ctx: SimContext): void {
 
   ctx.state.items.push(stoneItem);
   ctx.state.dirtyItemIds.add(stoneItem.id);
+
+  // Update the fortress tile: mined tile becomes open_air
+  upsertFortressTile(ctx, task.target_x, task.target_y, task.target_z, 'open_air', null, true);
+}
+
+function completeBuild(task: Task, ctx: SimContext): void {
+  if (task.target_x === null || task.target_y === null || task.target_z === null) return;
+
+  const tileType = BUILD_TILE_MAP[task.task_type];
+  if (!tileType) return;
+
+  upsertFortressTile(ctx, task.target_x, task.target_y, task.target_z, tileType, 'stone', false);
+}
+
+function upsertFortressTile(
+  ctx: SimContext,
+  x: number, y: number, z: number,
+  tileType: FortressTileType,
+  material: string | null,
+  isMined: boolean,
+): void {
+  const key = `${x},${y},${z}`;
+  const existing = ctx.state.fortressTileOverrides.get(key);
+
+  if (existing) {
+    existing.tile_type = tileType;
+    existing.material = material;
+    existing.is_mined = isMined;
+  } else {
+    const tile: FortressTile = {
+      id: crypto.randomUUID(),
+      civilization_id: ctx.civilizationId,
+      x, y, z,
+      tile_type: tileType,
+      material,
+      is_revealed: true,
+      is_mined: isMined,
+      created_at: new Date().toISOString(),
+    };
+    ctx.state.fortressTileOverrides.set(key, tile);
+  }
+
+  ctx.state.dirtyFortressTileKeys.add(key);
 }
 
 function completeHaul(task: Task, _ctx: SimContext): void {

--- a/sim/src/sim-context.ts
+++ b/sim/src/sim-context.ts
@@ -2,6 +2,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type {
   Dwarf,
   DwarfSkill,
+  FortressTile,
   Item,
   Structure,
   Monster,
@@ -32,6 +33,10 @@ export interface CachedState {
   /** Events queued during a tick, flushed by the event-firing phase. */
   pendingEvents: WorldEvent[];
 
+  /** Fortress tile overrides created by mining/building. Keyed by "x,y,z". */
+  fortressTileOverrides: Map<string, FortressTile>;
+  dirtyFortressTileKeys: Set<string>;
+
   /** Tracks ticks at zero need for starvation/dehydration death. */
   zeroFoodTicks: Map<string, number>;
   zeroDrinkTicks: Map<string, number>;
@@ -54,6 +59,8 @@ export function createEmptyCachedState(): CachedState {
     dirtyTaskIds: new Set(),
     newTasks: [],
     pendingEvents: [],
+    fortressTileOverrides: new Map(),
+    dirtyFortressTileKeys: new Set(),
     zeroFoodTicks: new Map(),
     zeroDrinkTicks: new Map(),
   };

--- a/sim/src/task-helpers.ts
+++ b/sim/src/task-helpers.ts
@@ -11,6 +11,11 @@ const TASK_SKILL_MAP: Record<TaskType, string | null> = {
   eat: null,
   drink: null,
   sleep: null,
+  build_wall: 'building',
+  build_floor: 'building',
+  build_stairs_up: 'building',
+  build_stairs_down: 'building',
+  build_stairs_both: 'building',
 };
 
 /** Get the skill name required for a task type, or null if no skill needed. */

--- a/supabase/migrations/00006_build_task_types.sql
+++ b/supabase/migrations/00006_build_task_types.sql
@@ -1,0 +1,10 @@
+-- ============================================================
+-- BUILD TASK TYPES
+-- Adds build_wall, build_floor, and stair task types
+-- ============================================================
+
+alter type task_type add value 'build_wall';
+alter type task_type add value 'build_floor';
+alter type task_type add value 'build_stairs_up';
+alter type task_type add value 'build_stairs_down';
+alter type task_type add value 'build_stairs_both';


### PR DESCRIPTION
## Summary

- Adds a **build menu** (`b` key) with 5 construction types: wall, floor, stairs up, stairs down, stairs up/down
- Each build type enters designation mode with drag-select rectangle (reuses existing mine designation pipeline)
- Sim processes build tasks: dwarves pathfind to site, advance work, then create fortress tile overrides on completion
- Mining completion now also persists tile changes (open_air) to the `fortress_tiles` table
- Adds `fortressTileOverrides` tracking to CachedState with flush support
- DB migration adds 5 new `task_type` enum values

## Changes

**Shared** (`shared/`)
- Added `build_wall`, `build_floor`, `build_stairs_up/down/both` to `TaskType` enum
- Added `WORK_BUILD_WALL`, `WORK_BUILD_FLOOR`, `WORK_BUILD_STAIRS`, `XP_BUILD` constants

**Sim** (`sim/`)
- `task-helpers.ts`: Building skill mapping for all build task types
- `task-execution.ts`: Build completion handlers creating fortress tile overrides; mine completion now also creates tile overrides
- `sim-context.ts`: Added `fortressTileOverrides` and `dirtyFortressTileKeys` to CachedState
- `flush-state.ts`: Flushes dirty fortress tiles to `fortress_tiles` table via upsert
- `load-state.ts`: Initialize new CachedState fields

**App** (`app/`)
- `BuildMenu.tsx`: New component with keyboard shortcuts (w/f/u/d/x) and click support
- `useKeyboard.ts`: Added `b` key → `open_build_menu` action
- `App.tsx`: Build menu state, designation mode expanded for build types, `handleDesignateArea` supports both mine and build tasks
- `BottomBar.tsx`: Shows `b build` key hint

**DB** (`supabase/migrations/`)
- `00006_build_task_types.sql`: Adds 5 new task_type enum values

## Playtest

Tested in Chrome on localhost:5174:
- `b` key opens build menu with all 5 options
- Keyboard shortcuts (w/f/u/d/x) select build type and enter designation mode
- Click on menu items also works
- Bottom bar shows active build mode (e.g. `[BUILD_WALL] click to designate`)
- Drag-select creates tasks in database (brown tile overlay appears)
- `Escape` cancels designation mode
- No console errors
- 5 new unit tests pass (build_wall, build_floor, all stair types, mine tile override, XP award)

## Test plan

- [x] Build menu opens with `b` key
- [x] All 5 build options selectable via keyboard and click
- [x] Drag-select creates correct task types in DB
- [x] Escape cancels build designation
- [x] Mine mode (`m`) still works independently
- [x] Unit tests for build task completion (tile overrides, XP)
- [x] All 241 tests pass (3 pre-existing AuthScreen failures)
- [x] TypeScript builds cleanly across all workspaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)