### PR TITLE
feat: add New Game button to restart with random seed (closes #216)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -60,6 +60,9 @@ export default function App() {
   // Fortress z-level
   const [zLevel, setZLevel] = useState(0);
 
+  // Selected world tile (persists on click)
+  const [selectedWorldTile, setSelectedWorldTile] = useState<{ x: number; y: number } | null>(null);
+
   // Designation mode
   const [designationMode, setDesignationMode] = useState<DesignationMode>("none");
   const [buildMenuOpen, setBuildMenuOpen] = useState(false);
@@ -91,6 +94,9 @@ export default function App() {
   });
 
   const cursorTile = worldId ? getTile(viewport.cursorX, viewport.cursorY) : null;
+  const selectedTileData = worldId && selectedWorldTile
+    ? getTile(selectedWorldTile.x, selectedWorldTile.y)
+    : null;
   const cursorFortressTile = civId ? getFortressTile(viewport.cursorX, viewport.cursorY) : null;
 
   // Live dwarves from DB
@@ -214,9 +220,9 @@ export default function App() {
   }, []);
 
   const handleEmbark = useCallback(async () => {
-    if (!worldId || !worldSeed || !cursorTile || cursorTile.terrain === "ocean") return;
+    if (!worldId || !worldSeed || !selectedWorldTile || !selectedTileData || selectedTileData.terrain === "ocean") return;
     try {
-      const id = await embark(worldId, viewport.cursorX, viewport.cursorY, worldSeed);
+      const id = await embark(worldId, selectedWorldTile.x, selectedWorldTile.y, worldSeed);
       setCivId(id);
       setMode("fortress");
       const center = Math.floor(FORTRESS_SIZE / 2);
@@ -224,7 +230,7 @@ export default function App() {
     } catch (err) {
       console.error("Embark failed:", err);
     }
-  }, [worldId, worldSeed, cursorTile, viewport.cursorX, viewport.cursorY]);
+  }, [worldId, worldSeed, selectedWorldTile, selectedTileData]);
 
   const handleDesignateArea = useCallback(async (x1: number, y1: number, x2: number, y2: number) => {
     if (designationMode === 'none' || !civId) return;
@@ -301,6 +307,24 @@ export default function App() {
     return () => window.removeEventListener("keydown", handleBuildKey, true);
   }, [buildMenuOpen]);
 
+  const handleRestart = useCallback(async () => {
+    // Clear the player's world_id so they get the world gen screen
+    const { data: { user: currentUser } } = await supabase.auth.getUser();
+    if (currentUser) {
+      await supabase.from('players').update({ world_id: null }).eq('id', currentUser.id);
+    }
+    // Reset all local state
+    setWorldId(null);
+    setWorldSeed(null);
+    setCivId(null);
+    setMode("world");
+    setDesignationMode("none");
+    setBuildMenuOpen(false);
+    setSelectedWorldTile(null);
+    setZLevel(0);
+    viewport.setOffset(0, 0);
+  }, [viewport.setOffset]);
+
   // Loading state
   if (loading) {
     return (
@@ -367,6 +391,7 @@ export default function App() {
       <Toolbar
         mode={mode}
         onSignOut={signOut}
+        onRestart={handleRestart}
         population={liveDwarves.length}
         year={1}
         civName={mode === "fortress" ? "Stonegear" : undefined}
@@ -383,8 +408,8 @@ export default function App() {
           mode={mode}
           collapsed={!leftOpen}
           onToggle={() => setLeftOpen((o) => !o)}
-          cursorTile={cursorTile}
-          onEmbark={mode === "world" ? handleEmbark : undefined}
+          cursorTile={mode === "world" ? (selectedTileData ?? cursorTile) : cursorTile}
+          onEmbark={mode === "world" && selectedWorldTile ? handleEmbark : undefined}
           dwarves={liveDwarves}
         />
 
@@ -405,6 +430,8 @@ export default function App() {
           designatedTiles={mode === "fortress" ? designatedTiles : undefined}
           designationMode={mode === "fortress" ? designationMode : undefined}
           onDesignateArea={mode === "fortress" ? handleDesignateArea : undefined}
+          onTileClick={mode === "world" ? (x: number, y: number) => setSelectedWorldTile({ x, y }) : undefined}
+          selectedTile={mode === "world" ? selectedWorldTile : undefined}
         />
 
         <RightPanel

--- a/app/src/components/MainViewport.tsx
+++ b/app/src/components/MainViewport.tsx
@@ -23,6 +23,10 @@ interface MainViewportProps {
   designationMode?: string;
   /** Area designation handler — called with rectangle bounds */
   onDesignateArea?: (x1: number, y1: number, x2: number, y2: number) => void;
+  /** Click handler for world map tile selection */
+  onTileClick?: (x: number, y: number) => void;
+  /** Selected world tile position */
+  selectedTile?: { x: number; y: number } | null;
 }
 
 // Character cell dimensions (monospace)
@@ -105,6 +109,8 @@ export default function MainViewport({
   designatedTiles,
   designationMode,
   onDesignateArea,
+  onTileClick,
+  selectedTile,
 }: MainViewportProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -212,6 +218,12 @@ export default function MainViewport({
           ctx.fillRect(px, py, CHAR_W, CHAR_H);
         }
 
+        // Highlight selected world tile
+        if (selectedTile && wx === selectedTile.x && wy === selectedTile.y) {
+          ctx.fillStyle = "rgba(74, 246, 38, 0.25)";
+          ctx.fillRect(px, py, CHAR_W, CHAR_H);
+        }
+
         // Highlight cursor tile
         if (wx === cursorX && wy === cursorY) {
           ctx.fillStyle = designationMode && designationMode !== 'none' ? "#442244" : "#333";
@@ -259,7 +271,7 @@ export default function MainViewport({
       ctx.lineWidth = 1;
       ctx.strokeRect(cx + 0.5, cy + 0.5, CHAR_W - 1, CHAR_H - 1);
     }
-  }, [offsetX, offsetY, cursorX, cursorY, getTile, onViewportSize, isDesignating, selStart, selEnd]);
+  }, [offsetX, offsetY, cursorX, cursorY, getTile, onViewportSize, isDesignating, selStart, selEnd, selectedTile]);
 
   // Re-render on state change
   useEffect(() => {
@@ -328,6 +340,10 @@ export default function MainViewport({
         const y2 = Math.max(selStart.y, selEnd.y);
         onDesignateArea(x1, y1, x2, y2);
       }
+      // Fire tile click if user clicked without dragging (world map selection)
+      if (dragging.current && !dragMoved.current && !isDesignating && onTileClick) {
+        onTileClick(cursorX, cursorY);
+      }
       dragging.current = false;
       dragMoved.current = false;
       setSelStart(null);
@@ -336,7 +352,7 @@ export default function MainViewport({
         onDragEnd();
       }
     },
-    [onDragEnd, onDesignateArea, isDesignating, selStart, selEnd],
+    [onDragEnd, onDesignateArea, onTileClick, isDesignating, selStart, selEnd, cursorX, cursorY],
   );
 
   return (

--- a/app/src/components/Toolbar.tsx
+++ b/app/src/components/Toolbar.tsx
@@ -1,12 +1,13 @@
 interface ToolbarProps {
   mode: "fortress" | "world";
   onSignOut?: () => void;
+  onRestart?: () => void;
   population?: number;
   year?: number;
   civName?: string;
 }
 
-export default function Toolbar({ mode, onSignOut, population = 0, year = 1, civName }: ToolbarProps) {
+export default function Toolbar({ mode, onSignOut, onRestart, population = 0, year = 1, civName }: ToolbarProps) {
   return (
     <header className="flex items-center justify-between px-3 py-1 border-b border-[var(--border)] bg-[var(--bg-panel)] text-xs select-none shrink-0">
       <div className="flex gap-4 items-center">
@@ -22,6 +23,14 @@ export default function Toolbar({ mode, onSignOut, population = 0, year = 1, civ
       <div className="flex gap-4 items-center">
         <span>Pop: {population}</span>
         <span className="text-[var(--amber)]">No alerts</span>
+        {onRestart && (
+          <button
+            onClick={onRestart}
+            className="px-2 py-0.5 border border-[var(--border)] text-[var(--text)] hover:text-[var(--red,#f87171)] hover:border-[var(--red,#f87171)] cursor-pointer"
+          >
+            New Game
+          </button>
+        )}
         {onSignOut && (
           <button
             onClick={onSignOut}


### PR DESCRIPTION
## Summary
- Add a **New Game** button to the toolbar that resets the player's world and returns to world generation
- Add **world map tile selection** — clicking a tile on the world map highlights it with a green overlay and persists the selection, so you know exactly where you're embarking
- Embark now uses the selected tile position instead of cursor position

Closes #216

## Playtest report

Tested locally at `localhost:5174`:

1. **Tile selection** — Clicked a plains tile on the world map. Green highlight appeared on the tile and persisted when moving cursor away. Left panel continued showing the selected tile's info (terrain, elevation, biome). "Embark Here" button appeared. ✅
2. **New Game button** — Clicked "New Game" in toolbar. Game reset to the world generation screen with "Generate World" button. ✅
3. **Console errors** — None observed throughout testing. ✅

## Test plan
- [x] Click a tile on the world map — verify green highlight persists
- [x] Move cursor away from selected tile — verify highlight stays
- [x] Click "New Game" button — verify world resets and returns to generation screen
- [x] Verify no console errors throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)