### PR TITLE
feat: skill-based task preferences and priorities UI

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -20,6 +20,7 @@ import { ensurePlayer } from "./lib/ensure-player";
 import { loadSession } from "./lib/load-session";
 import { supabase } from "./lib/supabase";
 import BuildMenu, { BUILD_OPTIONS } from "./components/BuildMenu";
+import TaskPriorities from "./components/TaskPriorities";
 import type { TaskType } from "@pwarf/shared";
 import {
   FORTRESS_MAX_Z,
@@ -66,6 +67,8 @@ export default function App() {
   // Designation mode
   const [designationMode, setDesignationMode] = useState<DesignationMode>("none");
   const [buildMenuOpen, setBuildMenuOpen] = useState(false);
+  const [prioritiesOpen, setPrioritiesOpen] = useState(false);
+  const [taskPriorities, setTaskPriorities] = useState<Record<string, number>>({});
 
   // Viewport size (reported from MainViewport)
   const [vpCols, setVpCols] = useState(120);
@@ -183,12 +186,21 @@ export default function App() {
         case "open_build_menu":
           if (mode === "fortress") {
             setDesignationMode("none");
+            setPrioritiesOpen(false);
             setBuildMenuOpen((o) => !o);
+          }
+          break;
+        case "open_priorities":
+          if (mode === "fortress") {
+            setDesignationMode("none");
+            setBuildMenuOpen(false);
+            setPrioritiesOpen((o) => !o);
           }
           break;
         case "cancel_designation":
           setDesignationMode("none");
           setBuildMenuOpen(false);
+          setPrioritiesOpen(false);
           break;
       }
     },
@@ -240,6 +252,7 @@ export default function App() {
     const isMine = designationMode === 'mine';
     const taskType = designationMode as TaskType;
     const workRequired = isMine ? WORK_MINE_BASE : (BUILD_WORK[designationMode] ?? WORK_BUILD_WALL);
+    const priority = taskPriorities[taskType] ?? 5;
 
     const tasks: Array<{
       civilization_id: string;
@@ -269,7 +282,7 @@ export default function App() {
           civilization_id: civId,
           task_type: taskType,
           status: 'pending',
-          priority: 5,
+          priority,
           target_x: x,
           target_y: y,
           target_z: zLevel,
@@ -284,11 +297,15 @@ export default function App() {
     if (error) {
       console.error('[designate] Failed to create tasks:', error.message);
     }
-  }, [designationMode, civId, zLevel, getFortressTile, designatedTiles]);
+  }, [designationMode, civId, zLevel, getFortressTile, designatedTiles, taskPriorities]);
 
   const handleBuildSelect = useCallback((taskType: TaskType) => {
     setBuildMenuOpen(false);
     setDesignationMode(taskType as DesignationMode);
+  }, []);
+
+  const handlePriorityChange = useCallback((taskType: TaskType, priority: number) => {
+    setTaskPriorities((prev) => ({ ...prev, [taskType]: priority }));
   }, []);
 
   // Keyboard shortcuts for build menu items when the menu is open
@@ -320,6 +337,8 @@ export default function App() {
     setMode("world");
     setDesignationMode("none");
     setBuildMenuOpen(false);
+    setPrioritiesOpen(false);
+    setTaskPriorities({});
     setSelectedWorldTile(null);
     setZLevel(0);
     viewport.setOffset(0, 0);
@@ -402,6 +421,13 @@ export default function App() {
           <BuildMenu
             onSelect={handleBuildSelect}
             onClose={() => setBuildMenuOpen(false)}
+          />
+        )}
+        {prioritiesOpen && (
+          <TaskPriorities
+            priorities={taskPriorities}
+            onChangePriority={handlePriorityChange}
+            onClose={() => setPrioritiesOpen(false)}
           />
         )}
         <LeftPanel

--- a/app/src/components/BottomBar.tsx
+++ b/app/src/components/BottomBar.tsx
@@ -47,6 +47,9 @@ export default function BottomBar({ mode, cursorX, cursorY, terrain, zLevel, for
             <span>
               <kbd className="text-[var(--amber)]">b</kbd> build
             </span>
+            <span>
+              <kbd className="text-[var(--amber)]">p</kbd> priorities
+            </span>
           </>
         )}
         <span>

--- a/app/src/components/LeftPanel.tsx
+++ b/app/src/components/LeftPanel.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type { WorldTile } from "@pwarf/shared";
 import type { LiveDwarf } from "../hooks/useDwarves";
 
@@ -15,8 +16,28 @@ function dwarfJobLabel(d: LiveDwarf): string {
   return "Idle";
 }
 
+function needBar(label: string, value: number, color: string) {
+  const pct = Math.round(value);
+  const barColor = value < 25 ? "var(--red, #f87171)" : color;
+  return (
+    <div className="flex items-center gap-1">
+      <span className="w-12 text-[var(--text)]">{label}</span>
+      <div className="flex-1 h-1.5 bg-[#333] rounded overflow-hidden">
+        <div
+          className="h-full rounded"
+          style={{ width: `${pct}%`, backgroundColor: barColor }}
+        />
+      </div>
+      <span className="w-6 text-right" style={{ color: barColor }}>{pct}</span>
+    </div>
+  );
+}
+
 export default function LeftPanel({ mode, collapsed, onToggle, cursorTile, onEmbark, dwarves = [] }: LeftPanelProps) {
   const isOcean = cursorTile?.terrain === "ocean";
+  const [selectedDwarfId, setSelectedDwarfId] = useState<string | null>(null);
+
+  const selectedDwarf = selectedDwarfId ? dwarves.find(d => d.id === selectedDwarfId) : null;
 
   return (
     <aside
@@ -33,27 +54,71 @@ export default function LeftPanel({ mode, collapsed, onToggle, cursorTile, onEmb
 
       {!collapsed && (
         <div className="px-2 pb-2 overflow-y-auto text-xs">
-          <h2 className="text-[var(--amber)] mb-1 font-bold">
-            {mode === "fortress" ? "Dwarves" : "Tile Info"}
-          </h2>
-
           {mode === "fortress" ? (
-            <ul className="space-y-0.5">
-              {dwarves.map((d) => (
-                <li
-                  key={d.id}
-                  className="flex justify-between hover:bg-[var(--bg-hover)] px-1"
-                >
-                  <span className="text-[var(--green)]">{d.name}</span>
-                  <span className="text-[var(--text)]">{dwarfJobLabel(d)}</span>
-                </li>
-              ))}
-              {dwarves.length === 0 && (
-                <li className="text-[var(--text)]">No dwarves</li>
-              )}
-            </ul>
+            selectedDwarf ? (
+              // Dwarf detail view
+              <div className="space-y-2">
+                <div className="flex items-center gap-1">
+                  <button
+                    onClick={() => setSelectedDwarfId(null)}
+                    className="text-[var(--amber)] hover:text-[var(--green)] cursor-pointer"
+                  >
+                    &larr;
+                  </button>
+                  <h2 className="text-[var(--green)] font-bold">
+                    {selectedDwarf.name}{selectedDwarf.surname ? ` ${selectedDwarf.surname}` : ""}
+                  </h2>
+                </div>
+
+                <div className="text-[var(--text)]">
+                  Status: <span className="text-[var(--green)]">{dwarfJobLabel(selectedDwarf)}</span>
+                </div>
+
+                <div className="text-[var(--text)]">
+                  Position: <span className="text-[var(--green)]">({selectedDwarf.position_x}, {selectedDwarf.position_y})</span>
+                </div>
+
+                <div className="border-t border-[var(--border)] pt-1 mt-1 space-y-1">
+                  <div className="text-[var(--amber)] font-bold mb-0.5">Needs</div>
+                  {needBar("Food", selectedDwarf.need_food, "var(--green)")}
+                  {needBar("Drink", selectedDwarf.need_drink, "#4488ff")}
+                  {needBar("Sleep", selectedDwarf.need_sleep, "#aa88ff")}
+                </div>
+
+                <div className="border-t border-[var(--border)] pt-1 mt-1">
+                  <div className="text-[var(--amber)] font-bold mb-0.5">Stress</div>
+                  {needBar("Stress", selectedDwarf.stress_level, "#ff6600")}
+                </div>
+
+                <div className="border-t border-[var(--border)] pt-1 mt-1">
+                  <div className="text-[var(--amber)] font-bold mb-0.5">Health</div>
+                  {needBar("HP", selectedDwarf.health, "var(--green)")}
+                </div>
+              </div>
+            ) : (
+              // Dwarf roster
+              <>
+                <h2 className="text-[var(--amber)] mb-1 font-bold">Dwarves</h2>
+                <ul className="space-y-0.5">
+                  {dwarves.map((d) => (
+                    <li
+                      key={d.id}
+                      className="flex justify-between hover:bg-[var(--bg-hover)] px-1 cursor-pointer"
+                      onClick={() => setSelectedDwarfId(d.id)}
+                    >
+                      <span className="text-[var(--green)]">{d.name}</span>
+                      <span className="text-[var(--text)]">{dwarfJobLabel(d)}</span>
+                    </li>
+                  ))}
+                  {dwarves.length === 0 && (
+                    <li className="text-[var(--text)]">No dwarves</li>
+                  )}
+                </ul>
+              </>
+            )
           ) : cursorTile ? (
             <div className="space-y-1">
+              <h2 className="text-[var(--amber)] mb-1 font-bold">Tile Info</h2>
               <p>
                 Terrain:{" "}
                 <span className="text-[var(--green)]">{cursorTile.terrain}</span>
@@ -91,6 +156,7 @@ export default function LeftPanel({ mode, collapsed, onToggle, cursorTile, onEmb
             </div>
           ) : (
             <div className="space-y-1 text-[var(--text)]">
+              <h2 className="text-[var(--amber)] mb-1 font-bold">Tile Info</h2>
               <p>Hover over a tile to see info</p>
             </div>
           )}

--- a/app/src/components/TaskPriorities.tsx
+++ b/app/src/components/TaskPriorities.tsx
@@ -1,0 +1,69 @@
+import type { TaskType } from "@pwarf/shared";
+
+/** Task types that can be player-designated (not autonomous) */
+const PRIORITY_TASK_TYPES: Array<{ label: string; taskType: TaskType }> = [
+  { label: "Mine", taskType: "mine" },
+  { label: "Haul", taskType: "haul" },
+  { label: "Farm (till)", taskType: "farm_till" },
+  { label: "Farm (plant)", taskType: "farm_plant" },
+  { label: "Farm (harvest)", taskType: "farm_harvest" },
+  { label: "Build Wall", taskType: "build_wall" },
+  { label: "Build Floor", taskType: "build_floor" },
+  { label: "Build Stairs Up", taskType: "build_stairs_up" },
+  { label: "Build Stairs Down", taskType: "build_stairs_down" },
+  { label: "Build Stairs Both", taskType: "build_stairs_both" },
+];
+
+interface TaskPrioritiesProps {
+  priorities: Record<string, number>;
+  onChangePriority: (taskType: TaskType, priority: number) => void;
+  onClose: () => void;
+}
+
+export default function TaskPriorities({ priorities, onChangePriority, onClose }: TaskPrioritiesProps) {
+  return (
+    <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-50 bg-[var(--bg-panel)] border border-[var(--amber)] p-3 min-w-[280px]">
+      <div className="flex justify-between items-center mb-2 border-b border-[var(--border)] pb-1">
+        <span className="text-[var(--amber)] font-bold text-sm">Task Priorities</span>
+        <button
+          onClick={onClose}
+          className="text-[var(--text)] hover:text-[var(--red,#f87171)] text-xs cursor-pointer"
+        >
+          [Esc]
+        </button>
+      </div>
+      <p className="text-[var(--text)] text-xs mb-2 opacity-60">
+        Higher priority tasks are claimed first (1–10)
+      </p>
+      <ul className="space-y-0.5">
+        {PRIORITY_TASK_TYPES.map(({ label, taskType }) => {
+          const value = priorities[taskType] ?? 5;
+          return (
+            <li key={taskType} className="flex items-center justify-between px-1 py-0.5 text-xs hover:bg-[var(--bg-hover)]">
+              <span className="text-[var(--text)]">{label}</span>
+              <div className="flex items-center gap-1">
+                <button
+                  onClick={() => onChangePriority(taskType, Math.max(1, value - 1))}
+                  className="text-[var(--amber)] hover:text-[var(--green)] cursor-pointer px-1"
+                  disabled={value <= 1}
+                >
+                  -
+                </button>
+                <span className={`w-4 text-center font-bold ${value >= 8 ? 'text-[var(--green)]' : value <= 3 ? 'text-[var(--red,#f87171)]' : 'text-[var(--text)]'}`}>
+                  {value}
+                </span>
+                <button
+                  onClick={() => onChangePriority(taskType, Math.min(10, value + 1))}
+                  className="text-[var(--amber)] hover:text-[var(--green)] cursor-pointer px-1"
+                  disabled={value >= 10}
+                >
+                  +
+                </button>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/app/src/hooks/useKeyboard.ts
+++ b/app/src/hooks/useKeyboard.ts
@@ -9,6 +9,7 @@ export type KeyAction =
   | { type: "z_down" }
   | { type: "designate_mine" }
   | { type: "open_build_menu" }
+  | { type: "open_priorities" }
   | { type: "cancel_designation" };
 
 export function useKeyboard(onAction: (action: KeyAction) => void) {
@@ -64,6 +65,9 @@ export function useKeyboard(onAction: (action: KeyAction) => void) {
           break;
         case "b":
           onAction({ type: "open_build_menu" });
+          break;
+        case "p":
+          onAction({ type: "open_priorities" });
           break;
         case "Escape":
           onAction({ type: "cancel_designation" });

--- a/app/src/lib/embark.ts
+++ b/app/src/lib/embark.ts
@@ -6,13 +6,13 @@ const FORTRESS_CENTER = Math.floor(FORTRESS_SIZE / 2);
 
 /** Starting dwarf roles with their skills */
 const STARTING_ROLES: { job: string; skills: string[] }[] = [
-  { job: 'Miner',      skills: ['mining'] },
-  { job: 'Miner',      skills: ['mining'] },
+  { job: 'Miner',      skills: ['mining', 'building'] },
+  { job: 'Miner',      skills: ['mining', 'building'] },
   { job: 'Farmer',     skills: ['farming'] },
   { job: 'Farmer',     skills: ['farming'] },
-  { job: 'Woodcutter', skills: [] },
-  { job: 'Mason',      skills: [] },
-  { job: 'Brewer',     skills: [] },
+  { job: 'Woodcutter', skills: ['building'] },
+  { job: 'Mason',      skills: ['building'] },
+  { job: 'Brewer',     skills: ['building'] },
 ];
 
 /** Offsets from fortress center for starting dwarf positions */

--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -169,3 +169,6 @@ export const XP_BUILD = 12;
 export const SCORE_PRIORITY_WEIGHT = 3;
 export const SCORE_SKILL_WEIGHT = 2;
 export const SCORE_DISTANCE_WEIGHT = 0.5;
+
+/** Bonus added when a task matches the dwarf's highest-level skill */
+export const SCORE_BEST_SKILL_BONUS = 5;

--- a/sim/src/__tests__/task-dispatch.test.ts
+++ b/sim/src/__tests__/task-dispatch.test.ts
@@ -22,7 +22,7 @@ import { jobClaiming } from "../phases/job-claiming.js";
 import { taskExecution } from "../phases/task-execution.js";
 import { needSatisfaction } from "../phases/need-satisfaction.js";
 import { stressUpdate } from "../phases/stress-update.js";
-import { createTask, isDwarfIdle } from "../task-helpers.js";
+import { createTask, isDwarfIdle, getBestSkill } from "../task-helpers.js";
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -848,5 +848,131 @@ describe("build tasks", () => {
     await taskExecution(ctx);
 
     expect(skill.xp).toBe(12); // XP_BUILD = 12
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getBestSkill tests
+// ---------------------------------------------------------------------------
+
+describe("getBestSkill", () => {
+  it("returns null for dwarf with no skills", () => {
+    expect(getBestSkill("dwarf-1", [])).toBeNull();
+  });
+
+  it("returns the highest-level skill", () => {
+    const skills = [
+      makeSkill("dwarf-1", "mining", 3),
+      makeSkill("dwarf-1", "farming", 7),
+      makeSkill("dwarf-1", "building", 1),
+    ];
+    expect(getBestSkill("dwarf-1", skills)).toBe("farming");
+  });
+
+  it("only considers skills belonging to the given dwarf", () => {
+    const skills = [
+      makeSkill("dwarf-1", "mining", 3),
+      makeSkill("dwarf-2", "mining", 10),
+    ];
+    expect(getBestSkill("dwarf-1", skills)).toBe("mining");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Skill preference tests
+// ---------------------------------------------------------------------------
+
+describe("skill-based task preferences", () => {
+  it("dwarf prefers task matching best skill over equidistant alternative", async () => {
+    const miner = makeDwarf({ position_x: 0, position_y: 0, position_z: 0 });
+    const skills = [
+      makeSkill(miner.id, "mining", 8),
+      makeSkill(miner.id, "building", 2),
+    ];
+    const ctx = makeContext({ dwarves: [miner], skills });
+
+    const buildTask = createTask(ctx.state, "civ-1", {
+      task_type: "build_wall",
+      priority: 5,
+      target_x: 5,
+      target_y: 0,
+      target_z: 0,
+    });
+    const mineTask = createTask(ctx.state, "civ-1", {
+      task_type: "mine",
+      priority: 5,
+      target_x: 5,
+      target_y: 0,
+      target_z: 0,
+    });
+
+    await jobClaiming(ctx);
+
+    // Miner's best skill is mining, so mine task should be preferred
+    expect(miner.current_task_id).toBe(mineTask.id);
+    expect(mineTask.status).toBe("claimed");
+    expect(buildTask.status).toBe("pending");
+  });
+
+  it("best skill bonus does not override large priority difference", async () => {
+    const dwarf = makeDwarf({ position_x: 0, position_y: 0, position_z: 0 });
+    const skills = [
+      makeSkill(dwarf.id, "mining", 5),
+      makeSkill(dwarf.id, "building", 0),
+    ];
+    const ctx = makeContext({ dwarves: [dwarf], skills });
+
+    // Build task with much higher priority
+    const buildTask = createTask(ctx.state, "civ-1", {
+      task_type: "build_wall",
+      priority: 10,
+      target_x: 5,
+      target_y: 0,
+      target_z: 0,
+    });
+    const mineTask = createTask(ctx.state, "civ-1", {
+      task_type: "mine",
+      priority: 1,
+      target_x: 5,
+      target_y: 0,
+      target_z: 0,
+    });
+
+    await jobClaiming(ctx);
+
+    // Priority difference of 9 (= 27 score points) overwhelms the best skill bonus (5)
+    expect(dwarf.current_task_id).toBe(buildTask.id);
+  });
+
+  it("two dwarves with different specializations pick matching tasks", async () => {
+    const miner = makeDwarf({ name: "Miner", position_x: 0, position_y: 0, position_z: 0 });
+    const builder = makeDwarf({ name: "Builder", position_x: 0, position_y: 0, position_z: 0 });
+    const skills = [
+      makeSkill(miner.id, "mining", 8),
+      makeSkill(miner.id, "building", 1),
+      makeSkill(builder.id, "mining", 1),
+      makeSkill(builder.id, "building", 8),
+    ];
+    const ctx = makeContext({ dwarves: [miner, builder], skills });
+
+    const mineTask = createTask(ctx.state, "civ-1", {
+      task_type: "mine",
+      priority: 5,
+      target_x: 5,
+      target_y: 0,
+      target_z: 0,
+    });
+    const buildTask = createTask(ctx.state, "civ-1", {
+      task_type: "build_wall",
+      priority: 5,
+      target_x: 5,
+      target_y: 0,
+      target_z: 0,
+    });
+
+    await jobClaiming(ctx);
+
+    expect(miner.current_task_id).toBe(mineTask.id);
+    expect(builder.current_task_id).toBe(buildTask.id);
   });
 });

--- a/sim/src/phases/job-claiming.ts
+++ b/sim/src/phases/job-claiming.ts
@@ -2,6 +2,7 @@ import {
   SCORE_PRIORITY_WEIGHT,
   SCORE_SKILL_WEIGHT,
   SCORE_DISTANCE_WEIGHT,
+  SCORE_BEST_SKILL_BONUS,
 } from "@pwarf/shared";
 import type { Dwarf, Task } from "@pwarf/shared";
 import type { SimContext } from "../sim-context.js";
@@ -11,6 +12,7 @@ import {
   getDwarfSkillLevel,
   getRequiredSkill,
   isAutonomousTask,
+  getBestSkill,
 } from "../task-helpers.js";
 import { manhattanDistance } from "../pathfinding.js";
 
@@ -74,8 +76,14 @@ function scoreTask(dwarf: Dwarf, task: Task, skills: SimContext['state']['dwarfS
       )
     : 0;
 
+  // Bonus when the task matches the dwarf's best skill — makes specialists gravitate
+  // toward their specialty even when a different task is slightly closer.
+  const bestSkill = getBestSkill(dwarf.id, skills);
+  const bestSkillBonus = (requiredSkill && bestSkill === requiredSkill) ? SCORE_BEST_SKILL_BONUS : 0;
+
   return (task.priority * SCORE_PRIORITY_WEIGHT)
     + (skillLevel * SCORE_SKILL_WEIGHT)
+    + bestSkillBonus
     - (distance * SCORE_DISTANCE_WEIGHT);
 }
 

--- a/sim/src/task-helpers.ts
+++ b/sim/src/task-helpers.ts
@@ -50,6 +50,19 @@ export function isAutonomousTask(taskType: TaskType): boolean {
   return AUTONOMOUS_TASKS.has(taskType);
 }
 
+/** Get the skill name a dwarf is best at (highest level). Returns null if dwarf has no skills. */
+export function getBestSkill(dwarfId: string, skills: DwarfSkill[]): string | null {
+  let best: string | null = null;
+  let bestLevel = -1;
+  for (const s of skills) {
+    if (s.dwarf_id === dwarfId && s.level > bestLevel) {
+      bestLevel = s.level;
+      best = s.skill_name;
+    }
+  }
+  return best;
+}
+
 /** Create a new task and add it to the cached state. */
 export function createTask(
   state: CachedState,


### PR DESCRIPTION
## Summary
- **Skill-based task preferences** (#221): Dwarves get a scoring bonus (+5) when a task matches their highest-level skill. Specialists gravitate toward their specialty.
- **Task priorities UI** (#220): Press `p` in fortress mode to adjust default priority (1–10) per task type. Higher priority tasks are claimed first.
- **Dwarf detail panel**: Click a dwarf name in the left panel to see needs (food/drink/sleep), stress, health, position, and status with color-coded progress bars. Back arrow returns to roster.
- **Building skill fix** (#224): Dwarves now start with the `building` skill at embark so they can actually execute build tasks.

Closes #220, closes #221, closes #224

## Playtest report

Tested locally at `localhost:5175`:

1. **Task Priorities panel** — Pressed `p`, panel shows all task types with adjustable priority. Color-coded: green (8+), white (mid), red (3-). ✅
2. **Dwarf detail panel** — Clicked dwarf name, saw full name, status, position, needs bars (food red when low), stress bar, health bar. Back arrow returns to roster. ✅
3. **Building fix** — After New Game, designated walls. Dwarves immediately started building. Log shows "begins build wall" / "finished build wall". ✅
4. **Skill preferences** — Verified via unit tests: specialists pick matching tasks, but priority still overrides when large enough. ✅
5. **No console errors** during gameplay. ✅

## Test plan
- [x] `getBestSkill` returns highest-level skill for dwarf
- [x] Dwarf prefers task matching best skill over equidistant alternative
- [x] Best skill bonus doesn't override large priority difference
- [x] Two specialists pick their matching tasks
- [x] Press `p` opens/closes priorities panel with +/- controls
- [x] Click dwarf name shows detail view with needs/stress/health bars
- [x] Dwarves can build walls after fresh embark
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)