### PR TITLE
feat: generate surface features on fortress z=0 (closes #226)

### DIFF
--- a/app/src/components/MainViewport.tsx
+++ b/app/src/components/MainViewport.tsx
@@ -36,6 +36,11 @@ const CHAR_H = 18;
 // --- Fortress tile glyph map ---
 const FORTRESS_GLYPHS: Record<FortressTileType, { ch: string; fg: string }> = {
   open_air:           { ch: ".",  fg: "#446" },
+  grass:              { ch: ".",  fg: "#4a8b3f" },
+  tree:               { ch: "\u2663", fg: "#228B22" },
+  rock:               { ch: "\u2022", fg: "#999" },
+  bush:               { ch: "\u2698", fg: "#5a9b40" },
+  pond:               { ch: "~",  fg: "#5599dd" },
   soil:               { ch: "\u2592", fg: "#8B6914" },
   stone:              { ch: "\u2593", fg: "#888" },
   ore:                { ch: "$",  fg: "#ffbf00" },

--- a/shared/src/db-types.ts
+++ b/shared/src/db-types.ts
@@ -172,6 +172,11 @@ export type TaskStatus =
 
 export type FortressTileType =
   | 'open_air'
+  | 'grass'
+  | 'tree'
+  | 'rock'
+  | 'bush'
+  | 'pond'
   | 'soil'
   | 'stone'
   | 'ore'

--- a/shared/src/fortress-gen-helpers.test.ts
+++ b/shared/src/fortress-gen-helpers.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect } from "vitest";
 import {
   createFortressDeriver,
+  deriveSurfaceTile,
   FORTRESS_MIN_Z,
   FORTRESS_MAX_Z,
 } from "./fortress-gen-helpers.js";
+import { createNoise2D } from "simplex-noise";
+import { createAleaRng } from "./world-gen-helpers.js";
 
 const SEED = 42n;
 const CIV_ID = "test-civ-001";
@@ -59,17 +62,28 @@ describe("createFortressDeriver", () => {
     expect(differences).toBeGreaterThan(0);
   });
 
-  it("z=0 is always open_air", () => {
+  it("z=0 has surface features (grass, tree, rock, bush, pond) or stairs", () => {
     const d = createFortressDeriver(SEED, CIV_ID);
+    const surfaceTypes = new Set(["grass", "tree", "rock", "bush", "pond", "stair_down"]);
     for (let x = 0; x < 50; x++) {
       for (let y = 0; y < 50; y++) {
         const tile = d.deriveTile(x, y, 0);
-        // Stairs are allowed at z=0
-        if (tile.tileType !== "stair_down") {
-          expect(tile.tileType).toBe("open_air");
-        }
+        expect(surfaceTypes.has(tile.tileType)).toBe(true);
       }
     }
+  });
+
+  it("z=0 surface has variety (at least 3 different tile types)", () => {
+    const d = createFortressDeriver(SEED, CIV_ID);
+    const tileTypes = new Set<string>();
+    for (let x = 0; x < 200; x += 2) {
+      for (let y = 0; y < 200; y += 2) {
+        const tile = d.deriveTile(x, y, 0);
+        tileTypes.add(tile.tileType);
+      }
+    }
+    // Should have at least grass, tree, and one more type
+    expect(tileTypes.size).toBeGreaterThanOrEqual(3);
   });
 
   it("z=-19 is magma or lava_stone (or stairs/ore)", () => {
@@ -183,5 +197,69 @@ describe("createFortressDeriver", () => {
     const d = createFortressDeriver(SEED, CIV_ID);
     expect(d.deriveTile(100, 100, 1).tileType).toBe("empty");
     expect(d.deriveTile(100, 100, -20).tileType).toBe("empty");
+  });
+
+  it("tree tiles have wood material", () => {
+    const d = createFortressDeriver(SEED, CIV_ID);
+    for (let x = 0; x < 300; x += 3) {
+      for (let y = 0; y < 300; y += 3) {
+        const tile = d.deriveTile(x, y, 0);
+        if (tile.tileType === "tree") {
+          expect(tile.material).toBe("wood");
+        }
+      }
+    }
+  });
+
+  it("rock tiles have stone material", () => {
+    const d = createFortressDeriver(SEED, CIV_ID);
+    for (let x = 0; x < 300; x += 3) {
+      for (let y = 0; y < 300; y += 3) {
+        const tile = d.deriveTile(x, y, 0);
+        if (tile.tileType === "rock") {
+          expect(tile.material).toBe("stone");
+        }
+      }
+    }
+  });
+});
+
+describe("deriveSurfaceTile", () => {
+  it("is deterministic for same noise functions", () => {
+    const rng1 = createAleaRng(42n);
+    const rng2 = createAleaRng(42n);
+    const tree1 = createNoise2D(rng1);
+    const rock1 = createNoise2D(rng1);
+    const pond1 = createNoise2D(rng1);
+    const tree2 = createNoise2D(rng2);
+    const rock2 = createNoise2D(rng2);
+    const pond2 = createNoise2D(rng2);
+
+    for (let x = 0; x < 50; x++) {
+      for (let y = 0; y < 50; y++) {
+        const t1 = deriveSurfaceTile(x, y, tree1, rock1, pond1);
+        const t2 = deriveSurfaceTile(x, y, tree2, rock2, pond2);
+        expect(t1.tileType).toBe(t2.tileType);
+        expect(t1.material).toBe(t2.material);
+      }
+    }
+  });
+
+  it("produces all expected tile types over a large area", () => {
+    const rng = createAleaRng(42n);
+    const treeN = createNoise2D(rng);
+    const rockN = createNoise2D(rng);
+    const pondN = createNoise2D(rng);
+
+    const types = new Set<string>();
+    for (let x = 0; x < 512; x += 2) {
+      for (let y = 0; y < 512; y += 2) {
+        types.add(deriveSurfaceTile(x, y, treeN, rockN, pondN).tileType);
+      }
+    }
+    expect(types.has("grass")).toBe(true);
+    expect(types.has("tree")).toBe(true);
+    expect(types.has("rock")).toBe(true);
+    // bush and pond may or may not appear with this seed, but grass/tree/rock are guaranteed
   });
 });

--- a/shared/src/fortress-gen-helpers.ts
+++ b/shared/src/fortress-gen-helpers.ts
@@ -262,6 +262,9 @@ export function createFortressDeriver(
   const magmaIslandNoise = createNoise2D(rng);
   const magmaPipeNoise = createNoise2D(rng);
   const stairNoise = createNoise2D(rng);
+  const surfaceTreeNoise = createNoise2D(rng);
+  const surfaceRockNoise = createNoise2D(rng);
+  const surfacePondNoise = createNoise2D(rng);
 
   // Per-material noise
   const materialNoises: NoiseFunction2D[] = MATERIALS.map(() => createNoise2D(rng));
@@ -313,9 +316,9 @@ export function createFortressDeriver(
         return { tileType: stairType, material: null };
       }
 
-      // z=0: Surface (open air)
+      // z=0: Surface with features (trees, rocks, grass, bushes, ponds)
       if (z === 0) {
-        return { tileType: "open_air", material: null };
+        return deriveSurfaceTile(x, y, surfaceTreeNoise, surfaceRockNoise, surfacePondNoise);
       }
 
       // z=-19: Magma sea
@@ -386,6 +389,46 @@ export function createFortressDeriver(
       return { tileType: "stone", material: null };
     },
   };
+}
+
+// ============================================================
+// Surface feature generation (z=0)
+// ============================================================
+
+export function deriveSurfaceTile(
+  x: number,
+  y: number,
+  treeNoise: NoiseFunction2D,
+  rockNoise: NoiseFunction2D,
+  pondNoise: NoiseFunction2D,
+): DerivedFortressTile {
+  // Ponds: small clusters using high-frequency noise
+  const pondVal = (pondNoise(x * 0.04, y * 0.04) + 1) / 2;
+  const pondRegion = (pondNoise(x * 0.008 + 300, y * 0.008 + 300) + 1) / 2;
+  if (pondRegion > 0.65 && pondVal > 0.75) {
+    return { tileType: "pond", material: null };
+  }
+
+  // Trees: dense forests using low-frequency for regions, high for individual placement
+  const treeRegion = (treeNoise(x * 0.006, y * 0.006) + 1) / 2;
+  const treeDetail = (treeNoise(x * 0.08 + 500, y * 0.08 + 500) + 1) / 2;
+  if (treeRegion > 0.45 && treeDetail > 0.55) {
+    return { tileType: "tree", material: "wood" };
+  }
+
+  // Bushes: appear at forest edges (moderate tree region)
+  if (treeRegion > 0.35 && treeRegion < 0.55 && treeDetail > 0.7) {
+    return { tileType: "bush", material: null };
+  }
+
+  // Rocks: scattered boulders, slightly clustered
+  const rockVal = (rockNoise(x * 0.05, y * 0.05) + 1) / 2;
+  if (rockVal > 0.88) {
+    return { tileType: "rock", material: "stone" };
+  }
+
+  // Default: grass
+  return { tileType: "grass", material: null };
 }
 
 function checkMaterial(

--- a/supabase/migrations/00007_surface_tile_types.sql
+++ b/supabase/migrations/00007_surface_tile_types.sql
@@ -1,0 +1,6 @@
+-- Add surface feature tile types to fortress_tile_type enum (issue #226)
+alter type fortress_tile_type add value if not exists 'grass';
+alter type fortress_tile_type add value if not exists 'tree';
+alter type fortress_tile_type add value if not exists 'rock';
+alter type fortress_tile_type add value if not exists 'bush';
+alter type fortress_tile_type add value if not exists 'pond';


### PR DESCRIPTION
## Summary
- Add procedural surface features to fortress z=0 level: grass, trees, rocks, bushes, and ponds
- Trees form forest clusters using low-frequency noise regions with high-frequency detail placement
- Bushes appear at forest edges, rocks scatter randomly, ponds form small water clusters
- New tile types added to `FortressTileType` enum and Postgres migration applied
- Added glyphs: grass (green `.`), tree (green `♣`), rock (gray `•`), bush (olive `⚘`), pond (blue `~`)

## Playtest
Tested in Chrome at localhost:5176. Surface renders with natural-looking terrain variety:
- Forest regions with tree clusters and bush edges
- Scattered rock boulders across grassland
- Pond clusters forming small water features
- No console errors
- All 66 tests pass

## Test plan
- [x] All existing fortress gen tests pass
- [x] New tests verify surface tile variety and determinism
- [x] Tree tiles have `wood` material, rock tiles have `stone` material
- [x] `deriveSurfaceTile` is deterministic for same noise inputs
- [x] TypeScript builds clean across all workspaces
- [x] Visual playtest confirms varied surface rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)