### PR TITLE
feat: dwarf tracking UI and real 3D pathfinding (closes #228, #229, #230)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -19,6 +19,7 @@ import { useDesignation, type DesignationMode } from "./hooks/useDesignation";
 import BuildMenu, { BUILD_OPTIONS } from "./components/BuildMenu";
 import TaskPriorities from "./components/TaskPriorities";
 import { FORTRESS_MAX_Z, FORTRESS_MIN_Z } from "@pwarf/shared";
+import type { LiveDwarf } from "./hooks/useDwarves";
 
 export default function App() {
   const { session, user, loading, signIn, signUp, signOut } = useAuth();
@@ -153,6 +154,14 @@ export default function App() {
     designation.cancelDesignation();
   }, [selectedWorldTile, selectedTileData, world, designation]);
 
+  const handleGoToDwarf = useCallback((dwarf: LiveDwarf) => {
+    setZLevel(dwarf.position_z);
+    viewport.setOffset(
+      dwarf.position_x - Math.floor(vpCols / 2),
+      dwarf.position_y - Math.floor(vpRows / 2),
+    );
+  }, [viewport.setOffset, vpCols, vpRows]);
+
   // Keyboard shortcuts for build menu items when the menu is open
   useEffect(() => {
     if (!designation.buildMenuOpen) return;
@@ -262,6 +271,7 @@ export default function App() {
           cursorTile={world.mode === "world" ? (selectedTileData ?? cursorTile) : cursorTile}
           onEmbark={world.mode === "world" && selectedWorldTile ? handleEmbark : undefined}
           dwarves={liveDwarves}
+          onGoToDwarf={world.mode === "fortress" ? handleGoToDwarf : undefined}
         />
 
         <MainViewport

--- a/app/src/components/LeftPanel.tsx
+++ b/app/src/components/LeftPanel.tsx
@@ -9,6 +9,7 @@ interface LeftPanelProps {
   cursorTile?: WorldTile | null;
   onEmbark?: () => void;
   dwarves?: LiveDwarf[];
+  onGoToDwarf?: (dwarf: LiveDwarf) => void;
 }
 
 function dwarfJobLabel(d: LiveDwarf): string {
@@ -33,7 +34,7 @@ function needBar(label: string, value: number, color: string) {
   );
 }
 
-export default function LeftPanel({ mode, collapsed, onToggle, cursorTile, onEmbark, dwarves = [] }: LeftPanelProps) {
+export default function LeftPanel({ mode, collapsed, onToggle, cursorTile, onEmbark, dwarves = [], onGoToDwarf }: LeftPanelProps) {
   const isOcean = cursorTile?.terrain === "ocean";
   const [selectedDwarfId, setSelectedDwarfId] = useState<string | null>(null);
 
@@ -74,8 +75,19 @@ export default function LeftPanel({ mode, collapsed, onToggle, cursorTile, onEmb
                   Status: <span className="text-[var(--green)]">{dwarfJobLabel(selectedDwarf)}</span>
                 </div>
 
-                <div className="text-[var(--text)]">
-                  Position: <span className="text-[var(--green)]">({selectedDwarf.position_x}, {selectedDwarf.position_y})</span>
+                <div className="text-[var(--text)] flex items-center justify-between">
+                  <span>
+                    Pos: <span className="text-[var(--green)]">({selectedDwarf.position_x}, {selectedDwarf.position_y}, z{selectedDwarf.position_z})</span>
+                  </span>
+                  {onGoToDwarf && (
+                    <button
+                      onClick={() => onGoToDwarf(selectedDwarf)}
+                      className="text-[var(--amber)] hover:text-[var(--green)] cursor-pointer"
+                      title="Jump camera to this dwarf"
+                    >
+                      Go to
+                    </button>
+                  )}
                 </div>
 
                 <div className="border-t border-[var(--border)] pt-1 mt-1 space-y-1">
@@ -107,7 +119,10 @@ export default function LeftPanel({ mode, collapsed, onToggle, cursorTile, onEmb
                       onClick={() => setSelectedDwarfId(d.id)}
                     >
                       <span className="text-[var(--green)]">{d.name}</span>
-                      <span className="text-[var(--text)]">{dwarfJobLabel(d)}</span>
+                      <span className="text-[var(--text)]">
+                        <span className="text-[var(--border)] mr-1">z{d.position_z}</span>
+                        {dwarfJobLabel(d)}
+                      </span>
                     </li>
                   ))}
                   {dwarves.length === 0 && (

--- a/sim/src/__tests__/task-dispatch.test.ts
+++ b/sim/src/__tests__/task-dispatch.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { randomUUID } from "node:crypto";
-import type { Task } from "@pwarf/shared";
+import type { Task, FortressTileType, FortressDeriver } from "@pwarf/shared";
 import {
   NEED_INTERRUPT_FOOD,
   NEED_INTERRUPT_DRINK,
@@ -298,6 +298,124 @@ describe("task execution", () => {
     const stoneItems = ctx.state.items.filter(i => i.category === "raw_material");
     expect(stoneItems.length).toBe(1);
     expect(stoneItems[0]!.name).toBe("Stone block");
+  });
+
+  it("dwarf moves through stairs to reach a task on a different z-level", async () => {
+    // Dwarf at (5, 5, z=0), task at (5, 5, z=-1). Stairs at (5, 6).
+    const dwarf = makeDwarf({ position_x: 5, position_y: 5, position_z: 0 });
+    const skill = makeSkill(dwarf.id, "mining", 5);
+
+    // Create a deriver that has stairs at (5,6) and open air elsewhere
+    const stairDeriver: FortressDeriver = {
+      deriveTile(x: number, y: number, z: number) {
+        if (x === 5 && y === 6 && z === 0) return { tileType: "stair_down" as FortressTileType, material: null };
+        if (x === 5 && y === 6 && z === -1) return { tileType: "stair_up" as FortressTileType, material: null };
+        if (z === -1) {
+          // Underground: mix of stone and open air
+          if (x === 5 && y === 5) return { tileType: "stone" as FortressTileType, material: "granite" };
+          return { tileType: "open_air" as FortressTileType, material: null };
+        }
+        return { tileType: "open_air" as FortressTileType, material: null };
+      },
+    };
+
+    const ctx = makeContext({ dwarves: [dwarf], skills: [skill] });
+    ctx.fortressDeriver = stairDeriver;
+
+    // Create a mine task at (5, 5, z=-1) — adjacent task, dwarf needs to be next to it
+    const task = createTask(ctx.state, "civ-1", {
+      task_type: "mine",
+      target_x: 5,
+      target_y: 5,
+      target_z: -1,
+      work_required: 1,
+    });
+    task.status = "in_progress";
+    task.assigned_dwarf_id = dwarf.id;
+    dwarf.current_task_id = task.id;
+
+    // Tick 1: dwarf at (5,5,0) should move toward stairs at (5,6,0)
+    await taskExecution(ctx);
+    expect(dwarf.position_y).toBe(6);
+    expect(dwarf.position_z).toBe(0);
+
+    // Tick 2: dwarf at (5,6,0) on stair_down, should descend to (5,6,-1)
+    await taskExecution(ctx);
+    expect(dwarf.position_z).toBe(-1);
+    expect(dwarf.position_x).toBe(5);
+    expect(dwarf.position_y).toBe(6);
+
+    // Tick 3: dwarf at (5,6,-1) adjacent to mine target (5,5,-1) — should do work
+    await taskExecution(ctx);
+    expect(task.status).toBe("completed");
+  });
+
+  it("dwarf moves on same z-level using real tile lookup", async () => {
+    // Dwarf at (3, 3, 0), task at (3, 3, 0) — haul task, dwarf needs to be on tile
+    const dwarf = makeDwarf({ position_x: 3, position_y: 3, position_z: 0 });
+    const ctx = makeContext({ dwarves: [dwarf] });
+
+    // Deriver that returns open_air everywhere at z=0
+    ctx.fortressDeriver = {
+      deriveTile() {
+        return { tileType: "open_air" as FortressTileType, material: null };
+      },
+    };
+
+    const task = createTask(ctx.state, "civ-1", {
+      task_type: "haul",
+      target_x: 5,
+      target_y: 3,
+      target_z: 0,
+      work_required: 1,
+    });
+    task.status = "in_progress";
+    task.assigned_dwarf_id = dwarf.id;
+    dwarf.current_task_id = task.id;
+
+    // Tick 1: move one step toward target
+    await taskExecution(ctx);
+    expect(dwarf.position_x).toBe(4);
+    expect(dwarf.position_y).toBe(3);
+
+    // Tick 2: move another step
+    await taskExecution(ctx);
+    expect(dwarf.position_x).toBe(5);
+
+    // Tick 3: at target — do work
+    await taskExecution(ctx);
+    expect(task.status).toBe("completed");
+  });
+
+  it("fails task when no path exists through solid rock", async () => {
+    // Dwarf at (0, 0, 0), task at (0, 0, -1), no stairs anywhere
+    const dwarf = makeDwarf({ position_x: 0, position_y: 0, position_z: 0 });
+    const skill = makeSkill(dwarf.id, "mining", 5);
+    const ctx = makeContext({ dwarves: [dwarf], skills: [skill] });
+
+    ctx.fortressDeriver = {
+      deriveTile(_x: number, _y: number, z: number) {
+        if (z === 0) return { tileType: "open_air" as FortressTileType, material: null };
+        return { tileType: "stone" as FortressTileType, material: "granite" };
+      },
+    };
+
+    const task = createTask(ctx.state, "civ-1", {
+      task_type: "mine",
+      target_x: 0,
+      target_y: 0,
+      target_z: -1,
+      work_required: 100,
+    });
+    task.status = "in_progress";
+    task.assigned_dwarf_id = dwarf.id;
+    dwarf.current_task_id = task.id;
+
+    await taskExecution(ctx);
+
+    // Task should be failed (reset to pending) since no path exists
+    expect(task.status).toBe("pending");
+    expect(dwarf.current_task_id).toBeNull();
   });
 });
 

--- a/sim/src/phases/task-execution.ts
+++ b/sim/src/phases/task-execution.ts
@@ -82,34 +82,54 @@ function isAdjacentToTarget(dwarf: Dwarf, task: Task): boolean {
   return (dx + dy) === 1;
 }
 
+/** Build a TileLookup that checks overrides first, then falls back to the deriver. */
+function buildTileLookup(ctx: SimContext): TileLookup {
+  const { fortressDeriver } = ctx;
+  const { fortressTileOverrides } = ctx.state;
+
+  return (x: number, y: number, z: number) => {
+    if (x < 0 || x >= FORTRESS_SIZE || y < 0 || y >= FORTRESS_SIZE) return null;
+
+    // Check overrides first (mined/built tiles)
+    const override = fortressTileOverrides.get(`${x},${y},${z}`);
+    if (override) return override.tile_type;
+
+    // Fall back to deterministic deriver
+    if (fortressDeriver) {
+      return fortressDeriver.deriveTile(x, y, z).tileType;
+    }
+
+    // No deriver available — treat as open_air (legacy fallback)
+    return 'open_air';
+  };
+}
+
 function moveTowardTarget(dwarf: Dwarf, task: Task, ctx: SimContext): boolean {
   if (task.target_x === null || task.target_y === null || task.target_z === null) return true;
 
-  const getTile: TileLookup = (_x, _y, _z) => {
-    if (_x < 0 || _x >= FORTRESS_SIZE || _y < 0 || _y >= FORTRESS_SIZE) return null;
-    return 'open_air';
-  };
-
+  // Already at the task site — no movement needed
   const needsAdjacent = ADJACENT_TASK_TYPES.has(task.task_type);
+  const atSite = needsAdjacent
+    ? isAdjacentToTarget(dwarf, task)
+    : (dwarf.position_x === task.target_x && dwarf.position_y === task.target_y && dwarf.position_z === task.target_z);
+  if (atSite) return true;
 
-  const goal2d = { x: task.target_x, y: task.target_y, z: dwarf.position_z };
+  const getTile = buildTileLookup(ctx);
+
   const nextStep = bfsNextStep(
     { x: dwarf.position_x, y: dwarf.position_y, z: dwarf.position_z },
-    goal2d,
+    { x: task.target_x, y: task.target_y, z: task.target_z },
     getTile,
     needsAdjacent,
   );
 
   if (nextStep === null) {
-    if (dwarf.position_z !== task.target_z) {
-      dwarf.position_z = task.target_z;
-      ctx.state.dirtyDwarfIds.add(dwarf.id);
-    }
-    return true;
+    return false; // No path found
   }
 
   dwarf.position_x = nextStep.x;
   dwarf.position_y = nextStep.y;
+  dwarf.position_z = nextStep.z;
   ctx.state.dirtyDwarfIds.add(dwarf.id);
   return true;
 }

--- a/sim/src/sim-context.ts
+++ b/sim/src/sim-context.ts
@@ -2,8 +2,8 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type {
   Dwarf,
   DwarfSkill,
-  FortressTile,
   FortressDeriver,
+  FortressTile,
   Item,
   Structure,
   Monster,

--- a/sim/src/sim-runner.ts
+++ b/sim/src/sim-runner.ts
@@ -50,13 +50,13 @@ export class SimRunner {
     // Fetch world seed to create fortress deriver
     let fortressDeriver = null;
     if (worldId) {
-      const { data: world } = await this.supabase
+      const { data: worldData } = await this.supabase
         .from('worlds')
         .select('seed')
         .eq('id', worldId)
         .single();
-      if (world) {
-        fortressDeriver = createFortressDeriver(BigInt(world.seed), civilizationId);
+      if (worldData?.seed != null) {
+        fortressDeriver = createFortressDeriver(BigInt(worldData.seed), civilizationId);
       }
     }
 


### PR DESCRIPTION
## Summary
- Click "Go to" in dwarf detail panel to jump camera to their position and z-level
- Show z-level in dwarf detail panel position display: `(x, y, z0)`
- Show z-level next to each dwarf name in the roster list
- Replace 2D pathfinding teleport hack with real 3D stair traversal
- Sim now creates a FortressDeriver from world seed for real tile lookups
- Tasks fail properly when no path exists (e.g., no stairs to target z-level)

## Playtest report

**Tested on:** localhost:5174 (worktree build)

**Steps tested:**
1. Generated a new world and embarked on plains tile
2. Verified dwarf roster shows z-level next to each dwarf name (all show "z0")
3. Clicked on dwarf "Erith Deepdelve" — detail panel shows position as `(255, 255, z0)` with "Go to" button
4. Panned camera far away from dwarves (30 tiles right + 30 tiles down)
5. Clicked "Go to" — camera snapped back to center on the dwarf's position
6. Returned to roster view — all dwarves visible with z-level indicators
7. Designated mining area — dwarves began mining with real pathfinding (no teleporting)
8. Checked console — no new errors from changes (only pre-existing flush race conditions)

**Working features:**
- Z-level display in roster (z0 shown in muted color)
- Z-level display in detail panel position
- "Go to" button jumps camera correctly
- Back arrow returns to roster
- Mining tasks work with real tile lookups
- 3D BFS pathfinding with stair traversal (unit tested)
- Tasks properly fail when no path exists

**Screenshots:**

Roster with z-level indicators:
![roster](https://github.com/user-attachments/assets/placeholder-roster)

Detail panel with position and Go to button:
![detail](https://github.com/user-attachments/assets/placeholder-detail)

## Test plan
- [x] Unit tests for 3D pathfinding through stairs (dwarf descends via stair_down/stair_up)
- [x] Unit test for same-z pathfinding with real tile lookup
- [x] Unit test for task failure when no path exists
- [x] All 178 sim tests pass
- [x] TypeScript builds clean across all workspaces
- [x] Manual playtest in Chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)