### PR TITLE
feat: allow building on grass and mining surface features (closes #232)

### DIFF
--- a/app/src/hooks/useDesignation.ts
+++ b/app/src/hooks/useDesignation.ts
@@ -2,6 +2,9 @@ import { useState, useCallback } from "react";
 import type { TaskType } from "@pwarf/shared";
 import {
   WORK_MINE_BASE,
+  WORK_CHOP_TREE,
+  WORK_CLEAR_ROCK,
+  WORK_CLEAR_BUSH,
   WORK_BUILD_WALL,
   WORK_BUILD_FLOOR,
   WORK_BUILD_STAIRS,
@@ -35,11 +38,11 @@ export function useDesignation(opts: {
   const handleDesignateArea = useCallback(async (x1: number, y1: number, x2: number, y2: number) => {
     if (designationMode === 'none' || !civId) return;
 
-    const mineable: string[] = ['stone', 'ore', 'gem', 'soil', 'cavern_wall'];
-    const buildable: string[] = ['open_air', 'constructed_floor', 'cavern_floor'];
+    const mineable: string[] = ['stone', 'ore', 'gem', 'soil', 'cavern_wall', 'tree', 'rock', 'bush'];
+    const buildable: string[] = ['open_air', 'grass', 'constructed_floor', 'cavern_floor'];
     const isMine = designationMode === 'mine';
     const taskType = designationMode as TaskType;
-    const workRequired = isMine ? WORK_MINE_BASE : (BUILD_WORK[designationMode] ?? WORK_BUILD_WALL);
+    const baseBuildWork = BUILD_WORK[designationMode] ?? WORK_BUILD_WALL;
     const priority = taskPriorities[taskType] ?? 5;
 
     const tasks: Array<{
@@ -64,6 +67,16 @@ export function useDesignation(opts: {
           if (!mineable.includes(tile.tileType)) continue;
         } else {
           if (!buildable.includes(tile.tileType)) continue;
+        }
+
+        let workRequired = baseBuildWork;
+        if (isMine) {
+          switch (tile.tileType) {
+            case 'tree': workRequired = WORK_CHOP_TREE; break;
+            case 'rock': workRequired = WORK_CLEAR_ROCK; break;
+            case 'bush': workRequired = WORK_CLEAR_BUSH; break;
+            default: workRequired = WORK_MINE_BASE; break;
+          }
         }
 
         tasks.push({

--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -112,6 +112,15 @@ export const FLOOR_SLEEP_STRESS = 5;
 /** Base work required to mine a tile */
 export const WORK_MINE_BASE = 100;
 
+/** Work required to chop a tree */
+export const WORK_CHOP_TREE = 60;
+
+/** Work required to clear a rock */
+export const WORK_CLEAR_ROCK = 40;
+
+/** Work required to clear a bush */
+export const WORK_CLEAR_BUSH = 20;
+
 /** Base work required to haul an item */
 export const WORK_HAUL_BASE = 20;
 

--- a/sim/src/__tests__/mine-product.test.ts
+++ b/sim/src/__tests__/mine-product.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { getMineProduct } from "../phases/task-completion.js";
+
+describe("getMineProduct", () => {
+  it("tree produces wood log", () => {
+    const result = getMineProduct("tree");
+    expect(result.itemName).toBe("Wood log");
+    expect(result.itemMaterial).toBe("wood");
+  });
+
+  it("rock produces stone block", () => {
+    const result = getMineProduct("rock");
+    expect(result.itemName).toBe("Stone block");
+    expect(result.itemMaterial).toBe("stone");
+  });
+
+  it("bush produces nothing", () => {
+    const result = getMineProduct("bush");
+    expect(result.itemName).toBeNull();
+  });
+
+  it("stone produces stone block", () => {
+    const result = getMineProduct("stone");
+    expect(result.itemName).toBe("Stone block");
+    expect(result.itemMaterial).toBe("stone");
+  });
+
+  it("ore produces stone block (default)", () => {
+    const result = getMineProduct("ore");
+    expect(result.itemName).toBe("Stone block");
+  });
+
+  it("null tile type produces stone block (default)", () => {
+    const result = getMineProduct(null);
+    expect(result.itemName).toBe("Stone block");
+  });
+});

--- a/sim/src/__tests__/task-completion.test.ts
+++ b/sim/src/__tests__/task-completion.test.ts
@@ -108,7 +108,7 @@ describe("completeTask", () => {
     expect(dwarf.need_sleep).toBe(MAX_NEED);
   });
 
-  it("mining creates stone item and open_air tile", () => {
+  it("mining at z=0 creates stone item and grass tile", () => {
     const dwarf = makeDwarf();
     const skill = makeSkill(dwarf.id, "mining", 0);
     const ctx = makeContext({ dwarves: [dwarf], skills: [skill] });
@@ -126,7 +126,8 @@ describe("completeTask", () => {
 
     const stones = ctx.state.items.filter(i => i.category === "raw_material");
     expect(stones).toHaveLength(1);
-    expect(ctx.state.fortressTileOverrides.get("10,10,0")!.tile_type).toBe("open_air");
+    // Surface mining (z=0) produces grass, not open_air
+    expect(ctx.state.fortressTileOverrides.get("10,10,0")!.tile_type).toBe("grass");
   });
 
   it("build_wall creates constructed_wall tile", () => {

--- a/sim/src/__tests__/task-dispatch.test.ts
+++ b/sim/src/__tests__/task-dispatch.test.ts
@@ -701,11 +701,11 @@ describe("build tasks", () => {
 
     expect(task.status).toBe("completed");
 
-    // Mining should create an open_air tile override
+    // Mining at z=0 should create a grass tile override (surface)
     const key = "3,5,0";
     expect(ctx.state.fortressTileOverrides.has(key)).toBe(true);
     const tile = ctx.state.fortressTileOverrides.get(key)!;
-    expect(tile.tile_type).toBe("open_air");
+    expect(tile.tile_type).toBe("grass");
     expect(tile.is_mined).toBe(true);
 
     // Should also create a stone item

--- a/sim/src/__tests__/test-helpers.ts
+++ b/sim/src/__tests__/test-helpers.ts
@@ -93,6 +93,7 @@ export function makeContext(opts?: {
     supabase: null as unknown as SupabaseClient,
     civilizationId: "civ-1",
     worldId: "world-1",
+    fortressDeriver: null,
     step: 0,
     year: 1,
     day: 1,

--- a/sim/src/phases/task-completion.ts
+++ b/sim/src/phases/task-completion.ts
@@ -98,30 +98,63 @@ export function completeTask(dwarf: Dwarf, task: Task, ctx: SimContext): void {
 function completeMine(task: Task, ctx: SimContext): void {
   if (task.target_x === null || task.target_y === null || task.target_z === null) return;
 
-  const stoneItem: Item = {
-    id: crypto.randomUUID(),
-    name: 'Stone block',
-    category: 'raw_material',
-    quality: 'standard',
-    material: 'stone',
-    weight: 10,
-    value: 1,
-    is_artifact: false,
-    created_by_dwarf_id: null,
-    created_in_civ_id: ctx.civilizationId,
-    created_year: ctx.year,
-    held_by_dwarf_id: null,
-    located_in_civ_id: ctx.civilizationId,
-    located_in_ruin_id: null,
-    lore: null,
-    properties: {},
-    created_at: new Date().toISOString(),
-  };
+  // Look up the tile type being mined (check overrides first, then deriver)
+  const key = `${task.target_x},${task.target_y},${task.target_z}`;
+  const override = ctx.state.fortressTileOverrides.get(key);
+  let tileType = override?.tile_type ?? null;
+  if (!tileType && ctx.fortressDeriver) {
+    tileType = ctx.fortressDeriver.deriveTile(task.target_x, task.target_y, task.target_z).tileType;
+  }
 
-  ctx.state.items.push(stoneItem);
-  ctx.state.dirtyItemIds.add(stoneItem.id);
+  const { itemName, itemMaterial, itemWeight, itemValue } = getMineProduct(tileType);
 
-  upsertFortressTile(ctx, task.target_x, task.target_y, task.target_z, 'open_air', null, true);
+  if (itemName) {
+    const minedItem: Item = {
+      id: crypto.randomUUID(),
+      name: itemName,
+      category: 'raw_material',
+      quality: 'standard',
+      material: itemMaterial,
+      weight: itemWeight,
+      value: itemValue,
+      is_artifact: false,
+      created_by_dwarf_id: null,
+      created_in_civ_id: ctx.civilizationId,
+      created_year: ctx.year,
+      held_by_dwarf_id: null,
+      located_in_civ_id: ctx.civilizationId,
+      located_in_ruin_id: null,
+      lore: null,
+      properties: {},
+      created_at: new Date().toISOString(),
+    };
+
+    ctx.state.items.push(minedItem);
+    ctx.state.dirtyItemIds.add(minedItem.id);
+  }
+
+  // Surface features (z=0) become grass; underground becomes open_air
+  const resultTile: FortressTileType = task.target_z === 0 ? 'grass' : 'open_air';
+  upsertFortressTile(ctx, task.target_x, task.target_y, task.target_z, resultTile, null, true);
+}
+
+/** Returns the item produced when mining a given tile type. */
+export function getMineProduct(tileType: string | null): {
+  itemName: string | null;
+  itemMaterial: string;
+  itemWeight: number;
+  itemValue: number;
+} {
+  switch (tileType) {
+    case 'tree':
+      return { itemName: 'Wood log', itemMaterial: 'wood', itemWeight: 8, itemValue: 2 };
+    case 'rock':
+      return { itemName: 'Stone block', itemMaterial: 'stone', itemWeight: 10, itemValue: 1 };
+    case 'bush':
+      return { itemName: null, itemMaterial: '', itemWeight: 0, itemValue: 0 };
+    default:
+      return { itemName: 'Stone block', itemMaterial: 'stone', itemWeight: 10, itemValue: 1 };
+  }
 }
 
 function completeBuild(task: Task, ctx: SimContext): void {

--- a/sim/src/sim-context.ts
+++ b/sim/src/sim-context.ts
@@ -3,6 +3,7 @@ import type {
   Dwarf,
   DwarfSkill,
   FortressTile,
+  FortressDeriver,
   Item,
   Structure,
   Monster,
@@ -80,6 +81,9 @@ export interface SimContext {
 
   /** The world this civilization belongs to. */
   worldId: string;
+
+  /** Fortress tile deriver for looking up procedurally generated tile types. */
+  fortressDeriver: FortressDeriver | null;
 
   /** Monotonically increasing step counter since sim start. */
   step: number;

--- a/sim/src/sim-runner.ts
+++ b/sim/src/sim-runner.ts
@@ -1,5 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { STEPS_PER_SECOND, STEPS_PER_YEAR } from "@pwarf/shared";
+import { STEPS_PER_SECOND, STEPS_PER_YEAR, createFortressDeriver } from "@pwarf/shared";
 import type { SimContext } from "./sim-context.js";
 import { createEmptyCachedState } from "./sim-context.js";
 import { loadStateFromSupabase } from "./load-state.js";
@@ -47,10 +47,24 @@ export class SimRunner {
       cached = createEmptyCachedState();
     }
 
+    // Fetch world seed to create fortress deriver
+    let fortressDeriver = null;
+    if (worldId) {
+      const { data: world } = await this.supabase
+        .from('worlds')
+        .select('seed')
+        .eq('id', worldId)
+        .single();
+      if (world) {
+        fortressDeriver = createFortressDeriver(BigInt(world.seed), civilizationId);
+      }
+    }
+
     this.ctx = {
       supabase: this.supabase,
       civilizationId,
       worldId: worldId ?? '',
+      fortressDeriver,
       step: this.stepCount,
       year: this.currentYear,
       day: this.currentDay,


### PR DESCRIPTION
## Summary
- Add `grass` to buildable tile list so walls/floors can be placed on the surface
- Add `tree`, `rock`, `bush` to mineable tile list — use mine (`m`) to clear them
- Mining trees produces **Wood logs**, rocks produce **Stone blocks**, bushes produce nothing
- Surface mining clears to grass (underground still becomes open_air)
- Add `FortressDeriver` to `SimContext` so `completeMine` can look up the original tile type
- Tuned work amounts: trees (60), rocks (40), bushes (20) vs underground stone (100)

## Playtest
Tested in Chrome:
- Designated mine area over trees/bushes/rocks — dwarves walked over and cleared them
- Trees cleared to grass tiles, resources produced
- Built walls on grass tiles — dwarves constructed them successfully
- No console errors
- All 158 tests pass (92 sim + 66 shared)

## Test plan
- [x] `getMineProduct` tests: tree→wood, rock→stone, bush→nothing, default→stone
- [x] Existing mine/build tests updated for surface tile behavior
- [x] All workspaces build clean
- [x] Visual playtest confirms mining trees and building on grass

🤖 Generated with [Claude Code](https://claude.com/claude-code)