### PR TITLE
perf: reduce polling overhead and unnecessary re-renders

### DIFF
--- a/app/src/hooks/useDwarves.ts
+++ b/app/src/hooks/useDwarves.ts
@@ -1,6 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
 import { supabase } from '../lib/supabase';
-import type { Dwarf } from '@pwarf/shared';
 
 export interface LiveDwarf {
   id: string;
@@ -18,13 +17,24 @@ export interface LiveDwarf {
   health: number;
 }
 
+/** Build a compact fingerprint string for diffing without deep comparison. */
+function fingerprint(dwarves: LiveDwarf[]): string {
+  let s = '';
+  for (const d of dwarves) {
+    s += `${d.id}:${d.position_x},${d.position_y},${d.position_z}:${d.current_task_id}:${d.need_food}:${d.need_drink}:${d.need_sleep}:${d.stress_level}:${d.health};`;
+  }
+  return s;
+}
+
 export function useDwarves(civId: string | null) {
   const [dwarves, setDwarves] = useState<LiveDwarf[]>([]);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const lastFingerprint = useRef<string>('');
 
   useEffect(() => {
     if (!civId) {
       setDwarves([]);
+      lastFingerprint.current = '';
       return;
     }
 
@@ -36,17 +46,19 @@ export function useDwarves(civId: string | null) {
         .eq('status', 'alive');
 
       if (!error && data) {
-        setDwarves(data);
+        const fp = fingerprint(data);
+        if (fp !== lastFingerprint.current) {
+          lastFingerprint.current = fp;
+          setDwarves(data);
+        }
       }
     }
 
-    // Initial fetch
     void fetchDwarves();
 
-    // Poll every 1 second for position updates
     pollRef.current = setInterval(() => {
       void fetchDwarves();
-    }, 1000);
+    }, 2000);
 
     return () => {
       if (pollRef.current) {

--- a/app/src/hooks/useEvents.ts
+++ b/app/src/hooks/useEvents.ts
@@ -8,7 +8,7 @@ export interface LiveEvent {
   created_at: string;
 }
 
-const POLL_INTERVAL = 2000;
+const POLL_INTERVAL = 3000;
 const MAX_EVENTS = 50;
 
 export function useEvents(civId: string | null): LiveEvent[] {

--- a/app/src/hooks/useFortressTiles.ts
+++ b/app/src/hooks/useFortressTiles.ts
@@ -27,6 +27,15 @@ interface UseFortressTilesOptions {
   viewportRows: number;
 }
 
+/** Build a fingerprint from override data to detect actual changes. */
+function overrideFingerprint(data: Array<{ x: number; y: number; tile_type: string; is_revealed: boolean; is_mined: boolean }>): string {
+  let s = '';
+  for (const t of data) {
+    s += `${t.x},${t.y}:${t.tile_type}:${t.is_revealed}:${t.is_mined};`;
+  }
+  return s;
+}
+
 export function useFortressTiles({
   civId,
   worldSeed,
@@ -38,6 +47,7 @@ export function useFortressTiles({
 }: UseFortressTilesOptions) {
   const [dbOverrides, setDbOverrides] = useState<Map<string, Partial<FortressTile>>>(new Map());
   const lastFetchKey = useRef<string>('');
+  const lastOverrideFingerprint = useRef<string>('');
 
   // Create deriver once per seed + civId
   const deriver = useMemo<FortressDeriver | null>(() => {
@@ -76,6 +86,10 @@ export function useFortressTiles({
     }
 
     if (data) {
+      const fp = overrideFingerprint(data as Array<{ x: number; y: number; tile_type: string; is_revealed: boolean; is_mined: boolean }>);
+      if (fp === lastOverrideFingerprint.current) return;
+      lastOverrideFingerprint.current = fp;
+
       const newOverrides = new Map<string, Partial<FortressTile>>();
       for (const tile of data) {
         newOverrides.set(`${tile.x},${tile.y}`, tile as Partial<FortressTile>);
@@ -93,7 +107,7 @@ export function useFortressTiles({
   // Poll for tile changes (e.g. mining/building completions)
   useEffect(() => {
     if (!civId) return;
-    const interval = setInterval(() => void fetchOverrides(true), 2000);
+    const interval = setInterval(() => void fetchOverrides(true), 3000);
     return () => clearInterval(interval);
   }, [civId, fetchOverrides]);
 

--- a/app/src/hooks/useTasks.ts
+++ b/app/src/hooks/useTasks.ts
@@ -12,13 +12,24 @@ export interface ActiveTask {
   work_required: number;
 }
 
+/** Build a compact fingerprint for diffing. */
+function fingerprint(tasks: ActiveTask[]): string {
+  let s = '';
+  for (const t of tasks) {
+    s += `${t.id}:${t.status}:${t.work_progress};`;
+  }
+  return s;
+}
+
 export function useTasks(civId: string | null) {
   const [tasks, setTasks] = useState<ActiveTask[]>([]);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const lastFingerprint = useRef<string>('');
 
   useEffect(() => {
     if (!civId) {
       setTasks([]);
+      lastFingerprint.current = '';
       return;
     }
 
@@ -30,12 +41,16 @@ export function useTasks(civId: string | null) {
         .in('status', ['pending', 'claimed', 'in_progress']);
 
       if (!error && data) {
-        setTasks(data);
+        const fp = fingerprint(data);
+        if (fp !== lastFingerprint.current) {
+          lastFingerprint.current = fp;
+          setTasks(data);
+        }
       }
     }
 
     void fetchTasks();
-    pollRef.current = setInterval(() => void fetchTasks(), 1000);
+    pollRef.current = setInterval(() => void fetchTasks(), 2000);
 
     return () => {
       if (pollRef.current) {


### PR DESCRIPTION
## Summary
- Add fingerprint-based data diffing to `useDwarves`, `useTasks`, and `useFortressTiles` — `setState` only fires when data actually changed, preventing unnecessary React re-renders and canvas redraws
- Slow poll intervals: dwarves/tasks 1s→2s, fortress tiles 2s→3s, events 2s→3s
- Skip `tileMap` recomputation when fortress tile overrides haven't changed

Closes #235

## Playtest report

Tested in Chrome — all features working:
- Fortress view: dwarves visible and working, activity log updating, surface features rendered
- Mine designation (m key) and build menu (b key) both functional
- World map: terrain glyphs render correctly, tile info panel updates
- Tab mode switching works
- No console errors

## Test plan
- [x] `npm test` passes (345/348, 3 pre-existing AuthScreen failures)
- [x] `npm run build` typechecks successfully
- [x] Dev server renders correctly
- [x] Playtested fortress view, world map, designations, build menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)