### PR TITLE
feat: shift+drag to cancel pending designations

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -292,6 +292,7 @@ export default function App() {
           designatedTiles={world.mode === "fortress" ? designatedTiles : undefined}
           designationMode={world.mode === "fortress" ? designation.designationMode : undefined}
           onDesignateArea={world.mode === "fortress" ? designation.handleDesignateArea : undefined}
+          onCancelArea={world.mode === "fortress" ? designation.handleCancelArea : undefined}
           onTileClick={world.mode === "world" ? (x: number, y: number) => setSelectedWorldTile({ x, y }) : undefined}
           selectedTile={world.mode === "world" ? selectedWorldTile : undefined}
         />

--- a/app/src/components/MainViewport.tsx
+++ b/app/src/components/MainViewport.tsx
@@ -24,6 +24,8 @@ interface MainViewportProps {
   designationMode?: string;
   /** Area designation handler — called with rectangle bounds */
   onDesignateArea?: (x1: number, y1: number, x2: number, y2: number) => void;
+  /** Cancel designation handler — shift+drag to cancel pending tasks in area */
+  onCancelArea?: (x1: number, y1: number, x2: number, y2: number) => void;
   /** Click handler for world map tile selection */
   onTileClick?: (x: number, y: number) => void;
   /** Selected world tile position */
@@ -64,6 +66,7 @@ export default function MainViewport({
   designatedTiles,
   designationMode,
   onDesignateArea,
+  onCancelArea,
   onTileClick,
   selectedTile,
 }: MainViewportProps) {
@@ -71,10 +74,12 @@ export default function MainViewport({
   const containerRef = useRef<HTMLDivElement>(null);
   const dragging = useRef(false);
   const dragMoved = useRef(false);
+  const shiftHeld = useRef(false);
 
   // Designation drag-select state
   const [selStart, setSelStart] = useState<{ x: number; y: number } | null>(null);
   const [selEnd, setSelEnd] = useState<{ x: number; y: number } | null>(null);
+  const [isCancelling, setIsCancelling] = useState(false);
   const isDesignating = designationMode && designationMode !== 'none';
 
   const getWorldTile = useCallback(
@@ -197,7 +202,7 @@ export default function MainViewport({
       const sx2 = Math.max(selStart.x, selEnd.x);
       const sy2 = Math.max(selStart.y, selEnd.y);
 
-      ctx.fillStyle = "rgba(255, 102, 0, 0.25)";
+      ctx.fillStyle = isCancelling ? "rgba(255, 0, 0, 0.25)" : "rgba(255, 102, 0, 0.25)";
       for (let sy = sy1; sy <= sy2; sy++) {
         for (let sx = sx1; sx <= sx2; sx++) {
           const px = (sx - offsetX) * CHAR_W;
@@ -213,7 +218,7 @@ export default function MainViewport({
       const ry = (sy1 - offsetY) * CHAR_H;
       const rw = (sx2 - sx1 + 1) * CHAR_W;
       const rh = (sy2 - sy1 + 1) * CHAR_H;
-      ctx.strokeStyle = "#ff6600";
+      ctx.strokeStyle = isCancelling ? "#ff0000" : "#ff6600";
       ctx.lineWidth = 2;
       ctx.strokeRect(rx + 0.5, ry + 0.5, rw - 1, rh - 1);
     }
@@ -226,7 +231,7 @@ export default function MainViewport({
       ctx.lineWidth = 1;
       ctx.strokeRect(cx + 0.5, cy + 0.5, CHAR_W - 1, CHAR_H - 1);
     }
-  }, [offsetX, offsetY, cursorX, cursorY, getTile, onViewportSize, isDesignating, selStart, selEnd, selectedTile]);
+  }, [offsetX, offsetY, cursorX, cursorY, getTile, onViewportSize, isDesignating, selStart, selEnd, selectedTile, isCancelling]);
 
   // Re-render on state change
   useEffect(() => {
@@ -250,6 +255,12 @@ export default function MainViewport({
       const wy = offsetY + row;
       onCursorMove(wx, wy);
 
+      // Track shift state for cancel mode visual feedback
+      if (dragging.current && isDesignating) {
+        shiftHeld.current = e.shiftKey;
+        setIsCancelling(e.shiftKey);
+      }
+
       if (dragging.current) {
         dragMoved.current = true;
         if (isDesignating) {
@@ -268,8 +279,10 @@ export default function MainViewport({
       if (e.button === 0) {
         dragging.current = true;
         dragMoved.current = false;
+        shiftHeld.current = e.shiftKey;
 
         if (isDesignating) {
+          setIsCancelling(e.shiftKey);
           // Start designation selection
           const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
           const col = Math.floor((e.clientX - rect.left) / CHAR_W);
@@ -288,12 +301,16 @@ export default function MainViewport({
 
   const handleMouseUp = useCallback(
     (_e: React.MouseEvent) => {
-      if (dragging.current && isDesignating && selStart && selEnd && onDesignateArea) {
+      if (dragging.current && isDesignating && selStart && selEnd) {
         const x1 = Math.min(selStart.x, selEnd.x);
         const y1 = Math.min(selStart.y, selEnd.y);
         const x2 = Math.max(selStart.x, selEnd.x);
         const y2 = Math.max(selStart.y, selEnd.y);
-        onDesignateArea(x1, y1, x2, y2);
+        if (shiftHeld.current && onCancelArea) {
+          onCancelArea(x1, y1, x2, y2);
+        } else if (onDesignateArea) {
+          onDesignateArea(x1, y1, x2, y2);
+        }
       }
       // Fire tile click if user clicked without dragging (world map selection)
       if (dragging.current && !dragMoved.current && !isDesignating && onTileClick) {
@@ -301,13 +318,15 @@ export default function MainViewport({
       }
       dragging.current = false;
       dragMoved.current = false;
+      shiftHeld.current = false;
       setSelStart(null);
       setSelEnd(null);
+      setIsCancelling(false);
       if (!isDesignating) {
         onDragEnd();
       }
     },
-    [onDragEnd, onDesignateArea, onTileClick, isDesignating, selStart, selEnd, cursorX, cursorY],
+    [onDragEnd, onDesignateArea, onCancelArea, onTileClick, isDesignating, selStart, selEnd, cursorX, cursorY],
   );
 
   return (

--- a/app/src/hooks/__tests__/useDesignation.test.ts
+++ b/app/src/hooks/__tests__/useDesignation.test.ts
@@ -1,0 +1,188 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { FortressViewTile } from "../useFortressTiles";
+
+// --- Supabase mock ---
+// Track all calls for assertions
+const calls: Array<{ method: string; args: unknown[] }> = [];
+let deleteResult = { error: null as { message: string } | null };
+
+function makeChain(): Record<string, (...args: unknown[]) => unknown> {
+  const chain: Record<string, (...args: unknown[]) => unknown> = {};
+  for (const method of ["delete", "eq", "gte", "lte"]) {
+    chain[method] = (...args: unknown[]) => {
+      calls.push({ method, args });
+      return { ...chain, then: (resolve: (v: unknown) => void) => resolve(deleteResult) };
+    };
+  }
+  return chain;
+}
+
+const mockInsert = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock("../../lib/supabase", () => ({
+  supabase: {
+    get from() {
+      return mockFrom;
+    },
+  },
+}));
+
+function setupDeleteChain(result: { error: { message: string } | null } = { error: null }) {
+  deleteResult = result;
+  mockFrom.mockReturnValue(makeChain());
+}
+
+function setupInsertChain(result = { error: null }) {
+  mockFrom.mockReturnValue({ insert: mockInsert });
+  mockInsert.mockResolvedValue(result);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  calls.length = 0;
+  deleteResult = { error: null };
+});
+
+const { useDesignation } = await import("../useDesignation");
+
+function makeHook(overrides: Partial<Parameters<typeof useDesignation>[0]> = {}) {
+  const designatedTiles = new Map<string, string>();
+  const getFortressTile = (): FortressViewTile | null => ({
+    tileType: "stone",
+    glyph: { ch: ".", fg: "#888" },
+  });
+
+  return renderHook(() =>
+    useDesignation({
+      civId: "civ-1",
+      zLevel: 0,
+      getFortressTile,
+      designatedTiles,
+      ...overrides,
+    }),
+  );
+}
+
+function findCall(method: string, argPrefix: string) {
+  return calls.find((c) => c.method === method && c.args[0] === argPrefix);
+}
+
+describe("useDesignation", () => {
+  describe("handleCancelArea", () => {
+    it("deletes pending tasks in the specified rectangle", async () => {
+      setupDeleteChain();
+      const { result } = makeHook();
+
+      await act(async () => {
+        await result.current.handleCancelArea(10, 20, 15, 25);
+      });
+
+      expect(mockFrom).toHaveBeenCalledWith("tasks");
+      expect(calls.some((c) => c.method === "delete")).toBe(true);
+      expect(findCall("eq", "civilization_id")?.args[1]).toBe("civ-1");
+      expect(findCall("eq", "status")?.args[1]).toBe("pending");
+      expect(findCall("eq", "target_z")?.args[1]).toBe(0);
+      expect(findCall("gte", "target_x")?.args[1]).toBe(10);
+      expect(findCall("lte", "target_x")?.args[1]).toBe(15);
+      expect(findCall("gte", "target_y")?.args[1]).toBe(20);
+      expect(findCall("lte", "target_y")?.args[1]).toBe(25);
+    });
+
+    it("does nothing when civId is null", async () => {
+      setupDeleteChain();
+      const { result } = makeHook({ civId: null });
+
+      await act(async () => {
+        await result.current.handleCancelArea(10, 20, 15, 25);
+      });
+
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it("uses current zLevel", async () => {
+      setupDeleteChain();
+      const { result } = makeHook({ zLevel: -3 });
+
+      await act(async () => {
+        await result.current.handleCancelArea(0, 0, 5, 5);
+      });
+
+      expect(findCall("eq", "target_z")?.args[1]).toBe(-3);
+    });
+
+    it("logs error on failure", async () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      setupDeleteChain({ error: { message: "RLS blocked" } });
+      const { result } = makeHook();
+
+      await act(async () => {
+        await result.current.handleCancelArea(0, 0, 5, 5);
+      });
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "[designate] Failed to cancel tasks:",
+        "RLS blocked",
+      );
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe("handleDesignateArea", () => {
+    it("inserts tasks for mineable tiles when in mine mode", async () => {
+      setupInsertChain();
+      const { result } = makeHook();
+
+      act(() => {
+        result.current.toggleMine();
+      });
+
+      await act(async () => {
+        await result.current.handleDesignateArea(5, 5, 6, 5);
+      });
+
+      expect(mockFrom).toHaveBeenCalledWith("tasks");
+      expect(mockInsert).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            civilization_id: "civ-1",
+            task_type: "mine",
+            status: "pending",
+            target_x: 5,
+            target_y: 5,
+            target_z: 0,
+          }),
+        ]),
+      );
+    });
+
+    it("does nothing when designation mode is none", async () => {
+      setupInsertChain();
+      const { result } = makeHook();
+
+      await act(async () => {
+        await result.current.handleDesignateArea(5, 5, 6, 5);
+      });
+
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it("skips already-designated tiles", async () => {
+      setupInsertChain();
+      const designatedTiles = new Map([["5,5", "mine"]]);
+      const { result } = makeHook({ designatedTiles });
+
+      act(() => {
+        result.current.toggleMine();
+      });
+
+      await act(async () => {
+        await result.current.handleDesignateArea(5, 5, 5, 5);
+      });
+
+      expect(mockInsert).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/src/hooks/useDesignation.ts
+++ b/app/src/hooks/useDesignation.ts
@@ -100,6 +100,25 @@ export function useDesignation(opts: {
     }
   }, [designationMode, civId, zLevel, getFortressTile, designatedTiles, taskPriorities]);
 
+  const handleCancelArea = useCallback(async (x1: number, y1: number, x2: number, y2: number) => {
+    if (!civId) return;
+
+    const { error } = await supabase
+      .from('tasks')
+      .delete()
+      .eq('civilization_id', civId)
+      .eq('status', 'pending')
+      .eq('target_z', zLevel)
+      .gte('target_x', x1)
+      .lte('target_x', x2)
+      .gte('target_y', y1)
+      .lte('target_y', y2);
+
+    if (error) {
+      console.error('[designate] Failed to cancel tasks:', error.message);
+    }
+  }, [civId, zLevel]);
+
   const handleBuildSelect = useCallback((taskType: TaskType) => {
     setBuildMenuOpen(false);
     setDesignationMode(taskType as DesignationMode);
@@ -140,6 +159,7 @@ export function useDesignation(opts: {
     prioritiesOpen,
     taskPriorities,
     handleDesignateArea,
+    handleCancelArea,
     handleBuildSelect,
     handlePriorityChange,
     toggleMine,

--- a/supabase/migrations/00008_tasks_delete_policy.sql
+++ b/supabase/migrations/00008_tasks_delete_policy.sql
@@ -1,0 +1,12 @@
+-- ============================================================
+-- DELETE POLICY FOR TASKS TABLE
+-- Allows players to cancel (delete) pending tasks for their civilizations
+-- ============================================================
+
+create policy "tasks_delete"
+  on tasks for delete
+  using (
+    civilization_id in (
+      select id from civilizations where player_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
## Summary
- In designation mode, holding shift while dragging shows a red selection rectangle and cancels all pending tasks in that area on mouse release (closes #244)
- Adds missing RLS delete policy on the `tasks` table so the client can delete pending tasks

## Changes
- `app/src/hooks/useDesignation.ts`: Added `handleCancelArea` that deletes pending tasks via Supabase in the selected rectangle
- `app/src/components/MainViewport.tsx`: Tracks shift key state during drag, shows red overlay when cancelling, dispatches to cancel handler on mouseup
- `app/src/App.tsx`: Wires `onCancelArea` prop through to MainViewport
- `supabase/migrations/00008_tasks_delete_policy.sql`: RLS delete policy for tasks

## Playtest
- Verified designations render correctly (orange X marks)
- Confirmed client-side Supabase delete works through RLS (20 tasks deleted successfully via JS console test)
- Verified UI removes cancelled designation overlays after poll cycle
- Shift key detection confirmed working via console logging (`shiftKey=true` on mousedown/mousemove/mouseup)
- Note: Browser automation tool (CDP) doesn't propagate shift modifier on drag events, so end-to-end shift+drag was tested via JS-dispatched events and direct Supabase client calls rather than pure mouse automation

**Screenshots:**

Before cancel (dense X designations):
![before](https://github.com/user-attachments/assets/placeholder-before)

After cancel (designations removed in area):
![after](https://github.com/user-attachments/assets/placeholder-after)

*(Screenshots captured during playtest but browser automation tool cannot upload — designations were visibly removed after cancellation)*

## Test plan
- [ ] Enter mine mode (press `m`)
- [ ] Shift+drag over pending mine designations — should see red selection overlay
- [ ] Release mouse — orange X marks in area should disappear
- [ ] Verify non-pending (claimed/in-progress) tasks are not cancelled
- [ ] Verify normal drag (without shift) still creates designations as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)