### PR TITLE
fix: surface tiles not walkable — dwarves stuck when wandering

### DIFF
--- a/sim/src/__tests__/pathfinding.test.ts
+++ b/sim/src/__tests__/pathfinding.test.ts
@@ -46,6 +46,22 @@ describe("isWalkable", () => {
   it("soil is walkable", () => {
     expect(isWalkable("soil")).toBe(true);
   });
+
+  it("grass is walkable", () => {
+    expect(isWalkable("grass")).toBe(true);
+  });
+
+  it("sand is walkable", () => {
+    expect(isWalkable("sand")).toBe(true);
+  });
+
+  it("mud is walkable", () => {
+    expect(isWalkable("mud")).toBe(true);
+  });
+
+  it("ice is walkable", () => {
+    expect(isWalkable("ice")).toBe(true);
+  });
 });
 
 describe("getNeighbors", () => {
@@ -123,6 +139,16 @@ describe("bfsNextStep", () => {
     const result = bfsNextStep({ x: 0, y: 0, z: 0 }, { x: 2, y: 0, z: 0 }, lookup);
     // First step should be downward (0,1) to go around
     expect(result).toEqual({ x: 0, y: 1, z: 0 });
+  });
+
+  it("finds path across grass tiles (surface wandering)", () => {
+    const grid: FortressTileType[][] = [
+      ["grass", "grass", "grass", "grass", "grass"],
+    ];
+    const lookup = gridLookup(grid);
+
+    const result = bfsNextStep({ x: 0, y: 0, z: 0 }, { x: 4, y: 0, z: 0 }, lookup);
+    expect(result).toEqual({ x: 1, y: 0, z: 0 });
   });
 
   it("returns null when no path exists", () => {

--- a/sim/src/pathfinding.ts
+++ b/sim/src/pathfinding.ts
@@ -19,6 +19,10 @@ const WALKABLE_TILES: ReadonlySet<FortressTileType> = new Set([
   'soil',
   'well',
   'mushroom_garden',
+  'grass',
+  'sand',
+  'mud',
+  'ice',
 ]);
 
 /** Check if a tile type is walkable. */


### PR DESCRIPTION
## Summary
- Add `grass`, `sand`, `mud`, `ice` to `WALKABLE_TILES` in pathfinding so dwarves can actually move on the surface (closes #248)
- `WALKABLE_TILES` was missing all surface terrain types, so BFS found zero neighbors and wander tasks failed instantly every tick

## Test plan
- [x] Added `isWalkable` tests for `grass`, `sand`, `mud`, `ice`
- [x] Added BFS test for pathfinding across grass tiles
- [x] All 154 tests pass on clean branch
- [x] Typecheck passes

## Playtest report

**Setup:** Logged in as test user, loaded existing fortress "Stonegear" with 7 dwarves.

**Observed (before fix):**
- 5 of 7 dwarves show "Idle" status and are completely stationary
- 2 dwarves with mining tasks ("Working") move normally
- Idle dwarves never change position despite the sim running continuously
- No console errors — the wander tasks silently fail because BFS can't pathfind on grass tiles

**Screenshots:**

Fortress view showing idle dwarves stuck in place:
![Fortress overview](ss_04677af3x)

After waiting 5+ seconds, same dwarves in identical positions:
![Still stuck](ss_5450paqqn)

Zoomed view showing dwarf positions unchanged:
![Zoomed dwarves](zoomed)

**Root cause confirmed:** `grass` (the primary surface tile) was not in `WALKABLE_TILES`. BFS returned null on every wander attempt, `failTask()` fired, dwarf went idle again, repeat forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)