### PR TITLE
feat: infinite food/drink sources (closes #251)

### DIFF
--- a/app/src/lib/embark.ts
+++ b/app/src/lib/embark.ts
@@ -136,32 +136,7 @@ export async function embark(worldId: string, tileX: number, tileY: number, worl
 
   // Create starting items
   const startingItems = [
-    ...Array.from({ length: 30 }, () => ({
-      name: 'Plump helmet spawn',
-      category: 'food',
-      quality: 'standard',
-      material: 'plant',
-      weight: 1,
-      value: 2,
-      is_artifact: false,
-      located_in_civ_id: civ.id,
-      created_in_civ_id: civ.id,
-      created_year: 1,
-      properties: {},
-    })),
-    ...Array.from({ length: 40 }, () => ({
-      name: 'Dwarven ale',
-      category: 'drink',
-      quality: 'standard',
-      material: 'plant',
-      weight: 1,
-      value: 3,
-      is_artifact: false,
-      located_in_civ_id: civ.id,
-      created_in_civ_id: civ.id,
-      created_year: 1,
-      properties: {},
-    })),
+    // Food and drink are provided by infinite sources (meat roast / beer fountain)
     ...Array.from({ length: 10 }, () => ({
       name: 'Plump helmet seed',
       category: 'raw_material',

--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -82,10 +82,10 @@ export const MAX_SKILL_LEVEL = 20;
 export const BASE_WORK_RATE = 1;
 
 /** Need threshold below which a dwarf interrupts work to drink */
-export const NEED_INTERRUPT_DRINK = 25;
+export const NEED_INTERRUPT_DRINK = 30;
 
 /** Need threshold below which a dwarf interrupts work to eat */
-export const NEED_INTERRUPT_FOOD = 25;
+export const NEED_INTERRUPT_FOOD = 30;
 
 /** Need threshold below which a dwarf interrupts work to sleep */
 export const NEED_INTERRUPT_SLEEP = 20;

--- a/sim/src/__tests__/need-satisfaction.test.ts
+++ b/sim/src/__tests__/need-satisfaction.test.ts
@@ -1,112 +1,50 @@
 import { describe, it, expect } from "vitest";
-import type { FortressTile, FortressDeriver, FortressTileType } from "@pwarf/shared";
-import { makeDwarf, makeItem, makeContext } from "./test-helpers.js";
+import { NEED_INTERRUPT_FOOD, NEED_INTERRUPT_DRINK } from "@pwarf/shared";
+import { makeDwarf, makeContext } from "./test-helpers.js";
 import { needSatisfaction } from "../phases/need-satisfaction.js";
-import { findNearestTileOfType } from "../task-helpers.js";
 
-describe("tile-based need satisfaction", () => {
-  it("creates drink task targeting a well when thirsty", async () => {
-    const dwarf = makeDwarf({ need_drink: 10, position_x: 128, position_y: 128, position_z: 0 });
+describe("infinite source need satisfaction", () => {
+  it("creates eat task with no target item when hungry", async () => {
+    const dwarf = makeDwarf({ need_food: NEED_INTERRUPT_FOOD - 1 });
     const ctx = makeContext({ dwarves: [dwarf] });
 
-    // Place a well tile in overrides
-    const wellKey = "130,128,0";
-    ctx.state.fortressTileOverrides.set(wellKey, {
-      id: "well-1",
-      civilization_id: "civ-1",
-      x: 130, y: 128, z: 0,
-      tile_type: "well",
-      material: "stone",
-      is_revealed: true,
-      is_mined: false,
-      created_at: new Date().toISOString(),
-    } as FortressTile);
+    await needSatisfaction(ctx);
+
+    const eatTasks = ctx.state.tasks.filter(t => t.task_type === "eat");
+    expect(eatTasks).toHaveLength(1);
+    expect(eatTasks[0]!.target_item_id).toBeNull();
+    expect(eatTasks[0]!.assigned_dwarf_id).toBe(dwarf.id);
+  });
+
+  it("creates drink task with no target item when thirsty", async () => {
+    const dwarf = makeDwarf({ need_drink: NEED_INTERRUPT_DRINK - 1 });
+    const ctx = makeContext({ dwarves: [dwarf] });
 
     await needSatisfaction(ctx);
 
     const drinkTasks = ctx.state.tasks.filter(t => t.task_type === "drink");
     expect(drinkTasks).toHaveLength(1);
-    expect(drinkTasks[0]!.target_x).toBe(130);
-    expect(drinkTasks[0]!.target_y).toBe(128);
     expect(drinkTasks[0]!.target_item_id).toBeNull();
+    expect(drinkTasks[0]!.assigned_dwarf_id).toBe(dwarf.id);
   });
 
-  it("creates eat task targeting a mushroom garden when hungry", async () => {
-    const dwarf = makeDwarf({ need_food: 10, position_x: 128, position_y: 128, position_z: 0 });
+  it("does not create eat task when food need is above threshold", async () => {
+    const dwarf = makeDwarf({ need_food: NEED_INTERRUPT_FOOD + 10 });
     const ctx = makeContext({ dwarves: [dwarf] });
 
-    // Place a mushroom garden tile
-    const gardenKey = "126,128,0";
-    ctx.state.fortressTileOverrides.set(gardenKey, {
-      id: "garden-1",
-      civilization_id: "civ-1",
-      x: 126, y: 128, z: 0,
-      tile_type: "mushroom_garden",
-      material: "plant",
-      is_revealed: true,
-      is_mined: false,
-      created_at: new Date().toISOString(),
-    } as FortressTile);
+    await needSatisfaction(ctx);
+
+    const eatTasks = ctx.state.tasks.filter(t => t.task_type === "eat");
+    expect(eatTasks).toHaveLength(0);
+  });
+
+  it("always creates eat task regardless of item availability", async () => {
+    const dwarf = makeDwarf({ need_food: NEED_INTERRUPT_FOOD - 1 });
+    const ctx = makeContext({ dwarves: [dwarf], items: [] });
 
     await needSatisfaction(ctx);
 
     const eatTasks = ctx.state.tasks.filter(t => t.task_type === "eat");
     expect(eatTasks).toHaveLength(1);
-    expect(eatTasks[0]!.target_x).toBe(126);
-    expect(eatTasks[0]!.target_y).toBe(128);
-    expect(eatTasks[0]!.target_item_id).toBeNull();
-  });
-
-  it("falls back to food item when no mushroom garden exists", async () => {
-    const dwarf = makeDwarf({ need_food: 10, position_x: 128, position_y: 128, position_z: 0 });
-    const food = makeItem({ category: "food" });
-    const ctx = makeContext({ dwarves: [dwarf], items: [food] });
-
-    await needSatisfaction(ctx);
-
-    const eatTasks = ctx.state.tasks.filter(t => t.task_type === "eat");
-    expect(eatTasks).toHaveLength(1);
-    expect(eatTasks[0]!.target_item_id).toBe(food.id);
-  });
-
-  it("does not create drink task when no well and no drink items exist", async () => {
-    const dwarf = makeDwarf({ need_drink: 10 });
-    const ctx = makeContext({ dwarves: [dwarf] });
-
-    await needSatisfaction(ctx);
-
-    const drinkTasks = ctx.state.tasks.filter(t => t.task_type === "drink");
-    expect(drinkTasks).toHaveLength(0);
-  });
-});
-
-describe("findNearestTileOfType", () => {
-  it("finds a tile in overrides", () => {
-    const overrides = new Map<string, FortressTile>();
-    overrides.set("5,5,0", {
-      id: "t1", civilization_id: "c1", x: 5, y: 5, z: 0,
-      tile_type: "well", material: null, is_revealed: true, is_mined: false,
-      created_at: "",
-    } as FortressTile);
-
-    const result = findNearestTileOfType("well", 3, 5, 0, overrides, null);
-    expect(result).toEqual({ x: 5, y: 5, z: 0 });
-  });
-
-  it("finds a tile via deriver", () => {
-    const deriver: FortressDeriver = {
-      deriveTile(x: number, y: number, _z: number) {
-        if (x === 10 && y === 10) return { tileType: "mushroom_garden" as FortressTileType, material: null };
-        return { tileType: "open_air" as FortressTileType, material: null };
-      },
-    };
-
-    const result = findNearestTileOfType("mushroom_garden", 10, 10, 0, new Map(), deriver);
-    expect(result).toEqual({ x: 10, y: 10, z: 0 });
-  });
-
-  it("returns null when tile type not found", () => {
-    const result = findNearestTileOfType("well", 5, 5, 0, new Map(), null, 5);
-    expect(result).toBeNull();
   });
 });

--- a/sim/src/__tests__/task-completion.test.ts
+++ b/sim/src/__tests__/task-completion.test.ts
@@ -58,7 +58,22 @@ describe("completeTask", () => {
     expect(events).toHaveLength(0);
   });
 
-  it("eating consumes food item and restores need", () => {
+  it("eating from infinite source restores need without consuming items", () => {
+    const dwarf = makeDwarf({ need_food: 20 });
+    const ctx = makeContext({ dwarves: [dwarf] });
+    const task = createTask(ctx.state, "civ-1", {
+      task_type: "eat",
+      work_required: 1,
+    });
+    task.status = "in_progress";
+    dwarf.current_task_id = task.id;
+
+    completeTask(dwarf, task, ctx);
+
+    expect(dwarf.need_food).toBe(Math.min(MAX_NEED, 20 + FOOD_RESTORE_AMOUNT));
+  });
+
+  it("eating with target item still consumes it", () => {
     const dwarf = makeDwarf({ need_food: 20 });
     const food = makeItem({ category: "food" });
     const ctx = makeContext({ dwarves: [dwarf], items: [food] });
@@ -76,13 +91,11 @@ describe("completeTask", () => {
     expect(ctx.state.items.find(i => i.id === food.id)).toBeUndefined();
   });
 
-  it("drinking consumes drink item and restores need", () => {
+  it("drinking from infinite source restores need without consuming items", () => {
     const dwarf = makeDwarf({ need_drink: 15 });
-    const drink = makeItem({ category: "drink", name: "Ale" });
-    const ctx = makeContext({ dwarves: [dwarf], items: [drink] });
+    const ctx = makeContext({ dwarves: [dwarf] });
     const task = createTask(ctx.state, "civ-1", {
       task_type: "drink",
-      target_item_id: drink.id,
       work_required: 1,
     });
     task.status = "in_progress";

--- a/sim/src/__tests__/task-dispatch.test.ts
+++ b/sim/src/__tests__/task-dispatch.test.ts
@@ -17,7 +17,7 @@ import { taskExecution } from "../phases/task-execution.js";
 import { needSatisfaction } from "../phases/need-satisfaction.js";
 import { stressUpdate } from "../phases/stress-update.js";
 import { createTask, isDwarfIdle, getBestSkill } from "../task-helpers.js";
-import { makeDwarf, makeSkill, makeItem, makeContext } from "./test-helpers.js";
+import { makeDwarf, makeSkill, makeContext } from "./test-helpers.js";
 
 // ---------------------------------------------------------------------------
 // Task helper tests
@@ -196,20 +196,18 @@ describe("task execution", () => {
     expect(dwarf.current_task_id).toBeNull();
   });
 
-  it("eating restores food need", async () => {
+  it("eating restores food need (infinite source)", async () => {
     const dwarf = makeDwarf({
       position_x: 0, position_y: 0, position_z: 0,
       need_food: 20,
     });
-    const food = makeItem({ category: "food" });
-    const ctx = makeContext({ dwarves: [dwarf], items: [food] });
+    const ctx = makeContext({ dwarves: [dwarf] });
 
     const task = createTask(ctx.state, "civ-1", {
       task_type: "eat",
       target_x: 0,
       target_y: 0,
       target_z: 0,
-      target_item_id: food.id,
       work_required: 1,
       assigned_dwarf_id: dwarf.id,
     });
@@ -221,24 +219,20 @@ describe("task execution", () => {
 
     expect(task.status).toBe("completed");
     expect(dwarf.need_food).toBe(Math.min(MAX_NEED, 20 + FOOD_RESTORE_AMOUNT));
-    // Food item should be consumed
-    expect(ctx.state.items.find(i => i.id === food.id)).toBeUndefined();
   });
 
-  it("drinking restores drink need", async () => {
+  it("drinking restores drink need (infinite source)", async () => {
     const dwarf = makeDwarf({
       position_x: 0, position_y: 0, position_z: 0,
       need_drink: 15,
     });
-    const drink = makeItem({ category: "drink", name: "Dwarven ale" });
-    const ctx = makeContext({ dwarves: [dwarf], items: [drink] });
+    const ctx = makeContext({ dwarves: [dwarf] });
 
     const task = createTask(ctx.state, "civ-1", {
       task_type: "drink",
       target_x: 0,
       target_y: 0,
       target_z: 0,
-      target_item_id: drink.id,
       work_required: 1,
       assigned_dwarf_id: dwarf.id,
     });
@@ -424,43 +418,32 @@ describe("task execution", () => {
 // ---------------------------------------------------------------------------
 
 describe("need satisfaction", () => {
-  it("creates eat task when food need is low", async () => {
+  it("creates eat task when food need is low (infinite source)", async () => {
     const dwarf = makeDwarf({ need_food: NEED_INTERRUPT_FOOD - 1 });
-    const food = makeItem({ category: "food" });
-    const ctx = makeContext({ dwarves: [dwarf], items: [food] });
+    const ctx = makeContext({ dwarves: [dwarf] });
 
     await needSatisfaction(ctx);
 
     const eatTasks = ctx.state.tasks.filter(t => t.task_type === "eat");
     expect(eatTasks).toHaveLength(1);
     expect(eatTasks[0]!.assigned_dwarf_id).toBe(dwarf.id);
+    expect(eatTasks[0]!.target_item_id).toBeNull();
   });
 
-  it("creates drink task when drink need is low", async () => {
+  it("creates drink task when drink need is low (infinite source)", async () => {
     const dwarf = makeDwarf({ need_drink: NEED_INTERRUPT_DRINK - 1 });
-    const drink = makeItem({ category: "drink", name: "Ale" });
-    const ctx = makeContext({ dwarves: [dwarf], items: [drink] });
+    const ctx = makeContext({ dwarves: [dwarf] });
 
     await needSatisfaction(ctx);
 
     const drinkTasks = ctx.state.tasks.filter(t => t.task_type === "drink");
     expect(drinkTasks).toHaveLength(1);
-  });
-
-  it("does not create eat task if no food exists", async () => {
-    const dwarf = makeDwarf({ need_food: NEED_INTERRUPT_FOOD - 1 });
-    const ctx = makeContext({ dwarves: [dwarf], items: [] });
-
-    await needSatisfaction(ctx);
-
-    const eatTasks = ctx.state.tasks.filter(t => t.task_type === "eat");
-    expect(eatTasks).toHaveLength(0);
+    expect(drinkTasks[0]!.target_item_id).toBeNull();
   });
 
   it("drops current task when need is critical", async () => {
     const dwarf = makeDwarf({ need_food: NEED_INTERRUPT_FOOD - 1 });
-    const food = makeItem({ category: "food" });
-    const ctx = makeContext({ dwarves: [dwarf], items: [food] });
+    const ctx = makeContext({ dwarves: [dwarf] });
 
     // Give dwarf a haul task
     const haulTask = createTask(ctx.state, "civ-1", {
@@ -487,9 +470,7 @@ describe("need satisfaction", () => {
 
   it("does not interrupt an existing autonomous task", async () => {
     const dwarf = makeDwarf({ need_food: 10, need_drink: 10 });
-    const food = makeItem({ category: "food" });
-    const drink = makeItem({ category: "drink", name: "Ale" });
-    const ctx = makeContext({ dwarves: [dwarf], items: [food, drink] });
+    const ctx = makeContext({ dwarves: [dwarf] });
 
     // Dwarf is already eating
     const eatTask = createTask(ctx.state, "civ-1", {
@@ -497,7 +478,6 @@ describe("need satisfaction", () => {
       target_x: 0,
       target_y: 0,
       target_z: 0,
-      target_item_id: food.id,
       assigned_dwarf_id: dwarf.id,
     });
     eatTask.status = "in_progress";
@@ -574,8 +554,7 @@ describe("starvation scenario", () => {
 
   it("dwarf survives if food is available before starvation", async () => {
     const dwarf = makeDwarf({ need_food: 0, need_drink: 80 });
-    const food = makeItem({ category: "food" });
-    const ctx = makeContext({ dwarves: [dwarf], items: [food] });
+    const ctx = makeContext({ dwarves: [dwarf] });
 
     // Run partway through starvation window
     for (let i = 0; i < STARVATION_TICKS / 2; i++) {
@@ -585,13 +564,12 @@ describe("starvation scenario", () => {
 
     expect(dwarf.status).toBe("alive");
 
-    // Now eat
+    // Now eat (infinite source — no target item needed)
     const eatTask = createTask(ctx.state, "civ-1", {
       task_type: "eat",
       target_x: 0,
       target_y: 0,
       target_z: 0,
-      target_item_id: food.id,
       work_required: 1,
       assigned_dwarf_id: dwarf.id,
     });
@@ -612,8 +590,7 @@ describe("starvation scenario", () => {
       need_drink: 80,
       need_sleep: 80,
     });
-    const food = makeItem({ category: "food" });
-    const ctx = makeContext({ dwarves: [dwarf], items: [food] });
+    const ctx = makeContext({ dwarves: [dwarf] });
 
     // Run needs decay until food drops below interrupt threshold
     let ticks = 0;

--- a/sim/src/phases/need-satisfaction.ts
+++ b/sim/src/phases/need-satisfaction.ts
@@ -8,7 +8,7 @@ import {
 } from "@pwarf/shared";
 import type { Dwarf, TaskType } from "@pwarf/shared";
 import type { SimContext } from "../sim-context.js";
-import { createTask, findNearestItem, findNearestTileOfType } from "../task-helpers.js";
+import { createTask } from "../task-helpers.js";
 
 /**
  * Need Satisfaction Phase
@@ -83,54 +83,18 @@ function maybeInterruptForNeed(dwarf: Dwarf, taskType: TaskType, ctx: SimContext
     : dwarf.need_sleep;
   const priority = Math.min(10, Math.floor(10 * (1 - needValue / 100)));
 
+  // Eat/drink use infinite sources (beer fountain / meat roast) — no item lookup needed
   const workRequired = taskType === 'eat' ? WORK_EAT
     : taskType === 'drink' ? WORK_DRINK
     : WORK_SLEEP;
 
-  // For eat/drink: try to find a tile source (mushroom garden / well) first,
-  // then fall back to consumable items.
-  let targetX = dwarf.position_x;
-  let targetY = dwarf.position_y;
-  let targetZ = dwarf.position_z;
-  let targetItemId: string | null = null;
-
-  if (taskType === 'eat') {
-    const garden = findNearestTileOfType(
-      'mushroom_garden', dwarf.position_x, dwarf.position_y, dwarf.position_z,
-      state.fortressTileOverrides, ctx.fortressDeriver,
-    );
-    if (garden) {
-      targetX = garden.x;
-      targetY = garden.y;
-      targetZ = garden.z;
-    } else {
-      const food = findNearestItem(state.items, 'food', dwarf.position_x, dwarf.position_y, dwarf.position_z);
-      if (!food) return; // No food source available
-      targetItemId = food.id;
-    }
-  } else if (taskType === 'drink') {
-    const well = findNearestTileOfType(
-      'well', dwarf.position_x, dwarf.position_y, dwarf.position_z,
-      state.fortressTileOverrides, ctx.fortressDeriver,
-    );
-    if (well) {
-      targetX = well.x;
-      targetY = well.y;
-      targetZ = well.z;
-    } else {
-      const drink = findNearestItem(state.items, 'drink', dwarf.position_x, dwarf.position_y, dwarf.position_z);
-      if (!drink) return; // No drink source available
-      targetItemId = drink.id;
-    }
-  }
-
   createTask(state, ctx.civilizationId, {
     task_type: taskType,
     priority,
-    target_x: targetX,
-    target_y: targetY,
-    target_z: targetZ,
-    target_item_id: targetItemId,
+    target_x: dwarf.position_x,
+    target_y: dwarf.position_y,
+    target_z: dwarf.position_z,
+    target_item_id: null,
     work_required: workRequired,
     assigned_dwarf_id: dwarf.id,
   });

--- a/sim/src/task-helpers.ts
+++ b/sim/src/task-helpers.ts
@@ -1,5 +1,4 @@
-import type { Dwarf, DwarfSkill, Task, TaskType, Item, FortressDeriver, FortressTileType, FortressTile } from "@pwarf/shared";
-import { FORTRESS_SIZE } from "@pwarf/shared";
+import type { Dwarf, DwarfSkill, Task, TaskType, Item } from "@pwarf/shared";
 import type { CachedState } from "./sim-context.js";
 
 /** Map task types to the skill name required. null means any dwarf can do it. */
@@ -100,45 +99,6 @@ export function createTask(
   state.tasks.push(task);
   state.newTasks.push(task);
   return task;
-}
-
-/**
- * Find the nearest tile of a given type by spiraling outward from the dwarf's position.
- * Checks overrides first, then the deriver. Returns the position or null.
- */
-export function findNearestTileOfType(
-  tileType: FortressTileType,
-  fromX: number,
-  fromY: number,
-  fromZ: number,
-  overrides: Map<string, FortressTile>,
-  deriver: FortressDeriver | null,
-  maxRadius = 30,
-): { x: number; y: number; z: number } | null {
-  // Spiral search outward from current position
-  for (let r = 0; r <= maxRadius; r++) {
-    for (let dy = -r; dy <= r; dy++) {
-      for (let dx = -r; dx <= r; dx++) {
-        if (Math.abs(dx) !== r && Math.abs(dy) !== r) continue; // only ring edges
-        const x = fromX + dx;
-        const y = fromY + dy;
-        if (x < 0 || x >= FORTRESS_SIZE || y < 0 || y >= FORTRESS_SIZE) continue;
-
-        const key = `${x},${y},${fromZ}`;
-        const override = overrides.get(key);
-        if (override && override.tile_type === tileType) {
-          return { x, y, z: fromZ };
-        }
-        if (!override && deriver) {
-          const derived = deriver.deriveTile(x, y, fromZ);
-          if (derived.tileType === tileType) {
-            return { x, y, z: fromZ };
-          }
-        }
-      }
-    }
-  }
-  return null;
 }
 
 /** Find the nearest item of a given category in the fortress. */


### PR DESCRIPTION
## Summary
- Dwarves now eat/drink from implicit infinite sources (beer fountain + meat roast) instead of consuming finite stockpile items
- Raised `NEED_INTERRUPT_FOOD` and `NEED_INTERRUPT_DRINK` from 25 → 30 so dwarves seek sustenance earlier
- Removed 30 starting food items and 40 starting drink items from embark (no longer needed)
- Warnings still only fire below need < 10, so no log spam

## Playtest
- Ran the game in Chrome, watched fortress for ~30 seconds
- **Before:** Log spammed with "X is starving" for all 7 dwarves
- **After:** Log shows only mining activity, zero starvation/dehydration warnings
- No console errors
- Dwarves happily mining, transitioning between Working/Idle as expected

## Test plan
- [x] All 137 sim tests pass
- [x] Typecheck passes across all workspaces
- [x] Playtested in Chrome — no starvation warnings, dwarves working normally
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)