### PR TITLE
fix: wander system — validate walkability, clear spawn area, fix orphaned tasks

### DIFF
--- a/app/src/hooks/useTasks.ts
+++ b/app/src/hooks/useTasks.ts
@@ -61,11 +61,14 @@ export function useTasks(civId: string | null) {
     };
   }, [civId]);
 
+  /** Task types that are autonomous (not player-designated) — don't show as designations. */
+  const AUTONOMOUS_TASK_TYPES: ReadonlySet<string> = new Set(['eat', 'drink', 'sleep', 'wander']);
+
   /** Map of "x,y" → task_type for tiles with active designations */
   const designatedTiles = useMemo(() => {
     const map = new Map<string, string>();
     for (const task of tasks) {
-      if (task.target_x !== null && task.target_y !== null) {
+      if (task.target_x !== null && task.target_y !== null && !AUTONOMOUS_TASK_TYPES.has(task.task_type)) {
         map.set(`${task.target_x},${task.target_y}`, task.task_type);
       }
     }

--- a/shared/src/fortress-gen-helpers.ts
+++ b/shared/src/fortress-gen-helpers.ts
@@ -319,6 +319,14 @@ export function createFortressDeriver(
 
       // z=0: Surface with features varying by biome
       if (z === 0) {
+        // Clear surface features near stair columns and fortress center so
+        // dwarves aren't trapped by trees on spawn or unable to reach stairs
+        const center = Math.floor(FORTRESS_SIZE / 2);
+        const nearCenter = Math.abs(x - center) <= 3 && Math.abs(y - center) <= 3;
+        if (nearCenter || isAdjacentToStair(x, y, stairTypes)) {
+          const p = getProfile(terrain);
+          return { tileType: p.base, material: p.baseMaterial };
+        }
         return deriveSurfaceTile(x, y, surfaceTreeNoise, surfaceRockNoise, surfacePondNoise, terrain);
       }
 
@@ -482,6 +490,14 @@ function getProfile(terrain: TerrainType): SurfaceProfile {
   const overrides = SURFACE_PROFILES[terrain];
   if (!overrides) return DEFAULT_PROFILE;
   return { ...DEFAULT_PROFILE, ...overrides };
+}
+
+/** Check if a tile is cardinally adjacent to a stair column on the surface. */
+function isAdjacentToStair(x: number, y: number, stairTypes: Map<string, FortressTileType>): boolean {
+  return stairTypes.has(`${x + 1},${y},0`)
+    || stairTypes.has(`${x - 1},${y},0`)
+    || stairTypes.has(`${x},${y + 1},0`)
+    || stairTypes.has(`${x},${y - 1},0`);
 }
 
 export function deriveSurfaceTile(

--- a/sim/src/__tests__/idle-wandering.test.ts
+++ b/sim/src/__tests__/idle-wandering.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import type { FortressDeriver } from "@pwarf/shared";
 import { makeDwarf, makeContext } from "./test-helpers.js";
 import { idleWandering } from "../phases/idle-wandering.js";
 
@@ -45,6 +46,24 @@ describe("idle wandering", () => {
     await idleWandering(ctx);
 
     expect(ctx.state.tasks).toHaveLength(0);
+  });
+
+  it("skips non-walkable target tiles", async () => {
+    const dwarf = makeDwarf({ position_x: 128, position_y: 128, position_z: 0 });
+    // Deriver that returns stone (non-walkable) for everything
+    const stoneDeriver = {
+      deriveTile: () => ({ tileType: 'stone' as const, material: 'granite' }),
+    } as unknown as FortressDeriver;
+    const ctx = makeContext({ dwarves: [dwarf] });
+    ctx.fortressDeriver = stoneDeriver;
+
+    // Run many times — should never create a task since all targets are stone
+    for (let i = 0; i < 20; i++) {
+      await idleWandering(ctx);
+    }
+
+    const wanderTasks = ctx.state.tasks.filter(t => t.task_type === "wander");
+    expect(wanderTasks).toHaveLength(0);
   });
 
   it("wander target stays within fortress bounds", async () => {

--- a/sim/src/phases/idle-wandering.ts
+++ b/sim/src/phases/idle-wandering.ts
@@ -1,6 +1,8 @@
 import { WORK_WANDER, WANDER_RADIUS, FORTRESS_SIZE } from "@pwarf/shared";
 import type { SimContext } from "../sim-context.js";
 import { createTask, isDwarfIdle } from "../task-helpers.js";
+import { isWalkable } from "../pathfinding.js";
+import { buildTileLookup } from "../tile-lookup.js";
 
 /**
  * Idle Wandering Phase
@@ -11,6 +13,7 @@ import { createTask, isDwarfIdle } from "../task-helpers.js";
  */
 export async function idleWandering(ctx: SimContext): Promise<void> {
   const { state } = ctx;
+  const getTile = buildTileLookup(ctx);
 
   for (const dwarf of state.dwarves) {
     if (!isDwarfIdle(dwarf)) continue;
@@ -32,6 +35,10 @@ export async function idleWandering(ctx: SimContext): Promise<void> {
 
     // Skip if it's the same spot
     if (targetX === dwarf.position_x && targetY === dwarf.position_y) continue;
+
+    // Only pick walkable targets so BFS can actually path to them
+    const targetTile = getTile(targetX, targetY, dwarf.position_z);
+    if (!isWalkable(targetTile)) continue;
 
     createTask(state, ctx.civilizationId, {
       task_type: 'wander',

--- a/sim/src/phases/task-execution.ts
+++ b/sim/src/phases/task-execution.ts
@@ -1,9 +1,9 @@
-import { BASE_WORK_RATE, FORTRESS_SIZE } from "@pwarf/shared";
+import { BASE_WORK_RATE } from "@pwarf/shared";
 import type { Dwarf, Task } from "@pwarf/shared";
 import type { SimContext } from "../sim-context.js";
 import { getDwarfSkillLevel, getRequiredSkill } from "../task-helpers.js";
 import { bfsNextStep } from "../pathfinding.js";
-import type { TileLookup } from "../pathfinding.js";
+import { buildTileLookup } from "../tile-lookup.js";
 import { handleDeprivationDeaths } from "./deprivation.js";
 import { completeTask } from "./task-completion.js";
 
@@ -82,28 +82,6 @@ function isAdjacentToTarget(dwarf: Dwarf, task: Task): boolean {
   return (dx + dy) === 1;
 }
 
-/** Build a TileLookup that checks overrides first, then falls back to the deriver. */
-function buildTileLookup(ctx: SimContext): TileLookup {
-  const { fortressDeriver } = ctx;
-  const { fortressTileOverrides } = ctx.state;
-
-  return (x: number, y: number, z: number) => {
-    if (x < 0 || x >= FORTRESS_SIZE || y < 0 || y >= FORTRESS_SIZE) return null;
-
-    // Check overrides first (mined/built tiles)
-    const override = fortressTileOverrides.get(`${x},${y},${z}`);
-    if (override) return override.tile_type;
-
-    // Fall back to deterministic deriver
-    if (fortressDeriver) {
-      return fortressDeriver.deriveTile(x, y, z).tileType;
-    }
-
-    // No deriver available — treat as open_air (legacy fallback)
-    return 'open_air';
-  };
-}
-
 function moveTowardTarget(dwarf: Dwarf, task: Task, ctx: SimContext): boolean {
   if (task.target_x === null || task.target_y === null || task.target_z === null) return true;
 
@@ -135,9 +113,16 @@ function moveTowardTarget(dwarf: Dwarf, task: Task, ctx: SimContext): boolean {
 }
 
 function failTask(dwarf: Dwarf, task: Task, state: SimContext['state']): void {
-  task.status = 'pending';
-  task.assigned_dwarf_id = null;
-  task.work_progress = 0;
+  // Wander tasks should be cancelled outright — resetting them to pending
+  // with no assignee creates orphaned autonomous tasks that can never be reclaimed.
+  if (task.task_type === 'wander') {
+    task.status = 'completed';
+    task.completed_at = new Date().toISOString();
+  } else {
+    task.status = 'pending';
+    task.assigned_dwarf_id = null;
+    task.work_progress = 0;
+  }
   state.dirtyTaskIds.add(task.id);
 
   dwarf.current_task_id = null;

--- a/sim/src/tile-lookup.ts
+++ b/sim/src/tile-lookup.ts
@@ -1,0 +1,25 @@
+import { FORTRESS_SIZE } from "@pwarf/shared";
+import type { TileLookup } from "./pathfinding.js";
+import type { SimContext } from "./sim-context.js";
+
+/** Build a TileLookup that checks overrides first, then falls back to the deriver. */
+export function buildTileLookup(ctx: SimContext): TileLookup {
+  const { fortressDeriver } = ctx;
+  const { fortressTileOverrides } = ctx.state;
+
+  return (x: number, y: number, z: number) => {
+    if (x < 0 || x >= FORTRESS_SIZE || y < 0 || y >= FORTRESS_SIZE) return null;
+
+    // Check overrides first (mined/built tiles)
+    const override = fortressTileOverrides.get(`${x},${y},${z}`);
+    if (override) return override.tile_type;
+
+    // Fall back to deterministic deriver
+    if (fortressDeriver) {
+      return fortressDeriver.deriveTile(x, y, z).tileType;
+    }
+
+    // No deriver available — treat as open_air (legacy fallback)
+    return 'open_air';
+  };
+}


### PR DESCRIPTION
## Summary

**Root cause:** In forest/jungle biomes, dense trees surrounded the fortress center and stair columns on z=0, making BFS pathfinding impossible — dwarves could never find a walkable neighbor to start moving.

- **Clear surface features around spawn area** — `fortress-gen-helpers.ts` now clears trees/bushes/rocks in a 7×7 area around fortress center and tiles adjacent to stair columns on z=0, ensuring dwarves always have walkable ground at spawn.
- **Validate walkability before creating wander tasks** — `idle-wandering.ts` now checks that the random target tile is walkable before creating a task.
- **Cancel failed wander tasks instead of orphaning them** — `failTask` now completes wander tasks on failure instead of resetting to `pending` with no assignee, preventing infinite accumulation of orphaned autonomous tasks.
- **Filter autonomous tasks from designation overlay** — `useTasks.ts` now excludes eat/drink/sleep/wander tasks from `designatedTiles`, fixing the orange "designated wander" overlay around dwarves.
- **Extract `buildTileLookup` to shared module** — Moved from `task-execution.ts` to `sim/src/tile-lookup.ts` so both `task-execution` and `idle-wandering` can use it.

Closes #253

## Playtest

- Generated a new world, embarked in a forest biome
- Verified no orange "designated wander" tiles appear around dwarves
- Verified all 7 dwarves show "Working" status and scatter across the map after wandering
- Verified no console errors
- All sim tests pass including new walkability rejection test

## Test plan

- [x] `npm test --workspace=sim` — all tests pass
- [x] New test: `idle-wandering.test.ts` "skips non-walkable target tiles"
- [x] `npm run build --workspace=sim` — typechecks clean
- [x] Visual verification: no orange designation overlay on wander tiles
- [x] Visual verification: dwarves actually move and wander
- [x] No console errors in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)