### PR TITLE
fix: add 5s timeout to getSession to prevent infinite hang

### DIFF
--- a/app/src/hooks/useAuth.ts
+++ b/app/src/hooks/useAuth.ts
@@ -7,13 +7,16 @@ export function useAuth() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    supabase.auth
-      .getSession()
+    const timeout = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error("timeout")), 5000),
+    );
+
+    Promise.race([supabase.auth.getSession(), timeout])
       .then(({ data: { session: s } }) => {
         setSession(s);
       })
       .catch(() => {
-        // Token refresh failed — clear stale session so login screen shows
+        // getSession hung or failed — show login screen
         setSession(null);
       })
       .finally(() => {


### PR DESCRIPTION
## Summary
- Fixes #260
- Follow-up to #259 — `.catch()` alone doesn't help because `getSession()` never rejects when Supabase is unreachable, the fetch just hangs forever
- Races `getSession()` against a 5-second timeout so the login screen appears instead of hanging indefinitely

## Test plan
- [ ] With Supabase paused, verify app shows login screen after ~5s instead of hanging
- [ ] With Supabase running, verify normal auth flow works (timeout doesn't interfere)

🤖 Generated with [Claude Code](https://claude.com/claude-code)