### PR TITLE
feat: live sim snapshots for instant UI updates

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -69,8 +69,24 @@ export default function App() {
     : null;
   const cursorFortressTile = world.civId ? getFortressTile(viewport.cursorX, viewport.cursorY) : null;
 
-  // Active tasks
-  const { designatedTiles } = useTasks(world.civId);
+  // Sim runner — provides live in-memory state
+  const { snapshot } = useSimRunner(world.civId, world.worldId);
+
+  // Active tasks — prefer live snapshot, fall back to DB polling
+  const polledTasks = useTasks(world.civId);
+  const designatedTiles = useMemo(() => {
+    const AUTONOMOUS: ReadonlySet<string> = new Set(['eat', 'drink', 'sleep', 'wander']);
+    const tasks = snapshot?.tasks ?? polledTasks.tasks;
+    const map = new Map<string, string>();
+    for (const t of tasks) {
+      const tx = 'target_x' in t ? t.target_x : null;
+      const ty = 'target_y' in t ? t.target_y : null;
+      if (tx !== null && ty !== null && !AUTONOMOUS.has(t.task_type) && ['pending', 'claimed', 'in_progress'].includes(t.status)) {
+        map.set(`${tx},${ty}`, t.task_type);
+      }
+    }
+    return map;
+  }, [snapshot?.tasks, polledTasks.tasks]);
 
   const designation = useDesignation({
     civId: world.civId,
@@ -79,8 +95,31 @@ export default function App() {
     designatedTiles,
   });
 
-  // Live dwarves from DB
-  const liveDwarves = useDwarves(world.civId);
+  // Live dwarves — prefer sim snapshot over DB polling
+  const polledDwarves = useDwarves(world.civId);
+  const liveDwarves: LiveDwarf[] = useMemo(() => {
+    if (snapshot) {
+      return snapshot.dwarves
+        .filter((d) => d.status === 'alive')
+        .map((d) => ({
+          id: d.id,
+          name: d.name,
+          surname: d.surname,
+          status: d.status,
+          position_x: d.position_x,
+          position_y: d.position_y,
+          position_z: d.position_z,
+          current_task_id: d.current_task_id,
+          need_food: d.need_food,
+          need_drink: d.need_drink,
+          need_sleep: d.need_sleep,
+          stress_level: d.stress_level,
+          health: d.health,
+          memories: d.memories as LiveDwarf['memories'],
+        }));
+    }
+    return polledDwarves;
+  }, [snapshot, polledDwarves]);
 
   // Build dwarf position map for rendering
   const dwarfPositions = useMemo(() => {
@@ -93,11 +132,22 @@ export default function App() {
     return map;
   }, [liveDwarves, zLevel]);
 
-  // Sim runner
-  useSimRunner(world.civId, world.worldId);
-
-  // Live activity log
-  const events = useEvents(world.civId);
+  // Live activity log — prefer snapshot, fall back to DB polling
+  const polledEvents = useEvents(world.civId);
+  const events = useMemo(() => {
+    if (snapshot && snapshot.events.length > 0) {
+      return snapshot.events
+        .slice(-50)
+        .reverse()
+        .map((e) => ({
+          id: e.id,
+          description: e.description,
+          category: e.category,
+          created_at: e.created_at ?? new Date().toISOString(),
+        }));
+    }
+    return polledEvents;
+  }, [snapshot, polledEvents]);
 
   const handleKeyAction = useCallback(
     (action: KeyAction) => {

--- a/app/src/hooks/useSimRunner.ts
+++ b/app/src/hooks/useSimRunner.ts
@@ -1,29 +1,61 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import { SimRunner } from '@pwarf/sim';
+import type { SimSnapshot } from '@pwarf/sim';
 import { supabase } from '../lib/supabase';
+
+export type { SimSnapshot };
 
 export function useSimRunner(civId: string | null, worldId: string | null) {
   const runnerRef = useRef<SimRunner | null>(null);
+  const [snapshot, setSnapshot] = useState<SimSnapshot | null>(null);
+
+  // Throttle UI updates — emit at most every 100ms (10 fps) to avoid
+  // re-rendering on every single sim tick (which runs at 10/s anyway).
+  const lastEmit = useRef(0);
+  const pendingFrame = useRef<ReturnType<typeof requestAnimationFrame> | null>(null);
+
+  const handleTick = useCallback((snap: SimSnapshot) => {
+    const now = performance.now();
+    if (now - lastEmit.current >= 100) {
+      lastEmit.current = now;
+      setSnapshot(snap);
+    } else if (!pendingFrame.current) {
+      pendingFrame.current = requestAnimationFrame(() => {
+        pendingFrame.current = null;
+        lastEmit.current = performance.now();
+        setSnapshot(snap);
+      });
+    }
+  }, []);
 
   useEffect(() => {
-    if (!civId || !worldId) return;
+    if (!civId || !worldId) {
+      setSnapshot(null);
+      return;
+    }
 
     // Cast to satisfy cross-package SupabaseClient type mismatch
     // (both app and sim depend on the same @supabase/supabase-js version)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const runner = new SimRunner(supabase as any);
+    runner.onTick = handleTick;
     runnerRef.current = runner;
     runner.start(civId, worldId).catch((err: unknown) => {
       console.error('[sim] failed to start:', err);
     });
 
     return () => {
+      runner.onTick = null;
+      if (pendingFrame.current) {
+        cancelAnimationFrame(pendingFrame.current);
+        pendingFrame.current = null;
+      }
       runner.stop().catch((err: unknown) => {
         console.error('[sim] failed to stop:', err);
       });
       runnerRef.current = null;
     };
-  }, [civId, worldId]);
+  }, [civId, worldId, handleTick]);
 
-  return runnerRef;
+  return { runnerRef, snapshot };
 }

--- a/sim/src/__tests__/sim-runner.test.ts
+++ b/sim/src/__tests__/sim-runner.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi } from "vitest";
+import { SimRunner } from "../sim-runner.js";
+import type { SimSnapshot } from "../sim-runner.js";
+import { makeDwarf, makeContext } from "./test-helpers.js";
+
+// Mock load-state to avoid hitting Supabase
+vi.mock("../load-state.js", () => ({
+  loadStateFromSupabase: vi.fn(),
+}));
+
+// Mock flush-state to avoid hitting Supabase
+vi.mock("../flush-state.js", () => ({
+  flushToSupabase: vi.fn(),
+}));
+
+// Minimal mock supabase client for SimRunner constructor
+function mockSupabase() {
+  return {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: { seed: "12345" }, error: null }),
+          eq: vi.fn().mockReturnValue({
+            in: vi.fn().mockResolvedValue({ data: [], error: null }),
+          }),
+        }),
+      }),
+    }),
+  } as never;
+}
+
+describe("SimRunner", () => {
+  describe("onTick callback", () => {
+    it("calls onTick with a snapshot after each tick", async () => {
+      const runner = new SimRunner(mockSupabase());
+      const dwarf = makeDwarf({ name: "Urist" });
+
+      // Manually set up the context to avoid start() hitting supabase
+      const ctx = makeContext({ dwarves: [dwarf] });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (runner as any).ctx = ctx;
+
+      const snapshots: SimSnapshot[] = [];
+      runner.onTick = (snap) => snapshots.push(snap);
+
+      await runner.tick();
+
+      expect(snapshots).toHaveLength(1);
+      expect(snapshots[0]!.dwarves).toHaveLength(1);
+      expect(snapshots[0]!.dwarves[0]!.name).toBe("Urist");
+    });
+
+    it("does not call onTick when callback is null", async () => {
+      const runner = new SimRunner(mockSupabase());
+      const ctx = makeContext({ dwarves: [makeDwarf()] });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (runner as any).ctx = ctx;
+
+      runner.onTick = null;
+
+      // Should not throw
+      await runner.tick();
+    });
+
+    it("snapshot reflects current dwarf positions", async () => {
+      const runner = new SimRunner(mockSupabase());
+      const dwarf = makeDwarf({ position_x: 10, position_y: 20 });
+      const ctx = makeContext({ dwarves: [dwarf] });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (runner as any).ctx = ctx;
+
+      let lastSnap: SimSnapshot | null = null;
+      runner.onTick = (snap) => { lastSnap = snap; };
+
+      await runner.tick();
+
+      // Position may have changed due to idle wandering, but snapshot should reflect current state
+      expect(lastSnap).not.toBeNull();
+      expect(lastSnap!.dwarves[0]!.position_x).toBe(dwarf.position_x);
+      expect(lastSnap!.dwarves[0]!.position_y).toBe(dwarf.position_y);
+    });
+
+    it("snapshot includes tasks", async () => {
+      const runner = new SimRunner(mockSupabase());
+      const ctx = makeContext({
+        dwarves: [makeDwarf()],
+        tasks: [{
+          id: "task-1",
+          civilization_id: "civ-1",
+          task_type: "mine",
+          status: "pending",
+          priority: 5,
+          target_x: 10,
+          target_y: 20,
+          target_z: 0,
+          target_item_id: null,
+          work_progress: 0,
+          work_required: 100,
+          assigned_dwarf_id: null,
+          created_at: new Date().toISOString(),
+          completed_at: null,
+        }],
+      });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (runner as any).ctx = ctx;
+
+      let lastSnap: SimSnapshot | null = null;
+      runner.onTick = (snap) => { lastSnap = snap; };
+
+      await runner.tick();
+
+      expect(lastSnap!.tasks.length).toBeGreaterThanOrEqual(1);
+      expect(lastSnap!.tasks.some(t => t.task_type === "mine")).toBe(true);
+    });
+  });
+});

--- a/sim/src/flush-state.ts
+++ b/sim/src/flush-state.ts
@@ -24,6 +24,19 @@ export async function flushToSupabase(ctx: SimContext): Promise<void> {
   const newTasks = [...state.newTasks];
   const events = [...state.pendingEvents];
 
+  // Flush tasks BEFORE dwarves — dwarves.current_task_id has a FK to tasks,
+  // so the referenced task row must exist first.
+  if (newTasks.length > 0) {
+    const { error } = await supabase.from("tasks").insert(newTasks);
+    if (error) console.warn(`[flush] tasks insert failed: ${error.message}`);
+  }
+
+  if (dirtyTasks.length > 0) {
+    const { error } = await supabase.from("tasks").upsert(dirtyTasks);
+    if (error) console.warn(`[flush] tasks upsert failed: ${error.message}`);
+  }
+
+  // Now flush everything else in parallel
   const promises: PromiseLike<void>[] = [];
 
   if (dirtyDwarves.length > 0) {
@@ -78,28 +91,6 @@ export async function flushToSupabase(ctx: SimContext): Promise<void> {
         .upsert(dirtyMonsters)
         .then(({ error }) => {
           if (error) console.warn(`[flush] monsters upsert failed: ${error.message}`);
-        }),
-    );
-  }
-
-  if (dirtyTasks.length > 0) {
-    promises.push(
-      supabase
-        .from("tasks")
-        .upsert(dirtyTasks)
-        .then(({ error }) => {
-          if (error) console.warn(`[flush] tasks upsert failed: ${error.message}`);
-        }),
-    );
-  }
-
-  if (newTasks.length > 0) {
-    promises.push(
-      supabase
-        .from("tasks")
-        .insert(newTasks)
-        .then(({ error }) => {
-          if (error) console.warn(`[flush] tasks insert failed: ${error.message}`);
         }),
     );
   }

--- a/sim/src/index.ts
+++ b/sim/src/index.ts
@@ -1,3 +1,4 @@
 export { SimRunner } from "./sim-runner.js";
+export type { SimSnapshot } from "./sim-runner.js";
 export { loadStateFromSupabase } from "./load-state.js";
 export { flushToSupabase } from "./flush-state.js";

--- a/sim/src/sim-runner.ts
+++ b/sim/src/sim-runner.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { STEPS_PER_SECOND, STEPS_PER_YEAR, SIM_FLUSH_INTERVAL_MS, createFortressDeriver } from "@pwarf/shared";
+import type { Dwarf, Task, WorldEvent } from "@pwarf/shared";
 import type { SimContext } from "./sim-context.js";
 import { createEmptyCachedState } from "./sim-context.js";
 import { loadStateFromSupabase } from "./load-state.js";
@@ -20,6 +21,13 @@ import {
   thoughtGeneration,
 } from "./phases/index.js";
 
+/** Snapshot of sim state emitted after every tick for live UI rendering. */
+export interface SimSnapshot {
+  dwarves: Dwarf[];
+  tasks: Task[];
+  events: WorldEvent[];
+}
+
 /**
  * Main simulation loop.
  *
@@ -31,6 +39,9 @@ export class SimRunner {
   private timer: ReturnType<typeof setInterval> | null = null;
   private flushTimer: ReturnType<typeof setInterval> | null = null;
   private ctx: SimContext | null = null;
+
+  /** Called after every tick with the current in-memory state. */
+  onTick: ((snapshot: SimSnapshot) => void) | null = null;
 
   stepCount = 0;
   currentYear = 1;
@@ -163,6 +174,15 @@ export class SimRunner {
       this.ctx.year = this.currentYear;
       this.ctx.day = this.currentDay;
       await yearlyRollup(this.ctx);
+    }
+
+    // Emit snapshot for live UI rendering
+    if (this.onTick) {
+      this.onTick({
+        dwarves: this.ctx.state.dwarves,
+        tasks: this.ctx.state.tasks,
+        events: this.ctx.state.worldEvents,
+      });
     }
   }
 }


### PR DESCRIPTION
## Summary
- Fixes #262
- SimRunner now emits an `onTick` callback with in-memory state (dwarves, tasks, events) after every tick
- `useSimRunner` captures snapshots and feeds them directly to React — UI updates at ~10fps instead of waiting for the 15s DB flush + 2-3s poll cycle
- App.tsx prefers live snapshot data over DB-polled data when available
- Fixes flush ordering bug: tasks are now inserted before dwarves so the `current_task_id` FK constraint is satisfied
- Adds 4 tests for the `onTick` snapshot callback

## Playtest report
- Dwarves now visibly wander around the fortress in real-time
- Status updates (Idle → Working) appear immediately
- No console errors from flush ordering after the fix
- Previously dwarves appeared frozen because positions only updated after 15s flush + 2s poll = up to 17s lag

Screenshots: Dwarves visible moving to different positions between 3-second intervals, statuses updating live in the left panel.

## Test plan
- [x] All 455 tests pass (36 files)
- [x] TypeScript compiles clean across all workspaces
- [x] Playtested locally — dwarves move in real-time
- [ ] Verify DB persistence still works after 15s flush
- [ ] Verify designation tasks still sync correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)