### PR TITLE
feat: blueprint preview, dwarf modal, gradual sleep, remove stairs

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -18,6 +18,7 @@ import { useWorldState } from "./hooks/useWorldState";
 import { useDesignation, type DesignationMode } from "./hooks/useDesignation";
 import BuildMenu, { BUILD_OPTIONS } from "./components/BuildMenu";
 import TaskPriorities from "./components/TaskPriorities";
+import { DwarfModal } from "./components/DwarfModal";
 import { SURFACE_Z, CAVE_Z } from "@pwarf/shared";
 import type { LiveDwarf } from "./hooks/useDwarves";
 
@@ -213,6 +214,16 @@ export default function App() {
     );
   }, [viewport.setOffset, vpCols, vpRows]);
 
+  // Dwarf info modal
+  const [modalDwarfId, setModalDwarfId] = useState<string | null>(null);
+  const modalDwarf = modalDwarfId ? liveDwarves.find(d => d.id === modalDwarfId) ?? null : null;
+
+  const handleDwarfClick = useCallback((x: number, y: number) => {
+    const key = `${x},${y}`;
+    const dwarf = liveDwarves.find(d => d.position_x === x && d.position_y === y && d.position_z === zLevel);
+    if (dwarf) setModalDwarfId(dwarf.id);
+  }, [liveDwarves, zLevel]);
+
   // Keyboard shortcuts for build menu items when the menu is open
   useEffect(() => {
     if (!designation.buildMenuOpen) return;
@@ -345,7 +356,16 @@ export default function App() {
           onCancelArea={world.mode === "fortress" ? designation.handleCancelArea : undefined}
           onTileClick={world.mode === "world" ? (x: number, y: number) => setSelectedWorldTile({ x, y }) : undefined}
           selectedTile={world.mode === "world" ? selectedWorldTile : undefined}
+          onDwarfClick={world.mode === "fortress" ? handleDwarfClick : undefined}
         />
+
+        {modalDwarf && (
+          <DwarfModal
+            dwarf={modalDwarf}
+            onClose={() => setModalDwarfId(null)}
+            onGoTo={handleGoToDwarf}
+          />
+        )}
 
         <RightPanel
           collapsed={!rightOpen}

--- a/app/src/components/BuildMenu.tsx
+++ b/app/src/components/BuildMenu.tsx
@@ -9,9 +9,6 @@ export type BuildOption = {
 const BUILD_OPTIONS: BuildOption[] = [
   { label: "Wall", key: "w", taskType: "build_wall" },
   { label: "Floor", key: "f", taskType: "build_floor" },
-  { label: "Stairs Up", key: "u", taskType: "build_stairs_up" },
-  { label: "Stairs Down", key: "d", taskType: "build_stairs_down" },
-  { label: "Stairs Up/Down", key: "x", taskType: "build_stairs_both" },
 ];
 
 interface BuildMenuProps {

--- a/app/src/components/DwarfModal.tsx
+++ b/app/src/components/DwarfModal.tsx
@@ -1,0 +1,121 @@
+import { useEffect } from "react";
+import type { LiveDwarf, DwarfThought } from "../hooks/useDwarves";
+
+interface DwarfModalProps {
+  dwarf: LiveDwarf;
+  onClose: () => void;
+  onGoTo: (dwarf: LiveDwarf) => void;
+}
+
+function dwarfJobLabel(d: LiveDwarf): string {
+  if (d.current_task_id) return "Working";
+  return "Idle";
+}
+
+function needBar(label: string, value: number, color: string) {
+  const pct = Math.round(value);
+  const barColor = value < 25 ? "var(--red, #f87171)" : color;
+  return (
+    <div className="flex items-center gap-1">
+      <span className="w-14 text-[var(--text)]">{label}</span>
+      <div className="flex-1 h-2 bg-[#333] rounded overflow-hidden">
+        <div
+          className="h-full rounded"
+          style={{ width: `${pct}%`, backgroundColor: barColor }}
+        />
+      </div>
+      <span className="w-8 text-right" style={{ color: barColor }}>{pct}</span>
+    </div>
+  );
+}
+
+export function DwarfModal({ dwarf, onClose, onGoTo }: DwarfModalProps) {
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        onClose();
+      }
+    }
+    window.addEventListener("keydown", handleKey, true);
+    return () => window.removeEventListener("keydown", handleKey, true);
+  }, [onClose]);
+
+  return (
+    <div
+      className="absolute inset-0 z-50 flex items-center justify-center"
+      onClick={onClose}
+    >
+      <div
+        className="bg-[var(--bg-panel)] border border-[var(--amber)] p-4 min-w-[280px] max-w-[360px] text-xs"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-2">
+          <h2 className="text-[var(--green)] font-bold text-sm">
+            {dwarf.name}{dwarf.surname ? ` ${dwarf.surname}` : ""}
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-[var(--text)] hover:text-[var(--amber)] cursor-pointer"
+          >
+            [Esc]
+          </button>
+        </div>
+
+        <div className="text-[var(--text)] mb-2">
+          Status: <span className="text-[var(--green)]">{dwarfJobLabel(dwarf)}</span>
+        </div>
+
+        <div className="text-[var(--text)] flex items-center justify-between mb-2">
+          <span>
+            Pos: <span className="text-[var(--green)]">({dwarf.position_x}, {dwarf.position_y}, z{dwarf.position_z})</span>
+          </span>
+          <button
+            onClick={() => onGoTo(dwarf)}
+            className="text-[var(--amber)] hover:text-[var(--green)] cursor-pointer"
+          >
+            Go to
+          </button>
+        </div>
+
+        <div className="border-t border-[var(--border)] pt-2 mt-2 space-y-1">
+          <div className="text-[var(--amber)] font-bold mb-0.5">Needs</div>
+          {needBar("Food", dwarf.need_food, "var(--green)")}
+          {needBar("Drink", dwarf.need_drink, "#4488ff")}
+          {needBar("Sleep", dwarf.need_sleep, "#aa88ff")}
+        </div>
+
+        <div className="border-t border-[var(--border)] pt-2 mt-2">
+          <div className="text-[var(--amber)] font-bold mb-0.5">Stress</div>
+          {needBar("Stress", dwarf.stress_level, "#ff6600")}
+        </div>
+
+        <div className="border-t border-[var(--border)] pt-2 mt-2">
+          <div className="text-[var(--amber)] font-bold mb-0.5">Health</div>
+          {needBar("HP", dwarf.health, "var(--green)")}
+        </div>
+
+        {dwarf.memories && dwarf.memories.length > 0 && (
+          <div className="border-t border-[var(--border)] pt-2 mt-2">
+            <div className="text-[var(--amber)] font-bold mb-0.5">Thoughts</div>
+            <ul className="space-y-0.5">
+              {[...dwarf.memories].reverse().slice(0, 5).map((thought: DwarfThought, i: number) => (
+                <li key={i} className="flex items-start gap-1">
+                  <span className={
+                    thought.sentiment === "positive" ? "text-[var(--green)]" :
+                    thought.sentiment === "negative" ? "text-[#f87171]" :
+                    "text-[var(--text)]"
+                  }>
+                    {thought.sentiment === "positive" ? "+" : thought.sentiment === "negative" ? "-" : "·"}
+                  </span>
+                  <span className="text-[var(--text)]">{thought.text}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/MainViewport.tsx
+++ b/app/src/components/MainViewport.tsx
@@ -30,6 +30,8 @@ interface MainViewportProps {
   onTileClick?: (x: number, y: number) => void;
   /** Selected world tile position */
   selectedTile?: { x: number; y: number } | null;
+  /** Click handler for clicking a dwarf on the map */
+  onDwarfClick?: (x: number, y: number) => void;
 }
 
 // Character cell dimensions (monospace)
@@ -69,6 +71,7 @@ export default function MainViewport({
   onCancelArea,
   onTileClick,
   selectedTile,
+  onDwarfClick,
 }: MainViewportProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -195,20 +198,29 @@ export default function MainViewport({
       }
     }
 
-    // Draw selection rectangle overlay
+    // Draw selection rectangle overlay with blueprint preview
     if (selStart && selEnd) {
       const sx1 = Math.min(selStart.x, selEnd.x);
       const sy1 = Math.min(selStart.y, selEnd.y);
       const sx2 = Math.max(selStart.x, selEnd.x);
       const sy2 = Math.max(selStart.y, selEnd.y);
 
-      ctx.fillStyle = isCancelling ? "rgba(255, 0, 0, 0.25)" : "rgba(255, 102, 0, 0.25)";
+      const preview = designationMode && !isCancelling ? DESIGNATION_PREVIEW[designationMode] : null;
+
       for (let sy = sy1; sy <= sy2; sy++) {
         for (let sx = sx1; sx <= sx2; sx++) {
           const px = (sx - offsetX) * CHAR_W;
           const py = (sy - offsetY) * CHAR_H;
           if (px >= 0 && px < w && py >= 0 && py < h) {
+            // Background tint
+            ctx.fillStyle = isCancelling ? "rgba(255, 0, 0, 0.25)" : "rgba(68, 34, 0, 0.6)";
             ctx.fillRect(px, py, CHAR_W, CHAR_H);
+
+            // Blueprint glyph preview
+            if (preview) {
+              ctx.fillStyle = preview.fg;
+              ctx.fillText(preview.ch, px + 1, py + 2);
+            }
           }
         }
       }
@@ -312,9 +324,15 @@ export default function MainViewport({
           onDesignateArea(x1, y1, x2, y2);
         }
       }
-      // Fire tile click if user clicked without dragging (world map selection)
-      if (dragging.current && !dragMoved.current && !isDesignating && onTileClick) {
-        onTileClick(cursorX, cursorY);
+      // Fire tile click if user clicked without dragging
+      if (dragging.current && !dragMoved.current && !isDesignating) {
+        // Check for dwarf click in fortress mode
+        const cursorKey = `${cursorX},${cursorY}`;
+        if (onDwarfClick && dwarfPositions?.has(cursorKey)) {
+          onDwarfClick(cursorX, cursorY);
+        } else if (onTileClick) {
+          onTileClick(cursorX, cursorY);
+        }
       }
       dragging.current = false;
       dragMoved.current = false;
@@ -326,7 +344,7 @@ export default function MainViewport({
         onDragEnd();
       }
     },
-    [onDragEnd, onDesignateArea, onCancelArea, onTileClick, isDesignating, selStart, selEnd, cursorX, cursorY],
+    [onDragEnd, onDesignateArea, onCancelArea, onTileClick, onDwarfClick, dwarfPositions, isDesignating, selStart, selEnd, cursorX, cursorY],
   );
 
   return (

--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -102,6 +102,9 @@ export const FOOD_RESTORE_AMOUNT = 40;
 /** Amount need_drink is restored when drinking basic drink */
 export const DRINK_RESTORE_AMOUNT = 50;
 
+/** Total amount need_sleep is restored over the course of one sleep task */
+export const SLEEP_RESTORE_AMOUNT = 60;
+
 /** Stress penalty per tick for sleeping on the floor instead of a bed */
 export const FLOOR_SLEEP_STRESS = 5;
 
@@ -139,8 +142,11 @@ export const WORK_EAT = 10;
 /** Work required for drinking */
 export const WORK_DRINK = 10;
 
-/** Work required for sleeping */
-export const WORK_SLEEP = 50;
+/** Work required for sleeping (~8 in-game hours ≈ 16 ticks) */
+export const WORK_SLEEP = 16;
+
+/** Amount need_sleep is restored per tick while sleeping (SLEEP_RESTORE_AMOUNT / WORK_SLEEP) */
+export const SLEEP_RESTORE_PER_TICK = SLEEP_RESTORE_AMOUNT / WORK_SLEEP;
 
 /** Work required to build a wall */
 export const WORK_BUILD_WALL = 80;

--- a/sim/src/__tests__/task-completion.test.ts
+++ b/sim/src/__tests__/task-completion.test.ts
@@ -106,7 +106,7 @@ describe("completeTask", () => {
     expect(dwarf.need_drink).toBe(Math.min(MAX_NEED, 15 + DRINK_RESTORE_AMOUNT));
   });
 
-  it("sleeping restores sleep to MAX_NEED", () => {
+  it("sleeping completion does not add extra sleep (gradual restore happens in task-execution)", () => {
     const dwarf = makeDwarf({ need_sleep: 10 });
     const ctx = makeContext({ dwarves: [dwarf] });
     const task = createTask(ctx.state, "civ-1", {
@@ -118,7 +118,8 @@ describe("completeTask", () => {
 
     completeTask(dwarf, task, ctx);
 
-    expect(dwarf.need_sleep).toBe(MAX_NEED);
+    // Sleep restoration is gradual — completeSleep no longer adds anything
+    expect(dwarf.need_sleep).toBe(10);
   });
 
   it("mining at z=0 creates stone item and grass tile", () => {

--- a/sim/src/__tests__/task-dispatch.test.ts
+++ b/sim/src/__tests__/task-dispatch.test.ts
@@ -7,8 +7,11 @@ import {
   STARVATION_TICKS,
   FOOD_RESTORE_AMOUNT,
   DRINK_RESTORE_AMOUNT,
+  SLEEP_RESTORE_AMOUNT,
+  SLEEP_RESTORE_PER_TICK,
   BASE_WORK_RATE,
   WORK_EAT,
+  WORK_SLEEP,
   MAX_NEED,
 } from "@pwarf/shared";
 import { needsDecay } from "../phases/needs-decay.js";
@@ -246,7 +249,7 @@ describe("task execution", () => {
     expect(dwarf.need_drink).toBe(Math.min(MAX_NEED, 15 + DRINK_RESTORE_AMOUNT));
   });
 
-  it("sleeping restores sleep to 100", async () => {
+  it("sleeping restores sleep gradually each tick", async () => {
     const dwarf = makeDwarf({
       position_x: 0, position_y: 0, position_z: 0,
       need_sleep: 10,
@@ -258,16 +261,22 @@ describe("task execution", () => {
       target_x: 0,
       target_y: 0,
       target_z: 0,
-      work_required: 1,
+      work_required: WORK_SLEEP,
       assigned_dwarf_id: dwarf.id,
     });
     task.status = "in_progress";
     task.assigned_dwarf_id = dwarf.id;
     dwarf.current_task_id = task.id;
 
+    // After 1 tick, only a fraction of sleep should be restored
     await taskExecution(ctx);
+    expect(dwarf.need_sleep).toBeCloseTo(10 + SLEEP_RESTORE_PER_TICK, 5);
 
-    expect(dwarf.need_sleep).toBe(MAX_NEED);
+    // After all ticks, full SLEEP_RESTORE_AMOUNT should be restored
+    for (let i = 1; i < WORK_SLEEP; i++) {
+      await taskExecution(ctx);
+    }
+    expect(dwarf.need_sleep).toBeCloseTo(10 + SLEEP_RESTORE_AMOUNT, 5);
   });
 
   it("mining creates a stone item", async () => {

--- a/sim/src/phases/task-completion.ts
+++ b/sim/src/phases/task-completion.ts
@@ -257,7 +257,8 @@ function completeDrink(dwarf: Dwarf, task: Task, ctx: SimContext): void {
 }
 
 function completeSleep(dwarf: Dwarf, ctx: SimContext): void {
-  dwarf.need_sleep = MAX_NEED;
+  // Sleep restoration happens gradually each tick in task-execution.
+  // Nothing extra to do on completion.
   ctx.state.dirtyDwarfIds.add(dwarf.id);
 }
 

--- a/sim/src/phases/task-execution.ts
+++ b/sim/src/phases/task-execution.ts
@@ -1,4 +1,4 @@
-import { BASE_WORK_RATE } from "@pwarf/shared";
+import { BASE_WORK_RATE, SLEEP_RESTORE_PER_TICK, MAX_NEED } from "@pwarf/shared";
 import type { Dwarf, Task } from "@pwarf/shared";
 import type { SimContext } from "../sim-context.js";
 import { getDwarfSkillLevel, getRequiredSkill } from "../task-helpers.js";
@@ -67,6 +67,12 @@ export async function taskExecution(ctx: SimContext): Promise<void> {
 
     task.work_progress += workRate;
     state.dirtyTaskIds.add(task.id);
+
+    // Restore sleep gradually each tick while sleeping
+    if (task.task_type === 'sleep') {
+      dwarf.need_sleep = Math.min(MAX_NEED, dwarf.need_sleep + SLEEP_RESTORE_PER_TICK);
+      state.dirtyDwarfIds.add(dwarf.id);
+    }
 
     if (task.work_progress >= task.work_required) {
       completeTask(dwarf, task, ctx);


### PR DESCRIPTION
## Summary
- **Blueprint preview during drag**: When dragging to designate (mine/build), preview glyphs now render immediately during drag, not just after release
- **Clickable dwarf info modal**: Click a dwarf on the fortress map to open an info modal showing name, status, position, needs, stress, health, and thoughts. Press Esc or click backdrop to dismiss. Same UI as left panel detail view.
- **Gradual sleep restoration**: Sleep now restores by `SLEEP_RESTORE_AMOUNT` (60) per sleep task completion instead of instantly jumping to `MAX_NEED` (100)
- **Remove stair build options**: Stairs removed from build menu since cave entrance system replaced the stair column approach

Closes #264

## Playtest
- Fortress loads with 7 alive dwarves, sim runs correctly
- Dwarves wander around the fortress and show Working/Idle status in real-time
- Clicking a dwarf opens the info modal with all data (needs bars, stress, health, thoughts)
- Esc dismisses the modal correctly
- Build menu shows only Wall and Floor (no stairs)
- Mining designation drag works and shows orange X glyphs on designated tiles
- No console errors throughout testing
- Gradual sleep verified via unit tests (sleep 10 → 70 after one sleep task, not 10 → 100)

Screenshots:

**Dwarf info modal (click on dwarf)**
![modal](https://github.com/user-attachments/assets/placeholder-modal)

**Build menu (no stairs)**
![build](https://github.com/user-attachments/assets/placeholder-build)

**Mining designations**
![mine](https://github.com/user-attachments/assets/placeholder-mine)

_Note: Screenshot URLs are placeholders — actual screenshots were taken during playtest but browser automation doesn't support image upload._

🤖 Generated with [Claude Code](https://claude.com/claude-code)