### PR TITLE
fix: walkable surface tiles + remove stair references

### DIFF
--- a/app/src/components/BuildMenu.tsx
+++ b/app/src/components/BuildMenu.tsx
@@ -9,9 +9,6 @@ export type BuildOption = {
 const BUILD_OPTIONS: BuildOption[] = [
   { label: "Wall", key: "w", taskType: "build_wall" },
   { label: "Floor", key: "f", taskType: "build_floor" },
-  { label: "Stairs Up", key: "u", taskType: "build_stairs_up" },
-  { label: "Stairs Down", key: "d", taskType: "build_stairs_down" },
-  { label: "Stairs Up/Down", key: "x", taskType: "build_stairs_both" },
 ];
 
 interface BuildMenuProps {

--- a/app/src/components/TaskPriorities.tsx
+++ b/app/src/components/TaskPriorities.tsx
@@ -9,9 +9,6 @@ const PRIORITY_TASK_TYPES: Array<{ label: string; taskType: TaskType }> = [
   { label: "Farm (harvest)", taskType: "farm_harvest" },
   { label: "Build Wall", taskType: "build_wall" },
   { label: "Build Floor", taskType: "build_floor" },
-  { label: "Build Stairs Up", taskType: "build_stairs_up" },
-  { label: "Build Stairs Down", taskType: "build_stairs_down" },
-  { label: "Build Stairs Both", taskType: "build_stairs_both" },
 ];
 
 interface TaskPrioritiesProps {

--- a/app/src/components/tile-glyphs.test.ts
+++ b/app/src/components/tile-glyphs.test.ts
@@ -12,7 +12,7 @@ const ALL_FORTRESS_TILES: FortressTileType[] = [
   "open_air", "grass", "tree", "rock", "bush", "pond",
   "soil", "stone", "ore", "gem", "water", "magma",
   "lava_stone", "cavern_floor", "cavern_wall", "constructed_wall",
-  "constructed_floor", "stair_up", "stair_down", "stair_both",
+  "constructed_floor",
   "sand", "ice", "mud", "cave_entrance", "empty",
 ];
 
@@ -38,7 +38,7 @@ describe("FORTRESS_GLYPHS", () => {
 
 describe("DESIGNATION_PREVIEW", () => {
   it("has entries for all designation types", () => {
-    const expected = ["mine", "build_wall", "build_floor", "build_stairs_up", "build_stairs_down", "build_stairs_both"];
+    const expected = ["mine", "build_wall", "build_floor"];
     for (const key of expected) {
       expect(DESIGNATION_PREVIEW[key]).toBeDefined();
     }

--- a/app/src/components/tile-glyphs.ts
+++ b/app/src/components/tile-glyphs.ts
@@ -35,9 +35,6 @@ export const FORTRESS_GLYPHS: Record<FortressTileType, { ch: string; fg: string 
   cavern_wall:        { ch: "\u2593", fg: "#666" },
   constructed_wall:   { ch: "#",  fg: "#aaa" },
   constructed_floor:  { ch: "+",  fg: "#888" },
-  stair_up:           { ch: "<",  fg: "#4af626" },
-  stair_down:         { ch: ">",  fg: "#4af626" },
-  stair_both:         { ch: "X",  fg: "#4af626" },
   well:               { ch: "O",  fg: "#5599dd" },
   mushroom_garden:    { ch: "\u2261", fg: "#aa66cc" },
   sand:               { ch: "≡",  fg: "#cc9944" },
@@ -52,7 +49,4 @@ export const DESIGNATION_PREVIEW: Record<string, { ch: string; fg: string }> = {
   mine:              { ch: "X", fg: "#cc6600" },
   build_wall:        { ch: "#", fg: "#cc8844" },
   build_floor:       { ch: "+", fg: "#cc8844" },
-  build_stairs_up:   { ch: "<", fg: "#cc8844" },
-  build_stairs_down: { ch: ">", fg: "#cc8844" },
-  build_stairs_both: { ch: "X", fg: "#cc8844" },
 };

--- a/app/src/hooks/useDesignation.ts
+++ b/app/src/hooks/useDesignation.ts
@@ -7,19 +7,15 @@ import {
   WORK_CLEAR_BUSH,
   WORK_BUILD_WALL,
   WORK_BUILD_FLOOR,
-  WORK_BUILD_STAIRS,
 } from "@pwarf/shared";
 import { supabase } from "../lib/supabase";
 import type { FortressViewTile } from "./useFortressTiles";
 
-export type DesignationMode = "none" | "mine" | "build_wall" | "build_floor" | "build_stairs_up" | "build_stairs_down" | "build_stairs_both";
+export type DesignationMode = "none" | "mine" | "build_wall" | "build_floor";
 
 const BUILD_WORK: Record<string, number> = {
   build_wall: WORK_BUILD_WALL,
   build_floor: WORK_BUILD_FLOOR,
-  build_stairs_up: WORK_BUILD_STAIRS,
-  build_stairs_down: WORK_BUILD_STAIRS,
-  build_stairs_both: WORK_BUILD_STAIRS,
 };
 
 export function useDesignation(opts: {

--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -148,9 +148,6 @@ export const WORK_BUILD_WALL = 80;
 /** Work required to build a floor */
 export const WORK_BUILD_FLOOR = 50;
 
-/** Work required to build stairs */
-export const WORK_BUILD_STAIRS = 60;
-
 /** Work required to wander (just walking, instant once arrived) */
 export const WORK_WANDER = 1;
 

--- a/shared/src/db-types.ts
+++ b/shared/src/db-types.ts
@@ -158,9 +158,6 @@ export type TaskType =
   | 'sleep'
   | 'build_wall'
   | 'build_floor'
-  | 'build_stairs_up'
-  | 'build_stairs_down'
-  | 'build_stairs_both'
   | 'wander';
 
 export type TaskStatus =
@@ -189,9 +186,6 @@ export type FortressTileType =
   | 'cavern_wall'
   | 'constructed_wall'
   | 'constructed_floor'
-  | 'stair_up'
-  | 'stair_down'
-  | 'stair_both'
   | 'well'
   | 'mushroom_garden'
   | 'sand'

--- a/sim/src/__tests__/pathfinding.test.ts
+++ b/sim/src/__tests__/pathfinding.test.ts
@@ -66,6 +66,26 @@ describe("isWalkable", () => {
   it("cave_entrance is walkable", () => {
     expect(isWalkable("cave_entrance")).toBe(true);
   });
+
+  it("tree is walkable (surface feature)", () => {
+    expect(isWalkable("tree")).toBe(true);
+  });
+
+  it("bush is walkable (surface feature)", () => {
+    expect(isWalkable("bush")).toBe(true);
+  });
+
+  it("rock is walkable (surface feature)", () => {
+    expect(isWalkable("rock")).toBe(true);
+  });
+
+  it("ore is not walkable (underground wall)", () => {
+    expect(isWalkable("ore")).toBe(false);
+  });
+
+  it("gem is not walkable (underground wall)", () => {
+    expect(isWalkable("gem")).toBe(false);
+  });
 });
 
 describe("getNeighbors", () => {
@@ -185,6 +205,16 @@ describe("bfsNextStep", () => {
     expect(result).toEqual({ x: 0, y: 1, z: 0 });
   });
 
+  it("finds path through trees (surface features are walkable)", () => {
+    const grid: FortressTileType[][] = [
+      ["grass", "tree", "tree", "rock", "grass"],
+    ];
+    const lookup = gridLookup(grid);
+
+    const result = bfsNextStep({ x: 0, y: 0, z: 0 }, { x: 4, y: 0, z: 0 }, lookup);
+    expect(result).toEqual({ x: 1, y: 0, z: 0 });
+  });
+
   it("finds path across grass tiles (surface wandering)", () => {
     const grid: FortressTileType[][] = [
       ["grass", "grass", "grass", "grass", "grass"],
@@ -274,7 +304,7 @@ describe("bfsNextStep", () => {
       return "open_air";
     };
 
-    // Goal at z=-1 is unreachable from z=0 (no stairs)
+    // Goal at z=-1 is unreachable from z=0 (no cave entrance)
     const result = bfsNextStep(
       { x: 100, y: 100, z: 0 },
       { x: 100, y: 100, z: -1 },

--- a/sim/src/__tests__/task-dispatch.test.ts
+++ b/sim/src/__tests__/task-dispatch.test.ts
@@ -294,56 +294,6 @@ describe("task execution", () => {
     expect(stoneItems[0]!.name).toBe("Stone block");
   });
 
-  it("dwarf moves through stairs to reach a task on a different z-level", async () => {
-    // Dwarf at (5, 5, z=0), task at (5, 5, z=-1). Stairs at (5, 6).
-    const dwarf = makeDwarf({ position_x: 5, position_y: 5, position_z: 0 });
-    const skill = makeSkill(dwarf.id, "mining", 5);
-
-    // Create a deriver that has stairs at (5,6) and open air elsewhere
-    const stairDeriver: FortressDeriver = {
-      deriveTile(x: number, y: number, z: number) {
-        if (x === 5 && y === 6 && z === 0) return { tileType: "stair_down" as FortressTileType, material: null };
-        if (x === 5 && y === 6 && z === -1) return { tileType: "stair_up" as FortressTileType, material: null };
-        if (z === -1) {
-          // Underground: mix of stone and open air
-          if (x === 5 && y === 5) return { tileType: "stone" as FortressTileType, material: "granite" };
-          return { tileType: "open_air" as FortressTileType, material: null };
-        }
-        return { tileType: "open_air" as FortressTileType, material: null };
-      },
-    };
-
-    const ctx = makeContext({ dwarves: [dwarf], skills: [skill] });
-    ctx.fortressDeriver = stairDeriver;
-
-    // Create a mine task at (5, 5, z=-1) — adjacent task, dwarf needs to be next to it
-    const task = createTask(ctx.state, "civ-1", {
-      task_type: "mine",
-      target_x: 5,
-      target_y: 5,
-      target_z: -1,
-      work_required: 1,
-    });
-    task.status = "in_progress";
-    task.assigned_dwarf_id = dwarf.id;
-    dwarf.current_task_id = task.id;
-
-    // Tick 1: dwarf at (5,5,0) should move toward stairs at (5,6,0)
-    await taskExecution(ctx);
-    expect(dwarf.position_y).toBe(6);
-    expect(dwarf.position_z).toBe(0);
-
-    // Tick 2: dwarf at (5,6,0) on stair_down, should descend to (5,6,-1)
-    await taskExecution(ctx);
-    expect(dwarf.position_z).toBe(-1);
-    expect(dwarf.position_x).toBe(5);
-    expect(dwarf.position_y).toBe(6);
-
-    // Tick 3: dwarf at (5,6,-1) adjacent to mine target (5,5,-1) — should do work
-    await taskExecution(ctx);
-    expect(task.status).toBe("completed");
-  });
-
   it("dwarf moves on same z-level using real tile lookup", async () => {
     // Dwarf at (3, 3, 0), task at (3, 3, 0) — haul task, dwarf needs to be on tile
     const dwarf = makeDwarf({ position_x: 3, position_y: 3, position_z: 0 });
@@ -382,7 +332,7 @@ describe("task execution", () => {
   });
 
   it("fails task when no path exists through solid rock", async () => {
-    // Dwarf at (0, 0, 0), task at (0, 0, -1), no stairs anywhere
+    // Dwarf at (0, 0, 0), task at (0, 0, -1), no cave entrance
     const dwarf = makeDwarf({ position_x: 0, position_y: 0, position_z: 0 });
     const skill = makeSkill(dwarf.id, "mining", 5);
     const ctx = makeContext({ dwarves: [dwarf], skills: [skill] });
@@ -723,47 +673,6 @@ describe("build tasks", () => {
     expect(task.status).toBe("completed");
     const tile = ctx.state.fortressTileOverrides.get("10,10,0")!;
     expect(tile.tile_type).toBe("constructed_floor");
-  });
-
-  it("completeBuild creates correct tile type for stairs", async () => {
-    const types: Array<{ taskType: "build_stairs_up" | "build_stairs_down" | "build_stairs_both"; expected: string }> = [
-      { taskType: "build_stairs_up", expected: "stair_up" },
-      { taskType: "build_stairs_down", expected: "stair_down" },
-      { taskType: "build_stairs_both", expected: "stair_both" },
-    ];
-
-    for (const { taskType, expected } of types) {
-      const dwarf = makeDwarf({ position_x: 0, position_y: 0, position_z: 0 });
-      const task: Task = {
-        id: randomUUID(),
-        civilization_id: "civ-1",
-        task_type: taskType,
-        status: "in_progress",
-        priority: 5,
-        assigned_dwarf_id: dwarf.id,
-        target_x: 0,
-        target_y: 0,
-        target_z: 0,
-        target_item_id: null,
-        work_progress: 59,
-        work_required: 60,
-        created_at: new Date().toISOString(),
-        completed_at: null,
-      };
-      dwarf.current_task_id = task.id;
-
-      const ctx = makeContext({
-        dwarves: [dwarf],
-        tasks: [task],
-        skills: [makeSkill(dwarf.id, "building", 0)],
-      });
-
-      await taskExecution(ctx);
-
-      expect(task.status).toBe("completed");
-      const tile = ctx.state.fortressTileOverrides.get("0,0,0")!;
-      expect(tile.tile_type).toBe(expected);
-    }
   });
 
   it("completeMine creates a fortress tile override with open_air", async () => {

--- a/sim/src/pathfinding.ts
+++ b/sim/src/pathfinding.ts
@@ -12,9 +12,6 @@ export type TileLookup = (x: number, y: number, z: number) => FortressTileType |
 const WALKABLE_TILES: ReadonlySet<FortressTileType> = new Set([
   'constructed_floor',
   'cavern_floor',
-  'stair_up',
-  'stair_down',
-  'stair_both',
   'open_air',
   'soil',
   'well',
@@ -24,6 +21,9 @@ const WALKABLE_TILES: ReadonlySet<FortressTileType> = new Set([
   'mud',
   'ice',
   'cave_entrance',
+  'tree',
+  'bush',
+  'rock',
 ]);
 
 /** Check if a tile type is walkable. */
@@ -33,8 +33,8 @@ export function isWalkable(tileType: FortressTileType | null): boolean {
 }
 
 /**
- * Get the 2D + stair neighbors of a position.
- * Returns adjacent tiles on the same z-level plus stair connections.
+ * Get walkable neighbors of a position.
+ * Returns adjacent tiles on the same z-level plus cave entrance transitions.
  */
 export function getNeighbors(pos: Position, getTile: TileLookup): Position[] {
   const neighbors: Position[] = [];
@@ -57,22 +57,8 @@ export function getNeighbors(pos: Position, getTile: TileLookup): Position[] {
     }
   }
 
-  // Stair connections between z-levels
-  const currentTile = getTile(x, y, z);
-  if (currentTile === 'stair_up' || currentTile === 'stair_both') {
-    const above = getTile(x, y, z + 1);
-    if (above === 'stair_down' || above === 'stair_both') {
-      neighbors.push({ x, y, z: z + 1 });
-    }
-  }
-  if (currentTile === 'stair_down' || currentTile === 'stair_both') {
-    const below = getTile(x, y, z - 1);
-    if (below === 'stair_up' || below === 'stair_both') {
-      neighbors.push({ x, y, z: z - 1 });
-    }
-  }
-
   // Cave entrance connections: surface cave_entrance ↔ cavern_floor below
+  const currentTile = getTile(x, y, z);
   if (currentTile === 'cave_entrance') {
     const below = getTile(x, y, z - 1);
     if (isWalkable(below)) {

--- a/sim/src/phases/task-completion.ts
+++ b/sim/src/phases/task-completion.ts
@@ -15,9 +15,6 @@ import type { SimContext } from "../sim-context.js";
 const BUILD_TILE_MAP: Record<string, FortressTileType> = {
   build_wall: 'constructed_wall',
   build_floor: 'constructed_floor',
-  build_stairs_up: 'stair_up',
-  build_stairs_down: 'stair_down',
-  build_stairs_both: 'stair_both',
 };
 
 /**
@@ -86,9 +83,6 @@ export function completeTask(dwarf: Dwarf, task: Task, ctx: SimContext): void {
       break;
     case 'build_wall':
     case 'build_floor':
-    case 'build_stairs_up':
-    case 'build_stairs_down':
-    case 'build_stairs_both':
       completeBuild(task, ctx);
       awardXp(dwarf.id, 'building', XP_BUILD, state);
       break;

--- a/sim/src/task-helpers.ts
+++ b/sim/src/task-helpers.ts
@@ -13,9 +13,6 @@ const TASK_SKILL_MAP: Record<TaskType, string | null> = {
   sleep: null,
   build_wall: 'building',
   build_floor: 'building',
-  build_stairs_up: 'building',
-  build_stairs_down: 'building',
-  build_stairs_both: 'building',
   wander: null,
 };
 


### PR DESCRIPTION
## Summary
- **Surface tiles (tree, bush, rock) are now walkable** — dwarves can path through forests to reach mine designations on the other side. In Dwarf Fortress style, surface features are things you walk past, not walls.
- **Underground tiles (stone, ore, gem) remain non-walkable** — solid rock you mine through.
- **Removed all stair references** — `stair_up`, `stair_down`, `stair_both` removed from types, pathfinding, build menu, task completion, task helpers, glyphs, and tests. Cave entrances replaced the stair system.

Closes #269

## Playtest
- Dwarves can now path through forested areas to reach mine designations
- Build menu shows only Wall and Floor (no stairs)
- Task priorities panel no longer lists stair tasks
- All 463 tests pass
- Pathfinding tests verify tree/bush/rock are walkable, ore/gem are not

🤖 Generated with [Claude Code](https://claude.com/claude-code)