### PR TITLE
fix: filter designations by z-level, show blueprints instantly (closes #268)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -82,12 +82,13 @@ export default function App() {
     for (const t of tasks) {
       const tx = 'target_x' in t ? t.target_x : null;
       const ty = 'target_y' in t ? t.target_y : null;
-      if (tx !== null && ty !== null && !AUTONOMOUS.has(t.task_type) && ['pending', 'claimed', 'in_progress'].includes(t.status)) {
+      const tz = 'target_z' in t ? t.target_z : null;
+      if (tx !== null && ty !== null && tz === zLevel && !AUTONOMOUS.has(t.task_type) && ['pending', 'claimed', 'in_progress'].includes(t.status)) {
         map.set(`${tx},${ty}`, t.task_type);
       }
     }
     return map;
-  }, [snapshot?.tasks, polledTasks.tasks]);
+  }, [snapshot?.tasks, polledTasks.tasks, zLevel]);
 
   const designation = useDesignation({
     civId: world.civId,
@@ -95,6 +96,16 @@ export default function App() {
     getFortressTile,
     designatedTiles,
   });
+
+  // Merge optimistic designations into the map for immediate feedback
+  const mergedDesignatedTiles = useMemo(() => {
+    if (designation.optimisticTiles.size === 0) return designatedTiles;
+    const merged = new Map(designatedTiles);
+    for (const [key, val] of designation.optimisticTiles) {
+      merged.set(key, val);
+    }
+    return merged;
+  }, [designatedTiles, designation.optimisticTiles]);
 
   // Live dwarves — prefer sim snapshot over DB polling
   const polledDwarves = useDwarves(world.civId);
@@ -296,7 +307,7 @@ export default function App() {
 
   const terrainForBar = world.mode === "world" ? (cursorTile?.terrain ?? null) : null;
   const cursorKey = `${viewport.cursorX},${viewport.cursorY}`;
-  const cursorDesignation = world.mode === "fortress" ? designatedTiles.get(cursorKey) : undefined;
+  const cursorDesignation = world.mode === "fortress" ? mergedDesignatedTiles.get(cursorKey) : undefined;
   const fortressTileLabel = world.mode === "fortress" && cursorFortressTile
     ? formatFortressTileLabel(cursorFortressTile.tileType, cursorFortressTile.material, cursorDesignation)
     : null;
@@ -350,7 +361,7 @@ export default function App() {
           getFortressTileData={world.mode === "fortress" ? getFortressTile : undefined}
           onViewportSize={handleViewportSize}
           dwarfPositions={world.mode === "fortress" ? dwarfPositions : undefined}
-          designatedTiles={world.mode === "fortress" ? designatedTiles : undefined}
+          designatedTiles={world.mode === "fortress" ? mergedDesignatedTiles : undefined}
           designationMode={world.mode === "fortress" ? designation.designationMode : undefined}
           onDesignateArea={world.mode === "fortress" ? designation.handleDesignateArea : undefined}
           onCancelArea={world.mode === "fortress" ? designation.handleCancelArea : undefined}

--- a/app/src/hooks/useDesignation.ts
+++ b/app/src/hooks/useDesignation.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import type { TaskType } from "@pwarf/shared";
 import {
   WORK_MINE_BASE,
@@ -30,6 +30,20 @@ export function useDesignation(opts: {
   const [buildMenuOpen, setBuildMenuOpen] = useState(false);
   const [prioritiesOpen, setPrioritiesOpen] = useState(false);
   const [taskPriorities, setTaskPriorities] = useState<Record<string, number>>({});
+
+  // Optimistic designations — shown immediately before poll picks them up
+  const [optimisticTiles, setOptimisticTiles] = useState<Map<string, string>>(new Map());
+  const prevDesignatedTiles = useRef(designatedTiles);
+
+  // Clear optimistic tiles once the real data arrives (designatedTiles changes)
+  useEffect(() => {
+    if (designatedTiles !== prevDesignatedTiles.current) {
+      prevDesignatedTiles.current = designatedTiles;
+      if (optimisticTiles.size > 0) {
+        setOptimisticTiles(new Map());
+      }
+    }
+  }, [designatedTiles, optimisticTiles.size]);
 
   const handleDesignateArea = useCallback(async (x1: number, y1: number, x2: number, y2: number) => {
     if (designationMode === 'none' || !civId) return;
@@ -93,6 +107,15 @@ export function useDesignation(opts: {
     const { error } = await supabase.from('tasks').insert(tasks);
     if (error) {
       console.error('[designate] Failed to create tasks:', error.message);
+    } else {
+      // Optimistically show the new designations immediately
+      setOptimisticTiles((prev) => {
+        const next = new Map(prev);
+        for (const t of tasks) {
+          next.set(`${t.target_x},${t.target_y}`, t.task_type);
+        }
+        return next;
+      });
     }
   }, [designationMode, civId, zLevel, getFortressTile, designatedTiles, taskPriorities]);
 
@@ -154,6 +177,7 @@ export function useDesignation(opts: {
     setBuildMenuOpen,
     prioritiesOpen,
     taskPriorities,
+    optimisticTiles,
     handleDesignateArea,
     handleCancelArea,
     handleBuildSelect,


### PR DESCRIPTION
## Summary

- **Z-level filter**: `designatedTiles` now checks `target_z === zLevel` — designations placed at z=0 no longer leak to z=-1, z=-2, etc.
- **Instant blueprints**: After a successful task insert, optimistic local state shows the designation glyphs immediately instead of waiting for the next poll cycle (up to 2s).

## Test plan

- [x] `npm run build` passes
- [ ] Playtest: place floor designations at z=0, switch to z=-1 — should not appear
- [ ] Playtest: designate builds — blueprints should appear instantly on release

🤖 Generated with [Claude Code](https://claude.com/claude-code)