### PR TITLE
feat: unify dwarf click to always show popup (closes #272)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -344,7 +344,7 @@ export default function App() {
           cursorTile={world.mode === "world" ? (selectedTileData ?? cursorTile) : cursorTile}
           onEmbark={world.mode === "world" && selectedWorldTile ? handleEmbark : undefined}
           dwarves={liveDwarves}
-          onGoToDwarf={world.mode === "fortress" ? handleGoToDwarf : undefined}
+          onDwarfClick={world.mode === "fortress" ? (id: string) => setModalDwarfId(id) : undefined}
         />
 
         <MainViewport
@@ -366,8 +366,8 @@ export default function App() {
           onDesignateArea={world.mode === "fortress" ? designation.handleDesignateArea : undefined}
           onCancelArea={world.mode === "fortress" ? designation.handleCancelArea : undefined}
           onTileClick={world.mode === "world" ? (x: number, y: number) => setSelectedWorldTile({ x, y }) : undefined}
-          selectedTile={world.mode === "world" ? selectedWorldTile : undefined}
           onDwarfClick={world.mode === "fortress" ? handleDwarfClick : undefined}
+          selectedTile={world.mode === "world" ? selectedWorldTile : undefined}
         />
 
         {modalDwarf && (

--- a/app/src/components/LeftPanel.tsx
+++ b/app/src/components/LeftPanel.tsx
@@ -1,6 +1,5 @@
-import { useState } from "react";
 import type { WorldTile } from "@pwarf/shared";
-import type { LiveDwarf, DwarfThought } from "../hooks/useDwarves";
+import type { LiveDwarf } from "../hooks/useDwarves";
 
 interface LeftPanelProps {
   mode: "fortress" | "world";
@@ -9,7 +8,7 @@ interface LeftPanelProps {
   cursorTile?: WorldTile | null;
   onEmbark?: () => void;
   dwarves?: LiveDwarf[];
-  onGoToDwarf?: (dwarf: LiveDwarf) => void;
+  onDwarfClick?: (dwarfId: string) => void;
 }
 
 function dwarfJobLabel(d: LiveDwarf): string {
@@ -17,28 +16,8 @@ function dwarfJobLabel(d: LiveDwarf): string {
   return "Idle";
 }
 
-function needBar(label: string, value: number, color: string) {
-  const pct = Math.round(value);
-  const barColor = value < 25 ? "var(--red, #f87171)" : color;
-  return (
-    <div className="flex items-center gap-1">
-      <span className="w-12 text-[var(--text)]">{label}</span>
-      <div className="flex-1 h-1.5 bg-[#333] rounded overflow-hidden">
-        <div
-          className="h-full rounded"
-          style={{ width: `${pct}%`, backgroundColor: barColor }}
-        />
-      </div>
-      <span className="w-6 text-right" style={{ color: barColor }}>{pct}</span>
-    </div>
-  );
-}
-
-export default function LeftPanel({ mode, collapsed, onToggle, cursorTile, onEmbark, dwarves = [], onGoToDwarf }: LeftPanelProps) {
+export default function LeftPanel({ mode, collapsed, onToggle, cursorTile, onEmbark, dwarves = [], onDwarfClick }: LeftPanelProps) {
   const isOcean = cursorTile?.terrain === "ocean";
-  const [selectedDwarfId, setSelectedDwarfId] = useState<string | null>(null);
-
-  const selectedDwarf = selectedDwarfId ? dwarves.find(d => d.id === selectedDwarfId) : null;
 
   return (
     <aside
@@ -56,101 +35,27 @@ export default function LeftPanel({ mode, collapsed, onToggle, cursorTile, onEmb
       {!collapsed && (
         <div className="px-2 pb-2 overflow-y-auto text-xs">
           {mode === "fortress" ? (
-            selectedDwarf ? (
-              // Dwarf detail view
-              <div className="space-y-2">
-                <div className="flex items-center gap-1">
-                  <button
-                    onClick={() => setSelectedDwarfId(null)}
-                    className="text-[var(--amber)] hover:text-[var(--green)] cursor-pointer"
+            <>
+              <h2 className="text-[var(--amber)] mb-1 font-bold">Dwarves</h2>
+              <ul className="space-y-0.5">
+                {dwarves.map((d) => (
+                  <li
+                    key={d.id}
+                    className="flex justify-between hover:bg-[var(--bg-hover)] px-1 cursor-pointer"
+                    onClick={() => onDwarfClick?.(d.id)}
                   >
-                    &larr;
-                  </button>
-                  <h2 className="text-[var(--green)] font-bold">
-                    {selectedDwarf.name}{selectedDwarf.surname ? ` ${selectedDwarf.surname}` : ""}
-                  </h2>
-                </div>
-
-                <div className="text-[var(--text)]">
-                  Status: <span className="text-[var(--green)]">{dwarfJobLabel(selectedDwarf)}</span>
-                </div>
-
-                <div className="text-[var(--text)] flex items-center justify-between">
-                  <span>
-                    Pos: <span className="text-[var(--green)]">({selectedDwarf.position_x}, {selectedDwarf.position_y}, z{selectedDwarf.position_z})</span>
-                  </span>
-                  {onGoToDwarf && (
-                    <button
-                      onClick={() => onGoToDwarf(selectedDwarf)}
-                      className="text-[var(--amber)] hover:text-[var(--green)] cursor-pointer"
-                      title="Jump camera to this dwarf"
-                    >
-                      Go to
-                    </button>
-                  )}
-                </div>
-
-                <div className="border-t border-[var(--border)] pt-1 mt-1 space-y-1">
-                  <div className="text-[var(--amber)] font-bold mb-0.5">Needs</div>
-                  {needBar("Food", selectedDwarf.need_food, "var(--green)")}
-                  {needBar("Drink", selectedDwarf.need_drink, "#4488ff")}
-                  {needBar("Sleep", selectedDwarf.need_sleep, "#aa88ff")}
-                </div>
-
-                <div className="border-t border-[var(--border)] pt-1 mt-1">
-                  <div className="text-[var(--amber)] font-bold mb-0.5">Stress</div>
-                  {needBar("Stress", selectedDwarf.stress_level, "#ff6600")}
-                </div>
-
-                <div className="border-t border-[var(--border)] pt-1 mt-1">
-                  <div className="text-[var(--amber)] font-bold mb-0.5">Health</div>
-                  {needBar("HP", selectedDwarf.health, "var(--green)")}
-                </div>
-
-                {selectedDwarf.memories && selectedDwarf.memories.length > 0 && (
-                  <div className="border-t border-[var(--border)] pt-1 mt-1">
-                    <div className="text-[var(--amber)] font-bold mb-0.5">Thoughts</div>
-                    <ul className="space-y-0.5">
-                      {[...selectedDwarf.memories].reverse().slice(0, 5).map((thought: DwarfThought, i: number) => (
-                        <li key={i} className="flex items-start gap-1">
-                          <span className={
-                            thought.sentiment === "positive" ? "text-[var(--green)]" :
-                            thought.sentiment === "negative" ? "text-[#f87171]" :
-                            "text-[var(--text)]"
-                          }>
-                            {thought.sentiment === "positive" ? "+" : thought.sentiment === "negative" ? "-" : "·"}
-                          </span>
-                          <span className="text-[var(--text)]">{thought.text}</span>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
+                    <span className="text-[var(--green)]">{d.name}</span>
+                    <span className="text-[var(--text)]">
+                      <span className="text-[var(--border)] mr-1">z{d.position_z}</span>
+                      {dwarfJobLabel(d)}
+                    </span>
+                  </li>
+                ))}
+                {dwarves.length === 0 && (
+                  <li className="text-[var(--text)]">No dwarves</li>
                 )}
-              </div>
-            ) : (
-              // Dwarf roster
-              <>
-                <h2 className="text-[var(--amber)] mb-1 font-bold">Dwarves</h2>
-                <ul className="space-y-0.5">
-                  {dwarves.map((d) => (
-                    <li
-                      key={d.id}
-                      className="flex justify-between hover:bg-[var(--bg-hover)] px-1 cursor-pointer"
-                      onClick={() => setSelectedDwarfId(d.id)}
-                    >
-                      <span className="text-[var(--green)]">{d.name}</span>
-                      <span className="text-[var(--text)]">
-                        <span className="text-[var(--border)] mr-1">z{d.position_z}</span>
-                        {dwarfJobLabel(d)}
-                      </span>
-                    </li>
-                  ))}
-                  {dwarves.length === 0 && (
-                    <li className="text-[var(--text)]">No dwarves</li>
-                  )}
-                </ul>
-              </>
-            )
+              </ul>
+            </>
           ) : cursorTile ? (
             <div className="space-y-1">
               <h2 className="text-[var(--amber)] mb-1 font-bold">Tile Info</h2>

--- a/app/src/components/MainViewport.tsx
+++ b/app/src/components/MainViewport.tsx
@@ -28,10 +28,10 @@ interface MainViewportProps {
   onCancelArea?: (x1: number, y1: number, x2: number, y2: number) => void;
   /** Click handler for world map tile selection */
   onTileClick?: (x: number, y: number) => void;
-  /** Selected world tile position */
-  selectedTile?: { x: number; y: number } | null;
   /** Click handler for clicking a dwarf on the map */
   onDwarfClick?: (x: number, y: number) => void;
+  /** Selected world tile position */
+  selectedTile?: { x: number; y: number } | null;
 }
 
 // Character cell dimensions (monospace)
@@ -70,8 +70,8 @@ export default function MainViewport({
   onDesignateArea,
   onCancelArea,
   onTileClick,
-  selectedTile,
   onDwarfClick,
+  selectedTile,
 }: MainViewportProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
## Summary
- Clicking a dwarf in the side panel roster now opens a centered floating popup instead of showing inline detail
- Clicking a dwarf smiley face on the game map also opens the same popup
- Both paths show the same DwarfPopup with name, status, position, needs, stress, and health
- Popup dismisses via X button or clicking outside

## Playtest
- Side panel click: opens popup with correct dwarf info ✅
- Game map click on dwarf tile: opens popup with correct dwarf info ✅
- Popup X button closes popup ✅
- Clicking outside popup (backdrop) closes popup ✅
- Side panel roster stays visible while popup is open ✅
- No console errors ✅

### Screenshots

**Side panel click → popup:**
![side-panel-click](https://github.com/user-attachments/assets/ss_53365ev64)

**Game map dwarf click → popup:**
![game-map-click](https://github.com/user-attachments/assets/ss_89137knyp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)