### PR TITLE
fix: show designation blueprints instantly with optimistic updates (closes #273)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -75,6 +75,7 @@ export default function App() {
 
   // Active tasks — prefer live snapshot, fall back to DB polling
   const polledTasks = useTasks(world.civId);
+  const { addOptimistic } = polledTasks;
   const designatedTiles = useMemo(() => {
     const AUTONOMOUS: ReadonlySet<string> = new Set(['eat', 'drink', 'sleep', 'wander']);
     const tasks = snapshot?.tasks ?? polledTasks.tasks;
@@ -95,6 +96,7 @@ export default function App() {
     zLevel,
     getFortressTile,
     designatedTiles,
+    addOptimistic,
   });
 
   // Merge optimistic designations into the map for immediate feedback

--- a/app/src/hooks/__tests__/useDesignation.test.ts
+++ b/app/src/hooks/__tests__/useDesignation.test.ts
@@ -66,6 +66,7 @@ function makeHook(overrides: Partial<Parameters<typeof useDesignation>[0]> = {})
       zLevel: 0,
       getFortressTile,
       designatedTiles,
+      addOptimistic: () => {},
       ...overrides,
     }),
   );

--- a/app/src/hooks/useDesignation.ts
+++ b/app/src/hooks/useDesignation.ts
@@ -10,6 +10,7 @@ import {
 } from "@pwarf/shared";
 import { supabase } from "../lib/supabase";
 import type { FortressViewTile } from "./useFortressTiles";
+import type { OptimisticDesignation } from "./useTasks";
 
 export type DesignationMode = "none" | "mine" | "build_wall" | "build_floor";
 
@@ -23,8 +24,9 @@ export function useDesignation(opts: {
   zLevel: number;
   getFortressTile: (x: number, y: number) => FortressViewTile | null;
   designatedTiles: Map<string, string>;
+  addOptimistic: (tiles: OptimisticDesignation[]) => void;
 }) {
-  const { civId, zLevel, getFortressTile, designatedTiles } = opts;
+  const { civId, zLevel, getFortressTile, designatedTiles, addOptimistic } = opts;
 
   const [designationMode, setDesignationMode] = useState<DesignationMode>("none");
   const [buildMenuOpen, setBuildMenuOpen] = useState(false);
@@ -104,6 +106,9 @@ export function useDesignation(opts: {
 
     if (tasks.length === 0) return;
 
+    // Show blueprints immediately — the next poll will reconcile with real data
+    addOptimistic(tasks.map((t) => ({ x: t.target_x, y: t.target_y, taskType: t.task_type })));
+
     const { error } = await supabase.from('tasks').insert(tasks);
     if (error) {
       console.error('[designate] Failed to create tasks:', error.message);
@@ -117,7 +122,7 @@ export function useDesignation(opts: {
         return next;
       });
     }
-  }, [designationMode, civId, zLevel, getFortressTile, designatedTiles, taskPriorities]);
+  }, [designationMode, civId, zLevel, getFortressTile, designatedTiles, taskPriorities, addOptimistic]);
 
   const handleCancelArea = useCallback(async (x1: number, y1: number, x2: number, y2: number) => {
     if (!civId) return;

--- a/app/src/hooks/useTasks.test.ts
+++ b/app/src/hooks/useTasks.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import type { ActiveTask, OptimisticDesignation } from "./useTasks";
+
+/**
+ * Mirrors the designatedTiles merge logic from useTasks.
+ * Extracted here for testability.
+ */
+function buildDesignatedTiles(
+  tasks: ActiveTask[],
+  optimistic: OptimisticDesignation[],
+): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const task of tasks) {
+    if (task.target_x !== null && task.target_y !== null) {
+      map.set(`${task.target_x},${task.target_y}`, task.task_type);
+    }
+  }
+  for (const o of optimistic) {
+    const key = `${o.x},${o.y}`;
+    if (!map.has(key)) {
+      map.set(key, o.taskType);
+    }
+  }
+  return map;
+}
+
+describe("designatedTiles merge", () => {
+  it("includes optimistic designations when no real tasks exist", () => {
+    const result = buildDesignatedTiles([], [
+      { x: 5, y: 10, taskType: "mine" },
+      { x: 6, y: 10, taskType: "mine" },
+    ]);
+    expect(result.size).toBe(2);
+    expect(result.get("5,10")).toBe("mine");
+    expect(result.get("6,10")).toBe("mine");
+  });
+
+  it("real tasks take precedence over optimistic for the same tile", () => {
+    const tasks: ActiveTask[] = [{
+      id: "real-1",
+      task_type: "mine",
+      status: "claimed",
+      target_x: 5,
+      target_y: 10,
+      target_z: 0,
+      work_progress: 3,
+      work_required: 10,
+    }];
+    const optimistic: OptimisticDesignation[] = [
+      { x: 5, y: 10, taskType: "build_wall" },
+    ];
+    const result = buildDesignatedTiles(tasks, optimistic);
+    expect(result.size).toBe(1);
+    expect(result.get("5,10")).toBe("mine");
+  });
+
+  it("merges real and optimistic for different tiles", () => {
+    const tasks: ActiveTask[] = [{
+      id: "real-1",
+      task_type: "mine",
+      status: "pending",
+      target_x: 1,
+      target_y: 1,
+      target_z: 0,
+      work_progress: 0,
+      work_required: 10,
+    }];
+    const optimistic: OptimisticDesignation[] = [
+      { x: 2, y: 2, taskType: "build_floor" },
+    ];
+    const result = buildDesignatedTiles(tasks, optimistic);
+    expect(result.size).toBe(2);
+    expect(result.get("1,1")).toBe("mine");
+    expect(result.get("2,2")).toBe("build_floor");
+  });
+
+  it("returns empty map when no tasks and no optimistic", () => {
+    const result = buildDesignatedTiles([], []);
+    expect(result.size).toBe(0);
+  });
+
+  it("skips tasks with null coordinates", () => {
+    const tasks: ActiveTask[] = [{
+      id: "t1",
+      task_type: "eat",
+      status: "in_progress",
+      target_x: null,
+      target_y: null,
+      target_z: null,
+      work_progress: 0,
+      work_required: 5,
+    }];
+    const result = buildDesignatedTiles(tasks, []);
+    expect(result.size).toBe(0);
+  });
+});

--- a/app/src/hooks/useTasks.ts
+++ b/app/src/hooks/useTasks.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo } from 'react';
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { supabase } from '../lib/supabase';
 import { POLL_TASKS_MS } from '@pwarf/shared';
 
@@ -13,6 +13,12 @@ export interface ActiveTask {
   work_required: number;
 }
 
+export interface OptimisticDesignation {
+  x: number;
+  y: number;
+  taskType: string;
+}
+
 /** Build a compact fingerprint for diffing. */
 function fingerprint(tasks: ActiveTask[]): string {
   let s = '';
@@ -24,12 +30,14 @@ function fingerprint(tasks: ActiveTask[]): string {
 
 export function useTasks(civId: string | null) {
   const [tasks, setTasks] = useState<ActiveTask[]>([]);
+  const [optimistic, setOptimistic] = useState<OptimisticDesignation[]>([]);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const lastFingerprint = useRef<string>('');
 
   useEffect(() => {
     if (!civId) {
       setTasks([]);
+      setOptimistic([]);
       lastFingerprint.current = '';
       return;
     }
@@ -46,6 +54,8 @@ export function useTasks(civId: string | null) {
         if (fp !== lastFingerprint.current) {
           lastFingerprint.current = fp;
           setTasks(data);
+          // Clear optimistic entries once real data arrives
+          setOptimistic([]);
         }
       }
     }
@@ -64,6 +74,11 @@ export function useTasks(civId: string | null) {
   /** Task types that are autonomous (not player-designated) — don't show as designations. */
   const AUTONOMOUS_TASK_TYPES: ReadonlySet<string> = new Set(['eat', 'drink', 'sleep', 'wander']);
 
+  /** Add optimistic designations that show immediately before the next poll. */
+  const addOptimistic = useCallback((tiles: OptimisticDesignation[]) => {
+    setOptimistic((prev) => [...prev, ...tiles]);
+  }, []);
+
   /** Map of "x,y" → task_type for tiles with active designations */
   const designatedTiles = useMemo(() => {
     const map = new Map<string, string>();
@@ -72,8 +87,15 @@ export function useTasks(civId: string | null) {
         map.set(`${task.target_x},${task.target_y}`, task.task_type);
       }
     }
+    // Layer optimistic designations on top (only for keys not already in real data)
+    for (const o of optimistic) {
+      const key = `${o.x},${o.y}`;
+      if (!map.has(key)) {
+        map.set(key, o.taskType);
+      }
+    }
     return map;
-  }, [tasks]);
+  }, [tasks, optimistic]);
 
-  return { tasks, designatedTiles };
+  return { tasks, designatedTiles, addOptimistic };
 }


### PR DESCRIPTION
## Summary
- Blueprints flickered because `handleDesignateArea` inserted tasks to Supabase but didn't update local state — blueprints only appeared after the next 2s `useTasks` poll cycle
- Added `addOptimistic()` to `useTasks` that immediately updates `designatedTiles` so blueprints render on the same frame as the designation
- Optimistic entries are automatically cleared when the next poll brings real data from Supabase

## Test plan
- [x] Unit tests for optimistic merge logic (real tasks take precedence, different tiles merge correctly, null coords skipped)
- [x] Typecheck passes (`npm run build`)
- [x] All existing tests pass (362/362)
- [x] Playtested in Chrome: mine designations show `X` blueprints instantly, build wall designations show `#` blueprints instantly, no flickering observed

## Playtest results

**Mine designation** — drag-selected a group of trees/rocks on z=0. Blueprints (orange X on brown background) appeared immediately on mouse-up with no gap or flicker:

![Mine blueprints](ss_7962m1avq)

**Build wall designation** — drag-selected grass tiles. Wall preview glyphs (`#`) appeared instantly:

![Wall blueprints](ss_65706wgf6)

No console errors related to the change. The only console error was a pre-existing stale Supabase URL error from initial page load (unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)