### PR TITLE
fix: collapse duplicate log entries with ×N count

### DIFF
--- a/app/src/components/RightPanel.test.ts
+++ b/app/src/components/RightPanel.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { groupConsecutiveEvents } from "./RightPanel";
+import type { LiveEvent } from "../hooks/useEvents";
+
+function makeEvent(id: string, description: string, category = "discovery"): LiveEvent {
+  return { id, description, category, created_at: new Date().toISOString() } as LiveEvent;
+}
+
+describe("groupConsecutiveEvents", () => {
+  it("returns empty array for empty input", () => {
+    expect(groupConsecutiveEvents([])).toEqual([]);
+  });
+
+  it("returns single group for single event", () => {
+    const event = makeEvent("1", "Aban begins mine.");
+    expect(groupConsecutiveEvents([event])).toEqual([{ event, count: 1 }]);
+  });
+
+  it("merges consecutive identical descriptions", () => {
+    const a = makeEvent("1", "Aban begins mine.");
+    const b = makeEvent("2", "Aban begins mine.");
+    const c = makeEvent("3", "Aban begins mine.");
+    const groups = groupConsecutiveEvents([a, b, c]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].event).toBe(a);
+    expect(groups[0].count).toBe(3);
+  });
+
+  it("does not merge non-consecutive duplicates", () => {
+    const a = makeEvent("1", "Aban begins mine.");
+    const b = makeEvent("2", "Aban has finished mine.");
+    const c = makeEvent("3", "Aban begins mine.");
+    const groups = groupConsecutiveEvents([a, b, c]);
+    expect(groups).toHaveLength(3);
+    expect(groups[0].count).toBe(1);
+    expect(groups[1].count).toBe(1);
+    expect(groups[2].count).toBe(1);
+  });
+
+  it("preserves the first event in each group", () => {
+    const a = makeEvent("1", "Aban begins mine.");
+    const b = makeEvent("2", "Aban begins mine.");
+    const groups = groupConsecutiveEvents([a, b]);
+    expect(groups[0].event.id).toBe("1");
+  });
+
+  it("handles mixed runs correctly", () => {
+    const events = [
+      makeEvent("1", "A"),
+      makeEvent("2", "A"),
+      makeEvent("3", "B"),
+      makeEvent("4", "B"),
+      makeEvent("5", "B"),
+      makeEvent("6", "C"),
+    ];
+    const groups = groupConsecutiveEvents(events);
+    expect(groups).toHaveLength(3);
+    expect(groups[0]).toEqual({ event: events[0], count: 2 });
+    expect(groups[1]).toEqual({ event: events[2], count: 3 });
+    expect(groups[2]).toEqual({ event: events[5], count: 1 });
+  });
+});

--- a/app/src/components/RightPanel.tsx
+++ b/app/src/components/RightPanel.tsx
@@ -17,6 +17,20 @@ const PLACEHOLDER_LEGENDS = [
   "Year 204 — Great flood",
 ];
 
+/** Group consecutive events with the same description into (event, count) pairs. */
+export function groupConsecutiveEvents(events: LiveEvent[]): Array<{ event: LiveEvent; count: number }> {
+  const groups: Array<{ event: LiveEvent; count: number }> = [];
+  for (const event of events) {
+    const last = groups[groups.length - 1];
+    if (last && last.event.description === event.description) {
+      last.count++;
+    } else {
+      groups.push({ event, count: 1 });
+    }
+  }
+  return groups;
+}
+
 /** Map event category to a CSS color variable. */
 function categoryColor(category: string): string {
   switch (category) {
@@ -83,10 +97,13 @@ export default function RightPanel({ collapsed, onToggle, events }: RightPanelPr
                 <p className="text-[var(--text)] opacity-50 italic">No events yet.</p>
               ) : (
                 <ul className="space-y-0.5">
-                  {events.map((event) => (
+                  {groupConsecutiveEvents(events).map(({ event, count }) => (
                     <li key={event.id} className="text-[var(--text)]">
                       <span style={{ color: categoryColor(event.category) }} className="mr-1">*</span>
                       {event.description}
+                      {count > 1 && (
+                        <span className="ml-1 opacity-50 text-[0.65rem]">×{count}</span>
+                      )}
                     </li>
                   ))}
                 </ul>


### PR DESCRIPTION
## Summary
- Consecutive identical log messages now collapse into a single entry with a `×N` repeat count
- Fixes the log panel being flooded when a dwarf mines multiple tiles in sequence
- Extracted `groupConsecutiveEvents()` as a named export with 6 unit tests

## Playtest Report

**Tested:** Fortress view with active mining session.

**Bug found:** Log panel was completely unusable — the same `* Aban Boulderfist begins mine.` message filled the entire visible log history, burying all other events (including "The fortress has fallen.").

**Working features:**
- Login, world map, fortress view all render correctly
- Dwarf roster visible in left panel
- Toolbar shortcuts displayed at bottom

**Screenshot (before fix — bug):**

<img width="800" alt="Log panel flooded with duplicate mine messages" src="https://github.com/user-attachments/assets/b900dc60-81dc-4063-88dd-ecbe36899ebc" />

**After (fix — collapsed to ×N count):**

<img width="800" alt="after: log deduplicated" src="https://github.com/user-attachments/assets/6500c7fc-7905-4b38-88a5-336c3ab8f06f" />