### PR TITLE
docs: add /review-pr skill and require self-review before PRs

### DIFF
--- a/.claude/skills/playtest.md
+++ b/.claude/skills/playtest.md
@@ -57,7 +57,8 @@ Run the pWarf game locally and playtest it in Chrome using browser automation to
    - Note any UI/UX friction
 
 5. **Report findings**
-   - Comment on the playtest GitHub issue with:
+   - Use the `github-upload-image-to-pr` skill to attach screenshots to the PR description
+   - Include a text report in the PR description summarizing:
      - Screenshots of any bugs found
      - List of working features
      - List of bugs/issues with descriptions

--- a/.claude/skills/review-pr.md
+++ b/.claude/skills/review-pr.md
@@ -1,0 +1,52 @@
+---
+name: review-pr
+description: Self-review the current PR before it is pushed — check diff, tests, types, and code quality
+user_invocable: true
+---
+
+# Review PR Skill
+
+Self-review the open PR (or staged changes) before pushing, catching issues before a human reviewer sees them.
+
+## Instructions
+
+1. **Get the diff**
+   - Run `git diff main...HEAD` to see all changes on the branch
+   - Run `git log main...HEAD --oneline` to confirm the commit list
+
+2. **Run tests and typecheck**
+   - `npm run build` — must pass with no type errors
+   - `npm test` — all tests must pass
+   - If either fails, stop and fix before continuing
+
+3. **Review the diff line by line, checking for:**
+
+   **Correctness**
+   - Does the implementation match the issue/feature description?
+   - Are edge cases handled?
+   - Any off-by-one errors, wrong conditions, or broken logic?
+
+   **Code quality**
+   - Dead code left in (console.logs, commented-out blocks, unused imports)?
+   - Magic numbers or duplicated constants that should be extracted?
+   - Files over ~300 LOC that should be split?
+   - Any default exports (project uses named exports only)?
+
+   **Tests**
+   - Do new modules/features have tests?
+   - Are test files named after what they test?
+   - Any obvious missing test cases for the new logic?
+
+   **Security**
+   - Any user input going into SQL, shell commands, or HTML without sanitization?
+   - Any secrets or credentials hardcoded?
+
+4. **Check the PR description**
+   - Run `gh pr view` to read the current PR description
+   - Confirm it references the correct issue number (`closes #NNN`)
+   - Confirm a playtest report is included with screenshots
+
+5. **Report**
+   - List any issues found, grouped by severity: **Blocking** (must fix) vs **Suggestions** (nice to have)
+   - If blocking issues exist, fix them and re-run this skill
+   - If clean, state clearly: "PR looks good — no blocking issues found"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,11 @@ Follow these when writing or modifying code to keep the codebase clean:
 - **Shared test helpers.** Test factory functions (`makeDwarf`, `makeContext`, etc.) live in `sim/src/__tests__/test-helpers.ts`. Don't duplicate them across test files.
 - **Name test files after what they test.** `dwarf-names.test.ts` tests `dwarf-names.ts`, not `embark.test.ts`.
 
+## PR Self-Review
+
+- **Every PR must be self-reviewed before it is created.** Run `/review-pr` to check the diff, tests, types, and code quality before pushing.
+- Fix any blocking issues found before opening the PR.
+
 ## Playtesting
 
 - **Every PR must include a playtest.** After implementing a feature or fix, run the game in Chrome and verify it works end-to-end.


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/review-pr.md` — a `/review-pr` skill that checks the diff, runs tests/typecheck, reviews code quality, and verifies the PR description before pushing
- Updates `CLAUDE.md` to require self-review before every PR is created

closes #300

## Test plan

- [ ] `/review-pr` skill is discoverable and runs correctly on a branch with changes
- [ ] CLAUDE.md self-review section is visible and clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)