### PR TITLE
feat: add WRITE_INTERVAL and WRITE_TICKS constants (closes #195)

### DIFF
--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -212,6 +212,12 @@ export const SCORE_BEST_SKILL_BONUS = 5;
 // Polling / flush intervals (milliseconds)
 // ============================================================
 
+/** Milliseconds between sim write cycles */
+export const WRITE_INTERVAL = 1_000;
+
+/** Number of sim ticks per write cycle (WRITE_INTERVAL / tick duration) */
+export const WRITE_TICKS = 10;
+
 /** How often the sim engine flushes dirty state to Supabase and polls for new tasks */
 export const SIM_FLUSH_INTERVAL_MS = 15_000;
 


### PR DESCRIPTION
## Summary

- Adds `WRITE_INTERVAL = 1000` and `WRITE_TICKS = 10` to `shared/src/constants.ts` as specified in the design doc

## Playtest

Constants-only change — no runtime behavior altered. Sim tests pass (17/17).

## Claude Cost

**Claude cost:** $3.13 (7.6M tokens)