### PR TITLE
feat: seeded RNG for deterministic sim runs (closes #282)

### DIFF
--- a/sim/src/__tests__/deprivation.test.ts
+++ b/sim/src/__tests__/deprivation.test.ts
@@ -72,7 +72,7 @@ describe("killDwarf", () => {
   it("fails the dwarf's current task", () => {
     const dwarf = makeDwarf();
     const ctx = makeContext({ dwarves: [dwarf] });
-    const task = createTask(ctx.state, "civ-1", {
+    const task = createTask(ctx, {
       task_type: "haul",
       target_x: 5,
       target_y: 5,

--- a/sim/src/__tests__/task-completion.test.ts
+++ b/sim/src/__tests__/task-completion.test.ts
@@ -8,7 +8,7 @@ describe("completeTask", () => {
   it("marks task completed and clears dwarf assignment", () => {
     const dwarf = makeDwarf();
     const ctx = makeContext({ dwarves: [dwarf] });
-    const task = createTask(ctx.state, "civ-1", {
+    const task = createTask(ctx, {
       task_type: "haul",
       target_x: 0,
       target_y: 0,
@@ -29,7 +29,7 @@ describe("completeTask", () => {
   it("fires completion event for player tasks", () => {
     const dwarf = makeDwarf();
     const ctx = makeContext({ dwarves: [dwarf] });
-    const task = createTask(ctx.state, "civ-1", {
+    const task = createTask(ctx, {
       task_type: "haul",
       work_required: 1,
     });
@@ -45,7 +45,7 @@ describe("completeTask", () => {
   it("does not fire event for autonomous tasks (eat/drink/sleep)", () => {
     const dwarf = makeDwarf();
     const ctx = makeContext({ dwarves: [dwarf] });
-    const task = createTask(ctx.state, "civ-1", {
+    const task = createTask(ctx, {
       task_type: "eat",
       work_required: 1,
     });
@@ -61,7 +61,7 @@ describe("completeTask", () => {
   it("eating from infinite source restores need without consuming items", () => {
     const dwarf = makeDwarf({ need_food: 20 });
     const ctx = makeContext({ dwarves: [dwarf] });
-    const task = createTask(ctx.state, "civ-1", {
+    const task = createTask(ctx, {
       task_type: "eat",
       work_required: 1,
     });
@@ -77,7 +77,7 @@ describe("completeTask", () => {
     const dwarf = makeDwarf({ need_food: 20 });
     const food = makeItem({ category: "food" });
     const ctx = makeContext({ dwarves: [dwarf], items: [food] });
-    const task = createTask(ctx.state, "civ-1", {
+    const task = createTask(ctx, {
       task_type: "eat",
       target_item_id: food.id,
       work_required: 1,
@@ -94,7 +94,7 @@ describe("completeTask", () => {
   it("drinking from infinite source restores need without consuming items", () => {
     const dwarf = makeDwarf({ need_drink: 15 });
     const ctx = makeContext({ dwarves: [dwarf] });
-    const task = createTask(ctx.state, "civ-1", {
+    const task = createTask(ctx, {
       task_type: "drink",
       work_required: 1,
     });
@@ -109,7 +109,7 @@ describe("completeTask", () => {
   it("sleeping completion does not add extra sleep (gradual restore happens in task-execution)", () => {
     const dwarf = makeDwarf({ need_sleep: 10 });
     const ctx = makeContext({ dwarves: [dwarf] });
-    const task = createTask(ctx.state, "civ-1", {
+    const task = createTask(ctx, {
       task_type: "sleep",
       work_required: 1,
     });
@@ -126,7 +126,7 @@ describe("completeTask", () => {
     const dwarf = makeDwarf();
     const skill = makeSkill(dwarf.id, "mining", 0);
     const ctx = makeContext({ dwarves: [dwarf], skills: [skill] });
-    const task = createTask(ctx.state, "civ-1", {
+    const task = createTask(ctx, {
       task_type: "mine",
       target_x: 10,
       target_y: 10,
@@ -148,7 +148,7 @@ describe("completeTask", () => {
     const dwarf = makeDwarf();
     const skill = makeSkill(dwarf.id, "building", 0, 0);
     const ctx = makeContext({ dwarves: [dwarf], skills: [skill] });
-    const task = createTask(ctx.state, "civ-1", {
+    const task = createTask(ctx, {
       task_type: "build_wall",
       target_x: 5,
       target_y: 5,
@@ -168,7 +168,7 @@ describe("completeTask", () => {
     const dwarf = makeDwarf();
     const skill = makeSkill(dwarf.id, "farming", 0);
     const ctx = makeContext({ dwarves: [dwarf], skills: [skill] });
-    const task = createTask(ctx.state, "civ-1", {
+    const task = createTask(ctx, {
       task_type: "farm_harvest",
       target_x: 0,
       target_y: 0,
@@ -190,7 +190,7 @@ describe("bed sleep completion", () => {
   it("floor sleep applies stress penalty", () => {
     const dwarf = makeDwarf({ need_sleep: 10, stress_level: 20 });
     const ctx = makeContext({ dwarves: [dwarf] });
-    const task = createTask(ctx.state, "civ-1", {
+    const task = createTask(ctx, {
       task_type: "sleep",
       work_required: 1,
       target_item_id: null,
@@ -207,7 +207,7 @@ describe("bed sleep completion", () => {
     const bed = makeStructure({ occupied_by_dwarf_id: "some-dwarf" });
     const dwarf = makeDwarf({ need_sleep: 10, stress_level: 20 });
     const ctx = makeContext({ dwarves: [dwarf], structures: [bed] });
-    const task = createTask(ctx.state, "civ-1", {
+    const task = createTask(ctx, {
       task_type: "sleep",
       work_required: 1,
       target_item_id: bed.id,
@@ -225,7 +225,7 @@ describe("bed sleep completion", () => {
     const dwarf = makeDwarf();
     const skill = makeSkill(dwarf.id, "building", 0);
     const ctx = makeContext({ dwarves: [dwarf], skills: [skill] });
-    const task = createTask(ctx.state, "civ-1", {
+    const task = createTask(ctx, {
       task_type: "build_bed",
       target_x: 5,
       target_y: 5,

--- a/sim/src/__tests__/task-dispatch.test.ts
+++ b/sim/src/__tests__/task-dispatch.test.ts
@@ -58,7 +58,7 @@ describe("job claiming", () => {
     const skill = makeSkill(dwarf.id, "mining", 5);
     const ctx = makeContext({ dwarves: [dwarf], skills: [skill] });
 
-    createTask(ctx.state, "civ-1", {
+    createTask(ctx, {
       task_type: "mine",
       target_x: 10,
       target_y: 10,
@@ -78,7 +78,7 @@ describe("job claiming", () => {
     // No mining skill
     const ctx = makeContext({ dwarves: [dwarf] });
 
-    createTask(ctx.state, "civ-1", {
+    createTask(ctx, {
       task_type: "mine",
       target_x: 10,
       target_y: 10,
@@ -95,7 +95,7 @@ describe("job claiming", () => {
     const dwarf = makeDwarf();
     const ctx = makeContext({ dwarves: [dwarf] });
 
-    createTask(ctx.state, "civ-1", {
+    createTask(ctx, {
       task_type: "haul",
       target_x: 5,
       target_y: 5,
@@ -112,14 +112,14 @@ describe("job claiming", () => {
     const dwarf = makeDwarf();
     const ctx = makeContext({ dwarves: [dwarf] });
 
-    createTask(ctx.state, "civ-1", {
+    createTask(ctx, {
       task_type: "haul",
       priority: 3,
       target_x: 5,
       target_y: 5,
       target_z: 0,
     });
-    createTask(ctx.state, "civ-1", {
+    createTask(ctx, {
       task_type: "haul",
       priority: 8,
       target_x: 5,
@@ -138,7 +138,7 @@ describe("job claiming", () => {
     const dwarf2 = makeDwarf();
     const ctx = makeContext({ dwarves: [dwarf1, dwarf2] });
 
-    createTask(ctx.state, "civ-1", {
+    createTask(ctx, {
       task_type: "haul",
       target_x: 5,
       target_y: 5,
@@ -161,7 +161,7 @@ describe("task execution", () => {
     const dwarf = makeDwarf({ position_x: 10, position_y: 10, position_z: 0 });
     const ctx = makeContext({ dwarves: [dwarf] });
 
-    const task = createTask(ctx.state, "civ-1", {
+    const task = createTask(ctx, {
       task_type: "haul",
       target_x: 10,
       target_y: 10,
@@ -182,7 +182,7 @@ describe("task execution", () => {
     const dwarf = makeDwarf({ position_x: 10, position_y: 10, position_z: 0 });
     const ctx = makeContext({ dwarves: [dwarf] });
 
-    const task = createTask(ctx.state, "civ-1", {
+    const task = createTask(ctx, {
       task_type: "haul",
       target_x: 10,
       target_y: 10,
@@ -206,7 +206,7 @@ describe("task execution", () => {
     });
     const ctx = makeContext({ dwarves: [dwarf] });
 
-    const task = createTask(ctx.state, "civ-1", {
+    const task = createTask(ctx, {
       task_type: "eat",
       target_x: 0,
       target_y: 0,
@@ -231,7 +231,7 @@ describe("task execution", () => {
     });
     const ctx = makeContext({ dwarves: [dwarf] });
 
-    const task = createTask(ctx.state, "civ-1", {
+    const task = createTask(ctx, {
       task_type: "drink",
       target_x: 0,
       target_y: 0,
@@ -256,7 +256,7 @@ describe("task execution", () => {
     });
     const ctx = makeContext({ dwarves: [dwarf] });
 
-    const task = createTask(ctx.state, "civ-1", {
+    const task = createTask(ctx, {
       task_type: "sleep",
       target_x: 0,
       target_y: 0,
@@ -284,7 +284,7 @@ describe("task execution", () => {
     const skill = makeSkill(dwarf.id, "mining", 0);
     const ctx = makeContext({ dwarves: [dwarf], skills: [skill] });
 
-    const task = createTask(ctx.state, "civ-1", {
+    const task = createTask(ctx, {
       task_type: "mine",
       target_x: 10,
       target_y: 10,
@@ -315,7 +315,7 @@ describe("task execution", () => {
       },
     };
 
-    const task = createTask(ctx.state, "civ-1", {
+    const task = createTask(ctx, {
       task_type: "haul",
       target_x: 5,
       target_y: 3,
@@ -353,7 +353,7 @@ describe("task execution", () => {
       },
     };
 
-    const task = createTask(ctx.state, "civ-1", {
+    const task = createTask(ctx, {
       task_type: "mine",
       target_x: 0,
       target_y: 0,
@@ -405,7 +405,7 @@ describe("need satisfaction", () => {
     const ctx = makeContext({ dwarves: [dwarf] });
 
     // Give dwarf a haul task
-    const haulTask = createTask(ctx.state, "civ-1", {
+    const haulTask = createTask(ctx, {
       task_type: "haul",
       target_x: 5,
       target_y: 5,
@@ -432,7 +432,7 @@ describe("need satisfaction", () => {
     const ctx = makeContext({ dwarves: [dwarf] });
 
     // Dwarf is already eating
-    const eatTask = createTask(ctx.state, "civ-1", {
+    const eatTask = createTask(ctx, {
       task_type: "eat",
       target_x: 0,
       target_y: 0,
@@ -524,7 +524,7 @@ describe("starvation scenario", () => {
     expect(dwarf.status).toBe("alive");
 
     // Now eat (infinite source — no target item needed)
-    const eatTask = createTask(ctx.state, "civ-1", {
+    const eatTask = createTask(ctx, {
       task_type: "eat",
       target_x: 0,
       target_y: 0,
@@ -799,14 +799,14 @@ describe("skill-based task preferences", () => {
     ];
     const ctx = makeContext({ dwarves: [miner], skills });
 
-    const buildTask = createTask(ctx.state, "civ-1", {
+    const buildTask = createTask(ctx, {
       task_type: "build_wall",
       priority: 5,
       target_x: 5,
       target_y: 0,
       target_z: 0,
     });
-    const mineTask = createTask(ctx.state, "civ-1", {
+    const mineTask = createTask(ctx, {
       task_type: "mine",
       priority: 5,
       target_x: 5,
@@ -831,14 +831,14 @@ describe("skill-based task preferences", () => {
     const ctx = makeContext({ dwarves: [dwarf], skills });
 
     // Build task with much higher priority
-    const buildTask = createTask(ctx.state, "civ-1", {
+    const buildTask = createTask(ctx, {
       task_type: "build_wall",
       priority: 10,
       target_x: 5,
       target_y: 0,
       target_z: 0,
     });
-    const mineTask = createTask(ctx.state, "civ-1", {
+    const mineTask = createTask(ctx, {
       task_type: "mine",
       priority: 1,
       target_x: 5,
@@ -863,14 +863,14 @@ describe("skill-based task preferences", () => {
     ];
     const ctx = makeContext({ dwarves: [miner, builder], skills });
 
-    const mineTask = createTask(ctx.state, "civ-1", {
+    const mineTask = createTask(ctx, {
       task_type: "mine",
       priority: 5,
       target_x: 5,
       target_y: 0,
       target_z: 0,
     });
-    const buildTask = createTask(ctx.state, "civ-1", {
+    const buildTask = createTask(ctx, {
       task_type: "build_wall",
       priority: 5,
       target_x: 5,

--- a/sim/src/__tests__/task-helpers.test.ts
+++ b/sim/src/__tests__/task-helpers.test.ts
@@ -9,8 +9,7 @@ import {
   createTask,
   findNearestItem,
 } from "../task-helpers.js";
-import { createEmptyCachedState } from "../sim-context.js";
-import { makeSkill, makeItem } from "./test-helpers.js";
+import { makeSkill, makeItem, makeContext } from "./test-helpers.js";
 
 describe("getRequiredSkill", () => {
   it("returns mining for mine tasks", () => {
@@ -82,20 +81,20 @@ describe("isAutonomousTask", () => {
 
 describe("createTask", () => {
   it("creates a task with defaults", () => {
-    const state = createEmptyCachedState();
-    const task = createTask(state, "civ-1", { task_type: "mine" });
+    const ctx = makeContext();
+    const task = createTask(ctx, { task_type: "mine" });
 
     expect(task.task_type).toBe("mine");
     expect(task.status).toBe("pending");
     expect(task.priority).toBe(5);
     expect(task.work_required).toBe(100);
-    expect(state.tasks).toContain(task);
-    expect(state.newTasks).toContain(task);
+    expect(ctx.state.tasks).toContain(task);
+    expect(ctx.state.newTasks).toContain(task);
   });
 
   it("applies overrides", () => {
-    const state = createEmptyCachedState();
-    const task = createTask(state, "civ-1", {
+    const ctx = makeContext();
+    const task = createTask(ctx, {
       task_type: "haul",
       priority: 8,
       target_x: 10,

--- a/sim/src/__tests__/test-helpers.ts
+++ b/sim/src/__tests__/test-helpers.ts
@@ -1,12 +1,14 @@
-import { randomUUID } from "node:crypto";
-import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Dwarf, DwarfSkill, Task, Item, Structure } from "@pwarf/shared";
 import type { SimContext } from "../sim-context.js";
-import { createEmptyCachedState } from "../sim-context.js";
+import { createTestContext } from "../sim-context.js";
+import { createRng, DEFAULT_TEST_SEED } from "../rng.js";
+
+// Shared RNG for generating IDs in test factories — uses fixed seed for reproducibility
+const _factoryRng = createRng(DEFAULT_TEST_SEED);
 
 export function makeDwarf(overrides?: Partial<Dwarf>): Dwarf {
   return {
-    id: randomUUID(),
+    id: _factoryRng.uuid(),
     civilization_id: "civ-1",
     name: "Urist",
     surname: "McTestdwarf",
@@ -45,7 +47,7 @@ export function makeDwarf(overrides?: Partial<Dwarf>): Dwarf {
 
 export function makeSkill(dwarfId: string, skillName: string, level = 0, xp = 0): DwarfSkill {
   return {
-    id: randomUUID(),
+    id: _factoryRng.uuid(),
     dwarf_id: dwarfId,
     skill_name: skillName,
     level,
@@ -56,7 +58,7 @@ export function makeSkill(dwarfId: string, skillName: string, level = 0, xp = 0)
 
 export function makeItem(overrides?: Partial<Item>): Item {
   return {
-    id: randomUUID(),
+    id: _factoryRng.uuid(),
     name: "Plump helmet",
     category: "food",
     quality: "standard",
@@ -82,7 +84,7 @@ export function makeItem(overrides?: Partial<Item>): Item {
 
 export function makeStructure(overrides?: Partial<Structure>): Structure {
   return {
-    id: randomUUID(),
+    id: _factoryRng.uuid(),
     civilization_id: "civ-1",
     name: null,
     type: "bed",
@@ -106,21 +108,5 @@ export function makeContext(opts?: {
   items?: Item[];
   structures?: Structure[];
 }): SimContext {
-  const state = createEmptyCachedState();
-  state.dwarves = opts?.dwarves ?? [];
-  state.dwarfSkills = opts?.skills ?? [];
-  state.tasks = opts?.tasks ?? [];
-  state.items = opts?.items ?? [];
-  state.structures = opts?.structures ?? [];
-
-  return {
-    supabase: null as unknown as SupabaseClient,
-    civilizationId: "civ-1",
-    worldId: "world-1",
-    fortressDeriver: null,
-    step: 0,
-    year: 1,
-    day: 1,
-    state,
-  };
+  return createTestContext(opts);
 }

--- a/sim/src/headless-runner.ts
+++ b/sim/src/headless-runner.ts
@@ -2,6 +2,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { STEPS_PER_YEAR } from "@pwarf/shared";
 import type { SimContext } from "./sim-context.js";
 import { createEmptyCachedState } from "./sim-context.js";
+import { createRng } from "./rng.js";
 import {
   needsDecay,
   taskExecution,
@@ -82,6 +83,7 @@ export async function runHeadless(opts: HeadlessRunOptions): Promise<HeadlessRun
     step: 0,
     year: 1,
     day: 1,
+    rng: createRng(scenarioDef?.seed ?? 0),
     state,
   };
 

--- a/sim/src/phases/deprivation.ts
+++ b/sim/src/phases/deprivation.ts
@@ -69,7 +69,7 @@ export function killDwarf(dwarf: Dwarf, cause: string, ctx: SimContext): void {
   const aliveDwarves = state.dwarves.filter(d => d.status === 'alive');
   if (aliveDwarves.length === 0) {
     state.pendingEvents.push({
-      id: crypto.randomUUID(),
+      id: ctx.rng.uuid(),
       world_id: '',
       year: ctx.year,
       category: 'fortress_fallen',

--- a/sim/src/phases/event-firing.ts
+++ b/sim/src/phases/event-firing.ts
@@ -22,7 +22,7 @@ export async function eventFiring(ctx: SimContext): Promise<void> {
     // Critical food warning at need_food < 10
     if (dwarf.need_food < 10 && dwarf.need_food >= 9.8) {
       state.pendingEvents.push({
-        id: crypto.randomUUID(),
+        id: ctx.rng.uuid(),
         world_id: '',
         year: ctx.year,
         category: 'death', // Using existing category — will be 'warning' later
@@ -41,7 +41,7 @@ export async function eventFiring(ctx: SimContext): Promise<void> {
     // Critical drink warning
     if (dwarf.need_drink < 10 && dwarf.need_drink >= 9.8) {
       state.pendingEvents.push({
-        id: crypto.randomUUID(),
+        id: ctx.rng.uuid(),
         world_id: '',
         year: ctx.year,
         category: 'death',

--- a/sim/src/phases/haul-assignment.ts
+++ b/sim/src/phases/haul-assignment.ts
@@ -28,7 +28,7 @@ export async function haulAssignment(ctx: SimContext): Promise<void> {
 
     // Create a haul task for the first carried item
     const item = carried[0];
-    createTask(state, ctx.civilizationId, {
+    createTask(ctx, {
       task_type: 'haul',
       priority: 4,
       target_x: target.x,

--- a/sim/src/phases/idle-wandering.ts
+++ b/sim/src/phases/idle-wandering.ts
@@ -27,8 +27,8 @@ export async function idleWandering(ctx: SimContext): Promise<void> {
     if (hasWander) continue;
 
     // Pick a random offset within wander radius
-    const dx = Math.floor(Math.random() * (WANDER_RADIUS * 2 + 1)) - WANDER_RADIUS;
-    const dy = Math.floor(Math.random() * (WANDER_RADIUS * 2 + 1)) - WANDER_RADIUS;
+    const dx = ctx.rng.int(-WANDER_RADIUS, WANDER_RADIUS);
+    const dy = ctx.rng.int(-WANDER_RADIUS, WANDER_RADIUS);
 
     const targetX = Math.max(0, Math.min(FORTRESS_SIZE - 1, dwarf.position_x + dx));
     const targetY = Math.max(0, Math.min(FORTRESS_SIZE - 1, dwarf.position_y + dy));
@@ -40,7 +40,7 @@ export async function idleWandering(ctx: SimContext): Promise<void> {
     const targetTile = getTile(targetX, targetY, dwarf.position_z);
     if (!isWalkable(targetTile)) continue;
 
-    createTask(state, ctx.civilizationId, {
+    createTask(ctx, {
       task_type: 'wander',
       priority: 1, // Lowest priority — any real task should take precedence
       target_x: targetX,

--- a/sim/src/phases/job-claiming.ts
+++ b/sim/src/phases/job-claiming.ts
@@ -109,7 +109,7 @@ function claimTask(dwarf: Dwarf, task: Task, ctx: SimContext): void {
     const dwarfLabel = `${dwarf.name}${dwarf.surname ? ' ' + dwarf.surname : ''}`;
     const taskLabel = task.task_type.replace(/_/g, ' ');
     state.pendingEvents.push({
-      id: crypto.randomUUID(),
+      id: ctx.rng.uuid(),
       world_id: '',
       year: ctx.year,
       category: 'discovery',

--- a/sim/src/phases/need-satisfaction.ts
+++ b/sim/src/phases/need-satisfaction.ts
@@ -140,7 +140,7 @@ function maybeInterruptForNeed(dwarf: Dwarf, taskType: TaskType, ctx: SimContext
     }
   }
 
-  createTask(state, ctx.civilizationId, {
+  createTask(ctx, {
     task_type: taskType,
     priority,
     target_x: targetX,

--- a/sim/src/phases/task-completion.ts
+++ b/sim/src/phases/task-completion.ts
@@ -40,7 +40,7 @@ export function completeTask(dwarf: Dwarf, task: Task, ctx: SimContext): void {
     const dwarfLabel = `${dwarf.name}${dwarf.surname ? ' ' + dwarf.surname : ''}`;
     const taskLabel = task.task_type.replace(/_/g, ' ');
     state.pendingEvents.push({
-      id: crypto.randomUUID(),
+      id: ctx.rng.uuid(),
       world_id: '',
       year: ctx.year,
       category: 'discovery',
@@ -112,7 +112,7 @@ function completeMine(dwarf: Dwarf, task: Task, ctx: SimContext): void {
 
   if (itemName) {
     const minedItem: Item = {
-      id: crypto.randomUUID(),
+      id: ctx.rng.uuid(),
       name: itemName,
       category: 'raw_material',
       quality: 'standard',
@@ -196,7 +196,7 @@ function upsertFortressTile(
     existing.is_mined = isMined;
   } else {
     const tile: FortressTile = {
-      id: crypto.randomUUID(),
+      id: ctx.rng.uuid(),
       civilization_id: ctx.civilizationId,
       x, y, z,
       tile_type: tileType,
@@ -228,7 +228,7 @@ function completeHaul(dwarf: Dwarf, task: Task, ctx: SimContext): void {
 
 function completeFarmHarvest(task: Task, ctx: SimContext): void {
   const food: Item = {
-    id: crypto.randomUUID(),
+    id: ctx.rng.uuid(),
     name: 'Plump helmet',
     category: 'food',
     quality: 'standard',
@@ -301,7 +301,7 @@ function completeBuildBed(task: Task, ctx: SimContext): void {
   if (task.target_x === null || task.target_y === null || task.target_z === null) return;
 
   const bed: Structure = {
-    id: crypto.randomUUID(),
+    id: ctx.rng.uuid(),
     civilization_id: ctx.civilizationId,
     name: null,
     type: 'bed',

--- a/sim/src/rng.test.ts
+++ b/sim/src/rng.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { createRng, DEFAULT_TEST_SEED } from "./rng.js";
+
+describe("createRng", () => {
+  it("produces values in [0, 1)", () => {
+    const rng = createRng(DEFAULT_TEST_SEED);
+    for (let i = 0; i < 100; i++) {
+      const v = rng.random();
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+
+  it("produces the same sequence for the same seed", () => {
+    const a = createRng(42);
+    const b = createRng(42);
+    for (let i = 0; i < 50; i++) {
+      expect(a.random()).toBe(b.random());
+    }
+  });
+
+  it("produces different sequences for different seeds", () => {
+    const a = createRng(1);
+    const b = createRng(2);
+    const aVals = Array.from({ length: 10 }, () => a.random());
+    const bVals = Array.from({ length: 10 }, () => b.random());
+    expect(aVals).not.toEqual(bVals);
+  });
+
+  it("int returns values in [min, max] inclusive", () => {
+    const rng = createRng(DEFAULT_TEST_SEED);
+    for (let i = 0; i < 200; i++) {
+      const v = rng.int(-5, 5);
+      expect(v).toBeGreaterThanOrEqual(-5);
+      expect(v).toBeLessThanOrEqual(5);
+    }
+  });
+
+  it("uuid produces valid v4-like UUIDs", () => {
+    const rng = createRng(DEFAULT_TEST_SEED);
+    const uuid = rng.uuid();
+    expect(uuid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+  });
+
+  it("uuid produces unique values", () => {
+    const rng = createRng(DEFAULT_TEST_SEED);
+    const ids = new Set(Array.from({ length: 100 }, () => rng.uuid()));
+    expect(ids.size).toBe(100);
+  });
+
+  it("uuid is deterministic with the same seed", () => {
+    const a = createRng(99);
+    const b = createRng(99);
+    expect(a.uuid()).toBe(b.uuid());
+    expect(a.uuid()).toBe(b.uuid());
+  });
+});

--- a/sim/src/rng.ts
+++ b/sim/src/rng.ts
@@ -1,0 +1,51 @@
+/**
+ * Seeded pseudo-random number generator (mulberry32).
+ *
+ * All sim phases must use this instead of Math.random() or crypto.randomUUID()
+ * so that runs with the same seed produce identical results.
+ */
+export interface Rng {
+  /** Returns a float in [0, 1). */
+  random(): number;
+  /** Returns a random integer in [min, max] inclusive. */
+  int(min: number, max: number): number;
+  /** Returns a v4-like UUID using the seeded RNG. */
+  uuid(): string;
+}
+
+/** Creates a seeded RNG using the mulberry32 algorithm. */
+export function createRng(seed: number): Rng {
+  let s = seed >>> 0;
+
+  function random(): number {
+    s += 0x6d2b79f5;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 0x100000000;
+  }
+
+  function int(min: number, max: number): number {
+    return Math.floor(random() * (max - min + 1)) + min;
+  }
+
+  function uuid(): string {
+    // Generate a v4-like UUID using the seeded RNG
+    const hex = (n: number) => n.toString(16).padStart(2, '0');
+    const b = Array.from({ length: 16 }, () => Math.floor(random() * 256));
+    b[6] = (b[6] & 0x0f) | 0x40; // version 4
+    b[8] = (b[8] & 0x3f) | 0x80; // variant
+    return [
+      hex(b[0]) + hex(b[1]) + hex(b[2]) + hex(b[3]),
+      hex(b[4]) + hex(b[5]),
+      hex(b[6]) + hex(b[7]),
+      hex(b[8]) + hex(b[9]),
+      hex(b[10]) + hex(b[11]) + hex(b[12]) + hex(b[13]) + hex(b[14]) + hex(b[15]),
+    ].join('-');
+  }
+
+  return { random, int, uuid };
+}
+
+/** Default seed used in tests for reproducible results. */
+export const DEFAULT_TEST_SEED = 12345;

--- a/sim/src/scenarios.ts
+++ b/sim/src/scenarios.ts
@@ -1,7 +1,7 @@
-import { randomUUID } from "node:crypto";
 import type { Dwarf, Item, Task } from "@pwarf/shared";
 import type { CachedState } from "./sim-context.js";
 import { createEmptyCachedState } from "./sim-context.js";
+import { createRng, type Rng } from "./rng.js";
 
 export interface ScenarioDefinition {
   name: string;
@@ -52,7 +52,7 @@ export const SCENARIOS: Record<string, ScenarioDefinition> = {
   },
 };
 
-function makeDwarf(civId: string, index: number, needFood: number, needDrink: number): Dwarf {
+function makeDwarf(rng: Rng, civId: string, index: number, needFood: number, needDrink: number): Dwarf {
   const names = [
     "Urist", "Zon", "Meng", "Datan", "Reg", "Ast", "Domas",
     "Logem", "Onol", "Sodel", "Iden", "Bim", "Erith", "Kubuk",
@@ -66,7 +66,7 @@ function makeDwarf(civId: string, index: number, needFood: number, needDrink: nu
   ];
 
   return {
-    id: randomUUID(),
+    id: rng.uuid(),
     civilization_id: civId,
     name: names[index % names.length] ?? "Urist",
     surname: surnames[index % surnames.length] ?? "McTestdwarf",
@@ -102,11 +102,11 @@ function makeDwarf(civId: string, index: number, needFood: number, needDrink: nu
   };
 }
 
-function makeFood(civId: string, count: number): Item[] {
+function makeFood(rng: Rng, civId: string, count: number): Item[] {
   const items: Item[] = [];
   for (let i = 0; i < count; i++) {
     items.push({
-      id: randomUUID(),
+      id: rng.uuid(),
       name: "Plump helmet",
       category: "food",
       quality: "standard",
@@ -131,11 +131,11 @@ function makeFood(civId: string, count: number): Item[] {
   return items;
 }
 
-function makeDrink(civId: string, count: number): Item[] {
+function makeDrink(rng: Rng, civId: string, count: number): Item[] {
   const items: Item[] = [];
   for (let i = 0; i < count; i++) {
     items.push({
-      id: randomUUID(),
+      id: rng.uuid(),
       name: "Dwarven ale",
       category: "drink",
       quality: "standard",
@@ -162,6 +162,7 @@ function makeDrink(civId: string, count: number): Item[] {
 
 /** Build initial CachedState from a scenario definition. */
 export function buildScenarioState(scenario: ScenarioDefinition): CachedState {
+  const rng = createRng(scenario.seed);
   const civId = "headless-civ";
   const state = createEmptyCachedState();
 
@@ -170,19 +171,20 @@ export function buildScenarioState(scenario: ScenarioDefinition): CachedState {
   const needDrink = scenario.initialDrink === 0 ? 80 : 80;
 
   state.dwarves = Array.from({ length: scenario.dwarfCount }, (_, i) =>
-    makeDwarf(civId, i, needFood, needDrink)
+    makeDwarf(rng, civId, i, needFood, needDrink)
   );
 
   state.items = [
-    ...makeFood(civId, scenario.initialFood),
-    ...makeDrink(civId, scenario.initialDrink),
+    ...makeFood(rng, civId, scenario.initialFood),
+    ...makeDrink(rng, civId, scenario.initialDrink),
   ];
 
   return state;
 }
 
 /** Build eat/drink tasks so dwarves know where food is. */
-export function buildEatDrinkTasks(state: CachedState): Task[] {
+export function buildEatDrinkTasks(state: CachedState, seed = 0): Task[] {
+  const rng = createRng(seed);
   const civId = "headless-civ";
   const tasks: Task[] = [];
 
@@ -190,7 +192,7 @@ export function buildEatDrinkTasks(state: CachedState): Task[] {
     if (item.position_x == null || item.position_y == null || item.position_z == null) continue;
     if (item.category === "food") {
       tasks.push({
-        id: randomUUID(),
+        id: rng.uuid(),
         civilization_id: civId,
         task_type: "eat",
         status: "pending",
@@ -207,7 +209,7 @@ export function buildEatDrinkTasks(state: CachedState): Task[] {
       });
     } else if (item.category === "drink") {
       tasks.push({
-        id: randomUUID(),
+        id: rng.uuid(),
         civilization_id: civId,
         task_type: "drink",
         status: "pending",

--- a/sim/src/sim-context.ts
+++ b/sim/src/sim-context.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { createRng, DEFAULT_TEST_SEED, type Rng } from "./rng.js";
 import type {
   Dwarf,
   DwarfSkill,
@@ -99,6 +100,43 @@ export interface SimContext {
   /** Current in-game day within the year. */
   day: number;
 
+  /** Seeded RNG — use instead of Math.random() or crypto.randomUUID(). */
+  rng: Rng;
+
   /** Mutable cached world state, loaded at start and patched each tick. */
   state: CachedState;
 }
+
+/** Creates a SimContext with a default test seed. Used in tests. */
+export function createTestContext(
+  opts?: {
+    dwarves?: Dwarf[];
+    skills?: DwarfSkill[];
+    tasks?: Task[];
+    items?: Item[];
+    structures?: Structure[];
+  },
+  seed = DEFAULT_TEST_SEED
+): SimContext {
+  const state = createEmptyCachedState();
+  state.dwarves = opts?.dwarves ?? [];
+  state.dwarfSkills = opts?.skills ?? [];
+  state.tasks = opts?.tasks ?? [];
+  state.items = opts?.items ?? [];
+  state.structures = opts?.structures ?? [];
+
+  return {
+    supabase: null as unknown as SupabaseClient,
+    civilizationId: "civ-1",
+    worldId: "world-1",
+    fortressDeriver: null,
+    step: 0,
+    year: 1,
+    day: 1,
+    rng: createRng(seed),
+    state,
+  };
+}
+
+export { createRng, DEFAULT_TEST_SEED };
+export type { Rng };

--- a/sim/src/sim-runner.ts
+++ b/sim/src/sim-runner.ts
@@ -3,6 +3,7 @@ import { STEPS_PER_SECOND, STEPS_PER_YEAR, SIM_FLUSH_INTERVAL_MS, createFortress
 import type { Dwarf, Item, Task, WorldEvent } from "@pwarf/shared";
 import type { SimContext } from "./sim-context.js";
 import { createEmptyCachedState } from "./sim-context.js";
+import { createRng } from "./rng.js";
 import { loadStateFromSupabase } from "./load-state.js";
 import { flushToSupabase } from "./flush-state.js";
 import {
@@ -83,6 +84,7 @@ export class SimRunner {
       step: this.stepCount,
       year: this.currentYear,
       day: this.currentDay,
+      rng: createRng(Date.now()),
       state: cached,
     };
 

--- a/sim/src/task-helpers.ts
+++ b/sim/src/task-helpers.ts
@@ -1,5 +1,5 @@
 import type { Dwarf, DwarfSkill, Task, TaskType, Item } from "@pwarf/shared";
-import type { CachedState } from "./sim-context.js";
+import type { CachedState, SimContext } from "./sim-context.js";
 
 /** Map task types to the skill name required. null means any dwarf can do it. */
 const TASK_SKILL_MAP: Record<TaskType, string | null> = {
@@ -64,8 +64,7 @@ export function getBestSkill(dwarfId: string, skills: DwarfSkill[]): string | nu
 
 /** Create a new task and add it to the cached state. */
 export function createTask(
-  state: CachedState,
-  civilizationId: string,
+  ctx: SimContext,
   opts: {
     task_type: TaskType;
     priority?: number;
@@ -78,8 +77,8 @@ export function createTask(
   },
 ): Task {
   const task: Task = {
-    id: crypto.randomUUID(),
-    civilization_id: civilizationId,
+    id: ctx.rng.uuid(),
+    civilization_id: ctx.civilizationId,
     task_type: opts.task_type,
     status: 'pending',
     priority: opts.priority ?? 5,
@@ -94,8 +93,8 @@ export function createTask(
     completed_at: null,
   };
 
-  state.tasks.push(task);
-  state.newTasks.push(task);
+  ctx.state.tasks.push(task);
+  ctx.state.newTasks.push(task);
   return task;
 }
 


### PR DESCRIPTION
## Summary

- Adds a mulberry32 seeded PRNG in `sim/src/rng.ts` with `random()`, `int()`, and `uuid()` methods
- Threads `ctx.rng` through `SimContext` — all phases use it instead of `Math.random()` or `crypto.randomUUID()`
- `SimRunner` seeds from `Date.now()` for live runs; headless runner uses the scenario's seed; tests use `DEFAULT_TEST_SEED = 12345`
- Refactored `createTask(state, civId, opts)` → `createTask(ctx, opts)` to give it access to the RNG
- Running the same scenario twice with the same seed now produces identical results

## Playtest

Pure sim/shared change — no frontend changes. All 456 sim tests pass. The live game uses `Date.now()` as seed so each run is still different for players.

## Claude Cost

**Claude cost:** $3.67 (9.9M tokens)