### PR TITLE
feat: StateAdapter interface — decouple sim from Supabase (closes #280)

### DIFF
--- a/sim/src/cli.ts
+++ b/sim/src/cli.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@supabase/supabase-js";
 import { SimRunner } from "./sim-runner.js";
+import { SupabaseStateAdapter } from "./state-adapter.js";
 import { runHeadless } from "./headless-runner.js";
 import { SCENARIOS } from "./scenarios.js";
 
@@ -73,7 +74,7 @@ if (scenarioArg || hasFlag("--headless")) {
   }
 
   const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
-  const runner = new SimRunner(supabase);
+  const runner = new SimRunner(new SupabaseStateAdapter(supabase));
 
   const civId = process.env.CIVILIZATION_ID ?? "default";
   const worldId = process.env.WORLD_ID;

--- a/sim/src/index.ts
+++ b/sim/src/index.ts
@@ -2,3 +2,5 @@ export { SimRunner } from "./sim-runner.js";
 export type { SimSnapshot } from "./sim-runner.js";
 export { loadStateFromSupabase } from "./load-state.js";
 export { flushToSupabase } from "./flush-state.js";
+export type { StateAdapter } from "./state-adapter.js";
+export { SupabaseStateAdapter, InMemoryStateAdapter } from "./state-adapter.js";

--- a/sim/src/sim-runner.ts
+++ b/sim/src/sim-runner.ts
@@ -1,11 +1,9 @@
-import type { SupabaseClient } from "@supabase/supabase-js";
 import { STEPS_PER_SECOND, STEPS_PER_YEAR, SIM_FLUSH_INTERVAL_MS, createFortressDeriver } from "@pwarf/shared";
 import type { Dwarf, Item, Task, WorldEvent } from "@pwarf/shared";
 import type { SimContext } from "./sim-context.js";
 import { createEmptyCachedState } from "./sim-context.js";
 import { createRng } from "./rng.js";
-import { loadStateFromSupabase } from "./load-state.js";
-import { flushToSupabase } from "./flush-state.js";
+import type { StateAdapter } from "./state-adapter.js";
 import {
   needsDecay,
   taskExecution,
@@ -38,7 +36,7 @@ export interface SimSnapshot {
  * function in deterministic order every tick.
  */
 export class SimRunner {
-  private supabase: SupabaseClient;
+  private adapter: StateAdapter;
   private timer: ReturnType<typeof setInterval> | null = null;
   private flushTimer: ReturnType<typeof setInterval> | null = null;
   private ctx: SimContext | null = null;
@@ -50,34 +48,26 @@ export class SimRunner {
   currentYear = 1;
   currentDay = 1;
 
-  constructor(supabase: SupabaseClient) {
-    this.supabase = supabase;
+  constructor(adapter: StateAdapter) {
+    this.adapter = adapter;
   }
 
-  /** Load initial state from Supabase and begin the tick loop. */
+  /** Load initial state and begin the tick loop. */
   async start(civilizationId: string, worldId?: string): Promise<void> {
-    let cached;
-    if (worldId) {
-      cached = await loadStateFromSupabase(this.supabase, civilizationId, worldId);
-    } else {
-      cached = createEmptyCachedState();
-    }
+    const cached = worldId
+      ? await this.adapter.loadState(civilizationId, worldId)
+      : createEmptyCachedState();
 
-    // Fetch world seed to create fortress deriver
     let fortressDeriver = null;
     if (worldId) {
-      const { data: worldData } = await this.supabase
-        .from('worlds')
-        .select('seed')
-        .eq('id', worldId)
-        .single();
-      if (worldData?.seed != null) {
-        fortressDeriver = createFortressDeriver(BigInt(worldData.seed), civilizationId);
+      const seed = await this.adapter.getWorldSeed(worldId);
+      if (seed != null) {
+        fortressDeriver = createFortressDeriver(seed, civilizationId);
       }
     }
 
     this.ctx = {
-      supabase: this.supabase,
+      supabase: null as never,
       civilizationId,
       worldId: worldId ?? '',
       fortressDeriver,
@@ -88,19 +78,16 @@ export class SimRunner {
       state: cached,
     };
 
-    console.log(
-      `[sim] starting simulation for civilization ${civilizationId}`
-    );
+    console.log(`[sim] starting simulation for civilization ${civilizationId}`);
 
     const intervalMs = 1000 / STEPS_PER_SECOND;
     this.timer = setInterval(() => {
       void this.tick();
     }, intervalMs);
 
-    // Flush dirty state to Supabase + poll for new tasks
     this.flushTimer = setInterval(() => {
       if (this.ctx) {
-        void flushToSupabase(this.ctx);
+        void this.adapter.flush(this.ctx);
         void this.pollNewTasks();
         void this.pollStockpileTiles();
       }
@@ -118,50 +105,29 @@ export class SimRunner {
       this.flushTimer = null;
     }
 
-    // Final flush before stopping
     if (this.ctx) {
-      await flushToSupabase(this.ctx);
+      await this.adapter.flush(this.ctx);
     }
 
     console.log(`[sim] stopped at step ${this.stepCount}`);
   }
 
-  /** Poll Supabase for new tasks created by the player (designations). */
   private async pollNewTasks(): Promise<void> {
     if (!this.ctx) return;
-    const { state, supabase, civilizationId } = this.ctx;
-
+    const { state, civilizationId } = this.ctx;
     const existingIds = new Set(state.tasks.map(t => t.id));
-
-    const { data, error } = await supabase
-      .from('tasks')
-      .select('*')
-      .eq('civilization_id', civilizationId)
-      .eq('status', 'pending');
-
-    if (error || !data) return;
-
-    for (const task of data) {
-      if (!existingIds.has(task.id)) {
-        state.tasks.push(task);
-      }
+    const newTasks = await this.adapter.pollNewTasks(civilizationId, existingIds);
+    for (const task of newTasks) {
+      state.tasks.push(task);
     }
   }
 
-  /** Poll Supabase for stockpile tiles created by the player. */
   private async pollStockpileTiles(): Promise<void> {
     if (!this.ctx) return;
-    const { state, supabase, civilizationId } = this.ctx;
-
-    const { data, error } = await supabase
-      .from('stockpile_tiles')
-      .select('*')
-      .eq('civilization_id', civilizationId);
-
-    if (error || !data) return;
-
+    const { state, civilizationId } = this.ctx;
+    const tiles = await this.adapter.pollStockpileTiles(civilizationId);
     state.stockpileTiles.clear();
-    for (const tile of data) {
+    for (const tile of tiles) {
       state.stockpileTiles.set(`${tile.x},${tile.y},${tile.z}`, tile);
     }
   }
@@ -191,7 +157,6 @@ export class SimRunner {
     await eventFiring(this.ctx);
     await thoughtGeneration(this.ctx);
 
-    // Yearly rollup only fires once every STEPS_PER_YEAR steps
     if (this.stepCount % STEPS_PER_YEAR === 0) {
       this.currentYear++;
       this.currentDay = 1;
@@ -200,7 +165,6 @@ export class SimRunner {
       await yearlyRollup(this.ctx);
     }
 
-    // Emit snapshot for live UI rendering
     if (this.onTick) {
       this.onTick({
         dwarves: this.ctx.state.dwarves,

--- a/sim/src/state-adapter.test.ts
+++ b/sim/src/state-adapter.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { InMemoryStateAdapter } from "./state-adapter.js";
+import { createEmptyCachedState, createTestContext } from "./sim-context.js";
+import type { Task } from "@pwarf/shared";
+
+describe("InMemoryStateAdapter", () => {
+  it("loadState returns provided initial state", async () => {
+    const state = createEmptyCachedState();
+    state.dwarves = [];
+    const adapter = new InMemoryStateAdapter(state);
+    const loaded = await adapter.loadState("civ-1", "world-1");
+    expect(loaded).toBe(state);
+  });
+
+  it("getWorldSeed returns null", async () => {
+    const adapter = new InMemoryStateAdapter();
+    expect(await adapter.getWorldSeed("world-1")).toBeNull();
+  });
+
+  it("pollNewTasks returns queued tasks and clears queue", async () => {
+    const adapter = new InMemoryStateAdapter();
+    const task: Task = {
+      id: "t1",
+      civilization_id: "civ-1",
+      task_type: "mine",
+      status: "pending",
+      priority: 5,
+      assigned_dwarf_id: null,
+      target_x: 1,
+      target_y: 2,
+      target_z: 0,
+      target_item_id: null,
+      work_progress: 0,
+      work_required: 100,
+      created_at: new Date().toISOString(),
+      completed_at: null,
+    };
+
+    adapter.queueTasks([task]);
+
+    const result = await adapter.pollNewTasks("civ-1", new Set());
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("t1");
+
+    // Queue should be cleared after poll
+    const empty = await adapter.pollNewTasks("civ-1", new Set());
+    expect(empty).toHaveLength(0);
+  });
+
+  it("pollNewTasks filters out already-known task IDs", async () => {
+    const adapter = new InMemoryStateAdapter();
+    const task: Task = {
+      id: "t1",
+      civilization_id: "civ-1",
+      task_type: "mine",
+      status: "pending",
+      priority: 5,
+      assigned_dwarf_id: null,
+      target_x: 1,
+      target_y: 2,
+      target_z: 0,
+      target_item_id: null,
+      work_progress: 0,
+      work_required: 100,
+      created_at: new Date().toISOString(),
+      completed_at: null,
+    };
+    adapter.queueTasks([task]);
+
+    const result = await adapter.pollNewTasks("civ-1", new Set(["t1"]));
+    expect(result).toHaveLength(0);
+  });
+
+  it("pollStockpileTiles returns empty array", async () => {
+    const adapter = new InMemoryStateAdapter();
+    expect(await adapter.pollStockpileTiles("civ-1")).toEqual([]);
+  });
+
+  it("flush clears dirty tracking and pending state", async () => {
+    const adapter = new InMemoryStateAdapter();
+    const ctx = createTestContext();
+    ctx.state.dirtyDwarfIds.add("d1");
+    ctx.state.dirtyItemIds.add("i1");
+    ctx.state.newTasks = [{ id: "t1" } as Task];
+    ctx.state.pendingEvents = [];
+
+    await adapter.flush(ctx);
+
+    expect(ctx.state.dirtyDwarfIds.size).toBe(0);
+    expect(ctx.state.dirtyItemIds.size).toBe(0);
+    expect(ctx.state.newTasks).toHaveLength(0);
+  });
+});

--- a/sim/src/state-adapter.ts
+++ b/sim/src/state-adapter.ts
@@ -1,0 +1,122 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Task, StockpileTile } from "@pwarf/shared";
+import type { CachedState } from "./sim-context.js";
+import { createEmptyCachedState } from "./sim-context.js";
+import { loadStateFromSupabase } from "./load-state.js";
+import type { SimContext } from "./sim-context.js";
+
+/**
+ * Abstracts all persistence operations from the sim.
+ * Swap implementations to run against Supabase or fully in-memory.
+ */
+export interface StateAdapter {
+  /** Load initial world state for a civilization. */
+  loadState(civilizationId: string, worldId: string): Promise<CachedState>;
+
+  /** Get the seed for a world (used to create FortressDeriver). */
+  getWorldSeed(worldId: string): Promise<bigint | null>;
+
+  /** Return any new tasks created externally (player designations) since last poll. */
+  pollNewTasks(civilizationId: string, existingTaskIds: Set<string>): Promise<Task[]>;
+
+  /** Return current stockpile tiles for a civilization. */
+  pollStockpileTiles(civilizationId: string): Promise<StockpileTile[]>;
+
+  /** Persist dirty state accumulated during the tick loop. */
+  flush(ctx: SimContext): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Supabase implementation
+// ---------------------------------------------------------------------------
+
+export class SupabaseStateAdapter implements StateAdapter {
+  constructor(private readonly supabase: SupabaseClient) {}
+
+  async loadState(civilizationId: string, worldId: string): Promise<CachedState> {
+    return loadStateFromSupabase(this.supabase, civilizationId, worldId);
+  }
+
+  async getWorldSeed(worldId: string): Promise<bigint | null> {
+    const { data } = await this.supabase
+      .from('worlds')
+      .select('seed')
+      .eq('id', worldId)
+      .single();
+    return data?.seed != null ? BigInt(data.seed) : null;
+  }
+
+  async pollNewTasks(civilizationId: string, existingTaskIds: Set<string>): Promise<Task[]> {
+    const { data, error } = await this.supabase
+      .from('tasks')
+      .select('*')
+      .eq('civilization_id', civilizationId)
+      .eq('status', 'pending');
+    if (error || !data) return [];
+    return (data as Task[]).filter(t => !existingTaskIds.has(t.id));
+  }
+
+  async pollStockpileTiles(civilizationId: string): Promise<StockpileTile[]> {
+    const { data, error } = await this.supabase
+      .from('stockpile_tiles')
+      .select('*')
+      .eq('civilization_id', civilizationId);
+    if (error || !data) return [];
+    return data as StockpileTile[];
+  }
+
+  async flush(ctx: SimContext): Promise<void> {
+    const { flushToSupabase } = await import('./flush-state.js');
+    await flushToSupabase(ctx);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// In-memory implementation (for tests and headless scenarios)
+// ---------------------------------------------------------------------------
+
+export class InMemoryStateAdapter implements StateAdapter {
+  private initialState: CachedState;
+  /** Queue of tasks to inject on next pollNewTasks call. */
+  private taskQueue: Task[] = [];
+
+  constructor(initialState?: CachedState) {
+    this.initialState = initialState ?? createEmptyCachedState();
+  }
+
+  async loadState(_civilizationId: string, _worldId: string): Promise<CachedState> {
+    return this.initialState;
+  }
+
+  async getWorldSeed(_worldId: string): Promise<bigint | null> {
+    return null;
+  }
+
+  async pollNewTasks(_civilizationId: string, existingTaskIds: Set<string>): Promise<Task[]> {
+    const newTasks = this.taskQueue.filter(t => !existingTaskIds.has(t.id));
+    this.taskQueue = [];
+    return newTasks;
+  }
+
+  async pollStockpileTiles(_civilizationId: string): Promise<StockpileTile[]> {
+    return [];
+  }
+
+  async flush(_ctx: SimContext): Promise<void> {
+    // No-op — state lives in-memory
+    const { state } = _ctx;
+    state.dirtyDwarfIds.clear();
+    state.dirtyItemIds.clear();
+    state.dirtyStructureIds.clear();
+    state.dirtyMonsterIds.clear();
+    state.dirtyTaskIds.clear();
+    state.dirtyFortressTileKeys.clear();
+    state.newTasks = [];
+    state.pendingEvents = [];
+  }
+
+  /** Inject tasks to be returned on the next pollNewTasks call. */
+  queueTasks(tasks: Task[]): void {
+    this.taskQueue.push(...tasks);
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `StateAdapter` interface in `sim/src/state-adapter.ts` abstracting all persistence operations
- `SupabaseStateAdapter` wraps the existing `load-state.ts` / `flush-state.ts` logic
- `InMemoryStateAdapter` holds state in memory with a task queue for scripted player actions; flush is a no-op
- `SimRunner` now takes a `StateAdapter` instead of a raw `SupabaseClient`
- `cli.ts` creates a `SupabaseStateAdapter` from env credentials as before

## Playtest

Infrastructure-only change — no game logic altered. All 462 sim tests pass. Live game behavior unchanged.

## Claude Cost

**Claude cost:** $1.50 (4.1M tokens)