### PR TITLE
fix: add missing stockpile_tiles migration (closes #308)

### DIFF
--- a/supabase/migrations/00012_stockpile_tiles.sql
+++ b/supabase/migrations/00012_stockpile_tiles.sql
@@ -1,0 +1,34 @@
+-- ============================================================
+-- STOCKPILE TILES (issue #308)
+-- Missing migration from PR #279 — table was created directly
+-- in production but never committed to migrations.
+-- ============================================================
+
+create table stockpile_tiles (
+  id              uuid primary key default uuid_generate_v4(),
+  civilization_id uuid not null references civilizations(id) on delete cascade,
+  x               int not null,
+  y               int not null,
+  z               int not null,
+  created_at      timestamptz not null default now(),
+  unique (civilization_id, x, y, z)
+);
+
+create index stockpile_tiles_civ_idx
+  on stockpile_tiles (civilization_id);
+
+-- ============================================================
+-- ROW LEVEL SECURITY
+-- ============================================================
+
+alter table stockpile_tiles enable row level security;
+
+-- Anyone can read stockpile tiles
+create policy "public stockpile_tiles readable"
+  on stockpile_tiles for select using (true);
+
+-- Players can manage stockpile tiles belonging to their own civilizations
+create policy "players manage own stockpile_tiles"
+  on stockpile_tiles for all using (
+    civilization_id in (select id from civilizations where player_id = auth.uid())
+  );


### PR DESCRIPTION
## Summary

- Adds `supabase/migrations/00012_stockpile_tiles.sql` for the `stockpile_tiles` table introduced in #279
- The table was created directly in production but the migration file was never committed, causing the sim to crash on startup in any environment without it
- Without this fix, all dwarves freeze on \"Idle\" immediately after embark

## What broke and why

PR #279 added stockpile zone support but only created the table manually in production — no migration file was committed. This meant local Supabase (and any fresh environment) was missing the table, causing:

```
[sim] failed to start: Error: Failed to load stockpile_tiles: Could not find the table 'public.stockpile_tiles' in the schema cache
```

## Why didn't we catch this sooner?

The PR #279 playtest was run against **production** Supabase where the table already existed. The failing scenario only surfaces on a fresh environment (local Supabase or a new deployment). This is a process gap — see below.

## Process fix needed

This bug reveals two gaps in our process:
1. **Playtests run against production** — they pass even when local migrations are missing. We should add a check that local Supabase tests pass before merging.
2. **No migration checklist** — when adding a new table in code (`load-state.ts`, `useStockpileTiles`, etc.), we need a migration file. Should add this to the PR checklist in CLAUDE.md.

## Playtest

Verified on local Supabase after applying the migration:
- Login ✅
- Generate World ✅  
- Embark ✅
- Dwarves show "Working" status and sim runs ✅ (was frozen on "Idle" before fix)
- No console errors ✅

## Claude Cost

**Claude cost:** $0.72 (1.9M tokens)