### PR TITLE
feat: runScenario — headless in-memory tick runner (closes #281)

### DIFF
--- a/sim/src/index.ts
+++ b/sim/src/index.ts
@@ -4,3 +4,5 @@ export { loadStateFromSupabase } from "./load-state.js";
 export { flushToSupabase } from "./flush-state.js";
 export type { StateAdapter } from "./state-adapter.js";
 export { SupabaseStateAdapter, InMemoryStateAdapter } from "./state-adapter.js";
+export { runScenario } from "./run-scenario.js";
+export type { ScenarioConfig, ScenarioResult } from "./run-scenario.js";

--- a/sim/src/run-scenario.test.ts
+++ b/sim/src/run-scenario.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { runScenario } from "./run-scenario.js";
+import { makeDwarf } from "./__tests__/test-helpers.js";
+import {
+  FOOD_DECAY_PER_TICK,
+  DRINK_DECAY_PER_TICK,
+  NEED_INTERRUPT_FOOD,
+  STEPS_PER_YEAR,
+} from "@pwarf/shared";
+
+describe("runScenario", () => {
+  it("returns correct tick and year counts", async () => {
+    const dwarf = makeDwarf();
+    const result = await runScenario({ dwarves: [dwarf], ticks: 10 });
+    expect(result.ticks).toBe(10);
+    expect(result.year).toBe(1);
+  });
+
+  it("advances year after STEPS_PER_YEAR ticks", async () => {
+    const result = await runScenario({ dwarves: [makeDwarf()], ticks: STEPS_PER_YEAR });
+    expect(result.year).toBe(2);
+  });
+
+  it("need_food decays each tick until eat task fires", async () => {
+    // Start with high needs — food decays at FOOD_DECAY_PER_TICK per tick
+    // It should drop until it hits NEED_INTERRUPT_FOOD, then eat tasks kick in
+    const dwarf = makeDwarf({ need_food: 100, need_drink: 100, need_sleep: 100 });
+    const ticks = Math.ceil((100 - NEED_INTERRUPT_FOOD) / FOOD_DECAY_PER_TICK) - 1;
+    const result = await runScenario({ dwarves: [dwarf], ticks, seed: 1 });
+    // After enough ticks, food should have decayed from 100
+    expect(result.dwarves[0].need_food).toBeLessThan(100);
+    expect(result.dwarves[0].need_food).toBeGreaterThanOrEqual(0);
+  });
+
+  it("dead dwarves are included in the result", async () => {
+    // A dwarf already marked dead should remain dead through the run
+    const dead = makeDwarf({ status: "dead", cause_of_death: "starvation" });
+    const result = await runScenario({ dwarves: [dead], ticks: 5 });
+    expect(result.dwarves).toHaveLength(1);
+    expect(result.dwarves[0].status).toBe("dead");
+  });
+
+  it("runs deterministically with same seed", async () => {
+    const dwarf = makeDwarf();
+    const a = await runScenario({ dwarves: [dwarf], ticks: 100, seed: 42 });
+    const b = await runScenario({ dwarves: [makeDwarf({ ...dwarf })], ticks: 100, seed: 42 });
+    expect(a.dwarves[0].position_x).toBe(b.dwarves[0].position_x);
+    expect(a.dwarves[0].position_y).toBe(b.dwarves[0].position_y);
+    expect(a.dwarves[0].need_food).toBe(b.dwarves[0].need_food);
+    expect(a.dwarves[0].stress_level).toBe(b.dwarves[0].stress_level);
+  });
+
+  it("does not mutate caller's input dwarves", async () => {
+    const dwarf = makeDwarf({ need_food: 100 });
+    const originalFood = dwarf.need_food;
+    await runScenario({ dwarves: [dwarf], ticks: 50, seed: 1 });
+    // Input object should be unchanged after the run
+    expect(dwarf.need_food).toBe(originalFood);
+  });
+
+  it("two different seeds produce different positions after idle wandering", async () => {
+    // Run enough ticks for wander tasks to complete and diverge
+    const makeBase = () => makeDwarf({ position_x: 100, position_y: 100 });
+    const a = await runScenario({ dwarves: [makeBase()], ticks: 200, seed: 1 });
+    const b = await runScenario({ dwarves: [makeBase()], ticks: 200, seed: 99999 });
+    const posA = `${a.dwarves[0].position_x},${a.dwarves[0].position_y}`;
+    const posB = `${b.dwarves[0].position_x},${b.dwarves[0].position_y}`;
+    expect(posA).not.toBe(posB);
+  });
+});

--- a/sim/src/run-scenario.ts
+++ b/sim/src/run-scenario.ts
@@ -1,0 +1,129 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { STEPS_PER_YEAR } from "@pwarf/shared";
+import type { Dwarf, Item, Structure, Monster, Task, WorldEvent } from "@pwarf/shared";
+import type { SimContext, CachedState } from "./sim-context.js";
+import { createEmptyCachedState, createRng } from "./sim-context.js";
+import { DEFAULT_TEST_SEED } from "./rng.js";
+import {
+  needsDecay,
+  taskExecution,
+  needSatisfaction,
+  stressUpdate,
+  tantrumCheck,
+  monsterPathfinding,
+  combatResolution,
+  constructionProgress,
+  jobClaiming,
+  eventFiring,
+  yearlyRollup,
+  idleWandering,
+  thoughtGeneration,
+  haulAssignment,
+} from "./phases/index.js";
+
+/** Input configuration for a scenario run. */
+export interface ScenarioConfig {
+  dwarves?: Dwarf[];
+  items?: Item[];
+  structures?: Structure[];
+  monsters?: Monster[];
+  tasks?: Task[];
+  ticks: number;
+  seed?: number;
+}
+
+/** Full final state returned after a scenario run — suitable for test assertions. */
+export interface ScenarioResult {
+  /** Final state of all dwarves (includes dead dwarves). */
+  dwarves: Dwarf[];
+  /** Final item state. */
+  items: Item[];
+  /** Final structure state. */
+  structures: Structure[];
+  /** All events fired during the run. */
+  events: WorldEvent[];
+  /** All tasks at end of run. */
+  tasks: Task[];
+  /** Total ticks executed. */
+  ticks: number;
+  /** Final in-game year. */
+  year: number;
+}
+
+/**
+ * Run the sim engine in-memory for exactly `ticks` iterations.
+ *
+ * No Supabase, no timers, no browser. Uses seeded RNG for deterministic
+ * results. Suitable for unit tests and scenario assertions.
+ */
+export async function runScenario(config: ScenarioConfig): Promise<ScenarioResult> {
+  const seed = config.seed ?? DEFAULT_TEST_SEED;
+  const state: CachedState = createEmptyCachedState();
+  // Deep-copy all input entities so mutations during the run don't affect the caller's objects
+  state.dwarves = config.dwarves ? config.dwarves.map(d => ({ ...d })) : [];
+  state.items = config.items ? config.items.map(i => ({ ...i })) : [];
+  state.structures = config.structures ? config.structures.map(s => ({ ...s })) : [];
+  state.monsters = config.monsters ? config.monsters.map(m => ({ ...m })) : [];
+  state.tasks = config.tasks ? config.tasks.map(t => ({ ...t })) : [];
+
+  const ctx: SimContext = {
+    supabase: null as unknown as SupabaseClient,
+    civilizationId: "test-civ",
+    worldId: "test-world",
+    fortressDeriver: null,
+    step: 0,
+    year: 1,
+    day: 1,
+    rng: createRng(seed),
+    state,
+  };
+
+  // Accumulate all events fired across the run
+  const allEvents: WorldEvent[] = [];
+  let stepCount = 0;
+  let currentYear = 1;
+  let currentDay = 1;
+
+  for (let i = 0; i < config.ticks; i++) {
+    stepCount++;
+    currentDay++;
+    ctx.step = stepCount;
+    ctx.day = currentDay;
+    ctx.year = currentYear;
+
+    await needsDecay(ctx);
+    await taskExecution(ctx);
+    await needSatisfaction(ctx);
+    await stressUpdate(ctx);
+    await tantrumCheck(ctx);
+    await monsterPathfinding(ctx);
+    await combatResolution(ctx);
+    await constructionProgress(ctx);
+    await idleWandering(ctx);
+    await haulAssignment(ctx);
+    await jobClaiming(ctx);
+    await eventFiring(ctx);
+    await thoughtGeneration(ctx);
+
+    if (stepCount % STEPS_PER_YEAR === 0) {
+      currentYear++;
+      currentDay = 1;
+      ctx.year = currentYear;
+      ctx.day = currentDay;
+      await yearlyRollup(ctx);
+    }
+
+    // Collect events fired this tick (eventFiring clears pendingEvents)
+    allEvents.push(...state.worldEvents.slice(allEvents.length));
+  }
+
+  return {
+    dwarves: state.dwarves,
+    items: state.items,
+    structures: state.structures,
+    events: allEvents,
+    tasks: state.tasks,
+    ticks: stepCount,
+    year: currentYear,
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `sim/src/run-scenario.ts` — `runScenario(config)` runs the full sim loop for N ticks with no Supabase, no timers, and seeded RNG
- Input entities are deep-copied so callers' objects are never mutated between runs
- Exported from `sim/src/index.ts` as `runScenario`, `ScenarioConfig`, `ScenarioResult`
- 7 scenario tests covering: tick/year counts, needs decay, year rollup, dead-dwarf passthrough, determinism, no-mutation guarantee, and seed divergence

## Notes

- Builds on #306 (seeded RNG) and #307 (StateAdapter) — this is the third piece of the headless testing trilogy
- Starvation/dehydration don't trigger in normal sim runs because eat/drink tasks auto-complete (infinite sources); the tests verify needs decay and year advancement instead

## Playtest

This is a backend-only change. Headless runner works as expected:
```
npm test --workspace=sim -- run-scenario
✓ 7 tests passed
```

## Claude Cost

**Claude cost:** $2.98 (8.1M tokens)