### PR TITLE
feat: social/purpose/beauty need restoration

### DIFF
--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -55,6 +55,37 @@ export const PURPOSE_DECAY_PER_TICK = 0.04;
 export const BEAUTY_DECAY_PER_TICK = 0.03;
 
 // ============================================================
+// Social / purpose / beauty need restoration
+// ============================================================
+
+/** How much social need restored per tick per nearby dwarf */
+export const SOCIAL_RESTORE_PER_NEARBY_DWARF = 0.3;
+
+/** Manhattan-distance radius within which dwarves count as "nearby" for social need */
+export const SOCIAL_PROXIMITY_RADIUS = 8;
+
+/** Max number of nearby dwarves that contribute to social restore (diminishing returns beyond this) */
+export const SOCIAL_PROXIMITY_MAX_DWARVES = 3;
+
+/** Purpose restored on completing a skilled work task (mine, build, farm, brew) */
+export const PURPOSE_RESTORE_SKILLED = 15;
+
+/** Purpose restored on completing a hauling task */
+export const PURPOSE_RESTORE_HAUL = 5;
+
+/** Purpose restored on completing any other work task */
+export const PURPOSE_RESTORE_DEFAULT = 8;
+
+/** Baseline beauty restoration per tick (passive, always applies) */
+export const BEAUTY_RESTORE_PASSIVE = 0.02;
+
+/** Bonus beauty restoration per tick when near a well or mushroom garden */
+export const BEAUTY_RESTORE_NEAR_STRUCTURE = 0.15;
+
+/** Manhattan-distance radius for beauty structure proximity */
+export const BEAUTY_STRUCTURE_RADIUS = 6;
+
+// ============================================================
 // Stress severity tiers
 // ============================================================
 

--- a/sim/src/__tests__/needs-restoration.test.ts
+++ b/sim/src/__tests__/needs-restoration.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from "vitest";
+import { restoreSocialNeed } from "../phases/need-satisfaction.js";
+import { restorePurposeNeed } from "../phases/task-completion.js";
+import { makeDwarf, makeContext, makeStructure } from "./test-helpers.js";
+import { beautyRestoration } from "../phases/beauty-restoration.js";
+import {
+  SOCIAL_RESTORE_PER_NEARBY_DWARF,
+  SOCIAL_PROXIMITY_MAX_DWARVES,
+  SOCIAL_PROXIMITY_RADIUS,
+  PURPOSE_RESTORE_SKILLED,
+  PURPOSE_RESTORE_HAUL,
+  BEAUTY_RESTORE_PASSIVE,
+  BEAUTY_RESTORE_NEAR_STRUCTURE,
+  MAX_NEED,
+} from "@pwarf/shared";
+
+// ============================================================
+// Social need restoration
+// ============================================================
+
+describe("restoreSocialNeed", () => {
+  it("does nothing when no other dwarves are nearby", () => {
+    const dwarf = makeDwarf({ need_social: 50, position_x: 0, position_y: 0, position_z: 0 });
+    const far = makeDwarf({ position_x: 100, position_y: 100, position_z: 0 });
+    restoreSocialNeed(dwarf, [dwarf, far]);
+    expect(dwarf.need_social).toBe(50);
+  });
+
+  it("restores social need when a dwarf is nearby", () => {
+    const dwarf = makeDwarf({ need_social: 50, position_x: 0, position_y: 0, position_z: 0 });
+    const neighbor = makeDwarf({ position_x: 3, position_y: 3, position_z: 0 });
+    restoreSocialNeed(dwarf, [dwarf, neighbor]);
+    expect(dwarf.need_social).toBeCloseTo(50 + SOCIAL_RESTORE_PER_NEARBY_DWARF);
+  });
+
+  it("restoration scales with nearby dwarf count up to max", () => {
+    const dwarf = makeDwarf({ need_social: 30, position_x: 0, position_y: 0, position_z: 0 });
+    const neighbors = Array.from({ length: SOCIAL_PROXIMITY_MAX_DWARVES + 2 }, (_, i) =>
+      makeDwarf({ position_x: i, position_y: 0, position_z: 0 }),
+    );
+    restoreSocialNeed(dwarf, [dwarf, ...neighbors]);
+    const expected = 30 + SOCIAL_PROXIMITY_MAX_DWARVES * SOCIAL_RESTORE_PER_NEARBY_DWARF;
+    expect(dwarf.need_social).toBeCloseTo(expected);
+  });
+
+  it("ignores dwarves on different z-levels", () => {
+    const dwarf = makeDwarf({ need_social: 50, position_x: 0, position_y: 0, position_z: 0 });
+    const other = makeDwarf({ position_x: 1, position_y: 1, position_z: -1 });
+    restoreSocialNeed(dwarf, [dwarf, other]);
+    expect(dwarf.need_social).toBe(50);
+  });
+
+  it("ignores dead dwarves", () => {
+    const dwarf = makeDwarf({ need_social: 50, position_x: 0, position_y: 0, position_z: 0 });
+    const dead = makeDwarf({ status: "dead", position_x: 1, position_y: 1, position_z: 0 });
+    restoreSocialNeed(dwarf, [dwarf, dead]);
+    expect(dwarf.need_social).toBe(50);
+  });
+
+  it("ignores dwarves beyond SOCIAL_PROXIMITY_RADIUS", () => {
+    const dwarf = makeDwarf({ need_social: 50, position_x: 0, position_y: 0, position_z: 0 });
+    const far = makeDwarf({ position_x: SOCIAL_PROXIMITY_RADIUS + 1, position_y: 0, position_z: 0 });
+    restoreSocialNeed(dwarf, [dwarf, far]);
+    expect(dwarf.need_social).toBe(50);
+  });
+
+  it("does not exceed MAX_NEED", () => {
+    const dwarf = makeDwarf({ need_social: MAX_NEED, position_x: 0, position_y: 0, position_z: 0 });
+    const neighbors = Array.from({ length: 3 }, () =>
+      makeDwarf({ position_x: 1, position_y: 1, position_z: 0 }),
+    );
+    restoreSocialNeed(dwarf, [dwarf, ...neighbors]);
+    expect(dwarf.need_social).toBe(MAX_NEED);
+  });
+});
+
+// ============================================================
+// Purpose need restoration
+// ============================================================
+
+describe("restorePurposeNeed", () => {
+  it("restores purpose on skilled tasks", () => {
+    const dwarf = makeDwarf({ need_purpose: 50 });
+    restorePurposeNeed(dwarf, "mine");
+    expect(dwarf.need_purpose).toBe(50 + PURPOSE_RESTORE_SKILLED);
+  });
+
+  it("restores less purpose on haul tasks", () => {
+    const dwarf = makeDwarf({ need_purpose: 50 });
+    restorePurposeNeed(dwarf, "haul");
+    expect(dwarf.need_purpose).toBe(50 + PURPOSE_RESTORE_HAUL);
+  });
+
+  it("restores no purpose on autonomous tasks (eat/drink/sleep/wander)", () => {
+    for (const taskType of ["eat", "drink", "sleep", "wander"]) {
+      const dwarf = makeDwarf({ need_purpose: 50 });
+      restorePurposeNeed(dwarf, taskType);
+      expect(dwarf.need_purpose).toBe(50);
+    }
+  });
+
+  it("restores purpose on all skilled task types", () => {
+    const skilled = ["mine", "build_wall", "build_floor", "build_bed", "farm_till", "farm_plant", "farm_harvest"];
+    for (const taskType of skilled) {
+      const dwarf = makeDwarf({ need_purpose: 0 });
+      restorePurposeNeed(dwarf, taskType);
+      expect(dwarf.need_purpose).toBe(PURPOSE_RESTORE_SKILLED);
+    }
+  });
+
+  it("does not exceed MAX_NEED", () => {
+    const dwarf = makeDwarf({ need_purpose: MAX_NEED });
+    restorePurposeNeed(dwarf, "mine");
+    expect(dwarf.need_purpose).toBe(MAX_NEED);
+  });
+});
+
+// ============================================================
+// Beauty need restoration
+// ============================================================
+
+describe("beautyRestoration", () => {
+  it("applies passive restoration every tick to alive dwarves", async () => {
+    const dwarf = makeDwarf({ need_beauty: 50 });
+    const ctx = makeContext({ dwarves: [dwarf] });
+    await beautyRestoration(ctx);
+    expect(ctx.state.dwarves[0].need_beauty).toBeCloseTo(50 + BEAUTY_RESTORE_PASSIVE);
+  });
+
+  it("applies bonus restoration near a completed well", async () => {
+    const dwarf = makeDwarf({ need_beauty: 50, position_x: 10, position_y: 10, position_z: 0 });
+    const well = makeStructure({
+      type: "well",
+      completion_pct: 100,
+      position_x: 12,
+      position_y: 12,
+      position_z: 0,
+    });
+    const ctx = makeContext({ dwarves: [dwarf], structures: [well] });
+    await beautyRestoration(ctx);
+    expect(ctx.state.dwarves[0].need_beauty).toBeCloseTo(50 + BEAUTY_RESTORE_PASSIVE + BEAUTY_RESTORE_NEAR_STRUCTURE);
+  });
+
+  it("no bonus from incomplete structure", async () => {
+    const dwarf = makeDwarf({ need_beauty: 50, position_x: 10, position_y: 10, position_z: 0 });
+    const well = makeStructure({ type: "well", completion_pct: 50, position_x: 10, position_y: 10, position_z: 0 });
+    const ctx = makeContext({ dwarves: [dwarf], structures: [well] });
+    await beautyRestoration(ctx);
+    expect(ctx.state.dwarves[0].need_beauty).toBeCloseTo(50 + BEAUTY_RESTORE_PASSIVE);
+  });
+
+  it("skips dead dwarves", async () => {
+    const dead = makeDwarf({ status: "dead", need_beauty: 50 });
+    const ctx = makeContext({ dwarves: [dead] });
+    await beautyRestoration(ctx);
+    expect(ctx.state.dwarves[0].need_beauty).toBe(50);
+  });
+
+  it("does not exceed MAX_NEED", async () => {
+    const dwarf = makeDwarf({ need_beauty: MAX_NEED });
+    const ctx = makeContext({ dwarves: [dwarf] });
+    await beautyRestoration(ctx);
+    expect(ctx.state.dwarves[0].need_beauty).toBe(MAX_NEED);
+  });
+});

--- a/sim/src/phases/beauty-restoration.ts
+++ b/sim/src/phases/beauty-restoration.ts
@@ -1,0 +1,49 @@
+import {
+  MAX_NEED,
+  BEAUTY_RESTORE_PASSIVE,
+  BEAUTY_RESTORE_NEAR_STRUCTURE,
+  BEAUTY_STRUCTURE_RADIUS,
+} from "@pwarf/shared";
+import type { SimContext } from "../sim-context.js";
+
+/** Structure types that provide beauty bonus */
+const BEAUTY_STRUCTURES = new Set(['well', 'mushroom_garden', 'bed']);
+
+/**
+ * Beauty Restoration Phase
+ *
+ * Every tick, alive dwarves receive:
+ * - A passive baseline restoration (always applies)
+ * - A bonus if near a well, mushroom garden, or similar structure
+ *
+ * Beauty decays slowly (0.03/tick) so even the passive rate provides
+ * meaningful recovery for dwarves who aren't in a barren fortress.
+ */
+export async function beautyRestoration(ctx: SimContext): Promise<void> {
+  const { state } = ctx;
+
+  for (const dwarf of state.dwarves) {
+    if (dwarf.status !== 'alive') continue;
+
+    let restore = BEAUTY_RESTORE_PASSIVE;
+
+    // Check for nearby beauty-providing structures
+    for (const structure of state.structures) {
+      if (!BEAUTY_STRUCTURES.has(structure.type)) continue;
+      if (structure.completion_pct < 100) continue;
+      if (structure.position_x === null || structure.position_y === null || structure.position_z === null) continue;
+      if (structure.position_z !== dwarf.position_z) continue;
+
+      const dist = Math.abs(structure.position_x - dwarf.position_x)
+        + Math.abs(structure.position_y - dwarf.position_y);
+
+      if (dist <= BEAUTY_STRUCTURE_RADIUS) {
+        restore += BEAUTY_RESTORE_NEAR_STRUCTURE;
+        break; // only one bonus per tick regardless of how many structures
+      }
+    }
+
+    dwarf.need_beauty = Math.min(MAX_NEED, dwarf.need_beauty + restore);
+    ctx.state.dirtyDwarfIds.add(dwarf.id);
+  }
+}

--- a/sim/src/phases/index.ts
+++ b/sim/src/phases/index.ts
@@ -14,3 +14,4 @@ export { yearlyRollup } from "./yearly-rollup.js";
 export { idleWandering } from "./idle-wandering.js";
 export { thoughtGeneration } from "./thought-generation.js";
 export { haulAssignment } from "./haul-assignment.js";
+export { beautyRestoration } from "./beauty-restoration.js";

--- a/sim/src/phases/need-satisfaction.ts
+++ b/sim/src/phases/need-satisfaction.ts
@@ -5,6 +5,10 @@ import {
   WORK_EAT,
   WORK_DRINK,
   WORK_SLEEP,
+  MAX_NEED,
+  SOCIAL_RESTORE_PER_NEARBY_DWARF,
+  SOCIAL_PROXIMITY_RADIUS,
+  SOCIAL_PROXIMITY_MAX_DWARVES,
 } from "@pwarf/shared";
 import type { Dwarf, TaskType, Structure } from "@pwarf/shared";
 import type { SimContext } from "../sim-context.js";
@@ -40,6 +44,9 @@ export async function needSatisfaction(ctx: SimContext): Promise<void> {
     if (dwarf.need_sleep < NEED_INTERRUPT_SLEEP) {
       maybeInterruptForNeed(dwarf, 'sleep', ctx);
     }
+
+    // Social: restore need based on proximity to other alive dwarves
+    restoreSocialNeed(dwarf, state.dwarves);
   }
 }
 
@@ -150,4 +157,28 @@ function maybeInterruptForNeed(dwarf: Dwarf, taskType: TaskType, ctx: SimContext
     work_required: workRequired,
     assigned_dwarf_id: dwarf.id,
   });
+}
+
+/**
+ * Restores social need based on how many other alive dwarves are nearby.
+ * Counts up to SOCIAL_PROXIMITY_MAX_DWARVES for diminishing returns.
+ * Exported for unit testing.
+ */
+export function restoreSocialNeed(dwarf: Dwarf, allDwarves: Dwarf[]): void {
+  let nearbyCount = 0;
+  for (const other of allDwarves) {
+    if (other.id === dwarf.id) continue;
+    if (other.status !== 'alive') continue;
+    if (other.position_z !== dwarf.position_z) continue;
+    const dist = Math.abs(other.position_x - dwarf.position_x) + Math.abs(other.position_y - dwarf.position_y);
+    if (dist <= SOCIAL_PROXIMITY_RADIUS) {
+      nearbyCount++;
+    }
+  }
+
+  if (nearbyCount === 0) return;
+
+  const effectiveCount = Math.min(nearbyCount, SOCIAL_PROXIMITY_MAX_DWARVES);
+  const restore = effectiveCount * SOCIAL_RESTORE_PER_NEARBY_DWARF;
+  dwarf.need_social = Math.min(MAX_NEED, dwarf.need_social + restore);
 }

--- a/sim/src/phases/task-completion.ts
+++ b/sim/src/phases/task-completion.ts
@@ -9,6 +9,9 @@ import {
   XP_FARM_HARVEST,
   XP_BUILD,
   XP_HAUL,
+  PURPOSE_RESTORE_SKILLED,
+  PURPOSE_RESTORE_HAUL,
+  PURPOSE_RESTORE_DEFAULT,
 } from "@pwarf/shared";
 import type { Dwarf, FortressTile, FortressTileType, Task, Item, Structure } from "@pwarf/shared";
 import type { SimContext } from "../sim-context.js";
@@ -94,6 +97,29 @@ export function completeTask(dwarf: Dwarf, task: Task, ctx: SimContext): void {
       completeBuildBed(task, ctx);
       awardXp(dwarf.id, 'building', XP_BUILD, state);
       break;
+  }
+
+  // Purpose restoration: work gives dwarves a sense of meaning
+  restorePurposeNeed(dwarf, task.task_type);
+}
+
+/**
+ * Restores purpose need on task completion.
+ * Skilled tasks restore more than hauling or wander.
+ * Exported for unit testing.
+ */
+export function restorePurposeNeed(dwarf: Dwarf, taskType: string): void {
+  const SKILLED_TASKS = new Set(['mine', 'build_wall', 'build_floor', 'build_bed', 'farm_till', 'farm_plant', 'farm_harvest']);
+  const restore = SKILLED_TASKS.has(taskType)
+    ? PURPOSE_RESTORE_SKILLED
+    : taskType === 'haul'
+      ? PURPOSE_RESTORE_HAUL
+      : taskType === 'eat' || taskType === 'drink' || taskType === 'sleep' || taskType === 'wander'
+        ? 0  // autonomous tasks don't restore purpose
+        : PURPOSE_RESTORE_DEFAULT;
+
+  if (restore > 0) {
+    dwarf.need_purpose = Math.min(MAX_NEED, dwarf.need_purpose + restore);
   }
 }
 

--- a/sim/src/run-scenario.ts
+++ b/sim/src/run-scenario.ts
@@ -19,6 +19,7 @@ import {
   idleWandering,
   thoughtGeneration,
   haulAssignment,
+  beautyRestoration,
 } from "./phases/index.js";
 
 /** Input configuration for a scenario run. */
@@ -104,6 +105,7 @@ export async function runScenario(config: ScenarioConfig): Promise<ScenarioResul
     await jobClaiming(ctx);
     await eventFiring(ctx);
     await thoughtGeneration(ctx);
+    await beautyRestoration(ctx);
 
     if (stepCount % STEPS_PER_YEAR === 0) {
       currentYear++;

--- a/sim/src/sim-runner.ts
+++ b/sim/src/sim-runner.ts
@@ -19,6 +19,7 @@ import {
   idleWandering,
   thoughtGeneration,
   haulAssignment,
+  beautyRestoration,
 } from "./phases/index.js";
 
 /** Snapshot of sim state emitted after every tick for live UI rendering. */
@@ -156,6 +157,7 @@ export class SimRunner {
     await jobClaiming(this.ctx);
     await eventFiring(this.ctx);
     await thoughtGeneration(this.ctx);
+    await beautyRestoration(this.ctx);
 
     if (this.stepCount % STEPS_PER_YEAR === 0) {
       this.currentYear++;


### PR DESCRIPTION
Implements issues #289, #290, #291 — need restoration for social, purpose, and beauty.

## Changes

### Social need (`restoreSocialNeed`)
- Scans nearby dwarves within `SOCIAL_PROXIMITY_RADIUS = 8` tiles (same z-level, alive only)
- Restores `SOCIAL_RESTORE_PER_NEARBY_DWARF = 0.3` per nearby dwarf
- Caps at `SOCIAL_PROXIMITY_MAX_DWARVES = 3` dwarves (max +0.9/tick)
- Capped at `MAX_NEED = 100`

### Purpose need (`restorePurposeNeed`)
- Called at end of `completeTask()`
- Skilled tasks (mine, build_*, farm_*): `PURPOSE_RESTORE_SKILLED = 15`
- Haul tasks: `PURPOSE_RESTORE_HAUL = 5`
- Autonomous tasks (eat/drink/sleep/wander): 0

### Beauty need (`beautyRestoration`)
- New sim phase, called every tick after `thoughtGeneration`
- Passive baseline: `BEAUTY_RESTORE_PASSIVE = 0.02/tick`
- Bonus near completed well/mushroom_garden/bed within `BEAUTY_STRUCTURE_RADIUS = 6`: `+BEAUTY_RESTORE_NEAR_STRUCTURE = 0.15`
- Bonus caps at one structure per tick

## Tests

17 unit tests in `needs-restoration.test.ts` covering:
- No nearby dwarves → no social restoration
- Proximity radius boundary
- Z-level isolation
- Dead dwarf exclusion
- MAX_NEED cap
- All skilled task types
- Incomplete structure no-op
- Beauty passive baseline

## Verification

This is a sim logic change — verified with `runScenario()` scenario tests + `npm test`. No UI changes.

```
Test Files: 21 passed (21)
Tests:      258 passed (258)
```

## Claude Cost

**Claude cost:** $0.09 (253k tokens)