### PR TITLE
feat: mining and building task scenario tests

### DIFF
--- a/sim/src/__tests__/task-scenarios.test.ts
+++ b/sim/src/__tests__/task-scenarios.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect } from "vitest";
+import { runScenario } from "../run-scenario.js";
+import { makeDwarf, makeTask } from "./test-helpers.js";
+import {
+  WORK_MINE_BASE,
+  WORK_BUILD_WALL,
+  WORK_BUILD_FLOOR,
+  WORK_BUILD_BED,
+} from "@pwarf/shared";
+
+// ============================================================
+// Mining scenarios
+// ============================================================
+
+describe("mine task scenario", () => {
+  it("completes and produces a stone block item", async () => {
+    // Dwarf at (1,5) is adjacent to target (2,5)
+    const dwarf = makeDwarf({ position_x: 1, position_y: 5, position_z: 0 });
+    const task = makeTask("mine", {
+      assigned_dwarf_id: dwarf.id,
+      target_x: 2,
+      target_y: 5,
+      target_z: 0,
+      work_required: WORK_MINE_BASE,
+    });
+    dwarf.current_task_id = task.id;
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      tasks: [task],
+      ticks: WORK_MINE_BASE + 5,
+    });
+
+    const completedTask = result.tasks.find(t => t.id === task.id);
+    expect(completedTask?.status).toBe("completed");
+
+    const stoneBlock = result.items.find(i => i.material === "stone");
+    expect(stoneBlock).toBeDefined();
+    expect(stoneBlock?.name).toBe("Stone block");
+  });
+
+  it("marks the target tile as mined", async () => {
+    const dwarf = makeDwarf({ position_x: 1, position_y: 5, position_z: 0 });
+    const task = makeTask("mine", {
+      assigned_dwarf_id: dwarf.id,
+      target_x: 2,
+      target_y: 5,
+      target_z: 0,
+      work_required: WORK_MINE_BASE,
+    });
+    dwarf.current_task_id = task.id;
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      tasks: [task],
+      ticks: WORK_MINE_BASE + 5,
+    });
+
+    const minedTile = result.fortressTileOverrides.find(
+      t => t.x === 2 && t.y === 5 && t.z === 0,
+    );
+    expect(minedTile?.is_mined).toBe(true);
+    // Surface tiles (z=0) become grass; underground (z<0) become open_air
+    expect(minedTile?.tile_type).toBe("grass");
+  });
+
+  it("dwarf moves to adjacent position before mining", async () => {
+    // Dwarf starts 5 tiles away; pathfinding should move it to (1,5,0)
+    const dwarf = makeDwarf({ position_x: 0, position_y: 0, position_z: 0 });
+    const task = makeTask("mine", {
+      assigned_dwarf_id: dwarf.id,
+      target_x: 2,
+      target_y: 5,
+      target_z: 0,
+      work_required: WORK_MINE_BASE,
+    });
+    dwarf.current_task_id = task.id;
+
+    // Extra ticks for travel (7 tiles manhattan) + work
+    const result = await runScenario({
+      dwarves: [dwarf],
+      tasks: [task],
+      ticks: WORK_MINE_BASE + 20,
+    });
+
+    const completedTask = result.tasks.find(t => t.id === task.id);
+    expect(completedTask?.status).toBe("completed");
+  });
+});
+
+// ============================================================
+// Build wall scenarios
+// ============================================================
+
+describe("build_wall task scenario", () => {
+  it("completes and creates a constructed_wall tile", async () => {
+    const dwarf = makeDwarf({ position_x: 1, position_y: 5, position_z: 0 });
+    const task = makeTask("build_wall", {
+      assigned_dwarf_id: dwarf.id,
+      target_x: 2,
+      target_y: 5,
+      target_z: 0,
+      work_required: WORK_BUILD_WALL,
+    });
+    dwarf.current_task_id = task.id;
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      tasks: [task],
+      ticks: WORK_BUILD_WALL + 5,
+    });
+
+    const completedTask = result.tasks.find(t => t.id === task.id);
+    expect(completedTask?.status).toBe("completed");
+
+    const wallTile = result.fortressTileOverrides.find(
+      t => t.x === 2 && t.y === 5 && t.z === 0,
+    );
+    expect(wallTile?.tile_type).toBe("constructed_wall");
+  });
+});
+
+// ============================================================
+// Build floor scenarios
+// ============================================================
+
+describe("build_floor task scenario", () => {
+  it("completes and creates a constructed_floor tile", async () => {
+    const dwarf = makeDwarf({ position_x: 5, position_y: 5, position_z: 0 });
+    const task = makeTask("build_floor", {
+      assigned_dwarf_id: dwarf.id,
+      target_x: 5,
+      target_y: 5,
+      target_z: 0,
+      work_required: WORK_BUILD_FLOOR,
+    });
+    dwarf.current_task_id = task.id;
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      tasks: [task],
+      ticks: WORK_BUILD_FLOOR + 5,
+    });
+
+    const completedTask = result.tasks.find(t => t.id === task.id);
+    expect(completedTask?.status).toBe("completed");
+
+    const floorTile = result.fortressTileOverrides.find(
+      t => t.x === 5 && t.y === 5 && t.z === 0,
+    );
+    expect(floorTile?.tile_type).toBe("constructed_floor");
+  });
+});
+
+// ============================================================
+// Build bed scenarios
+// ============================================================
+
+describe("build_bed task scenario", () => {
+  it("completes and adds a bed structure", async () => {
+    const dwarf = makeDwarf({ position_x: 5, position_y: 5, position_z: 0 });
+    const task = makeTask("build_bed", {
+      assigned_dwarf_id: dwarf.id,
+      target_x: 5,
+      target_y: 5,
+      target_z: 0,
+      work_required: WORK_BUILD_BED,
+    });
+    dwarf.current_task_id = task.id;
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      tasks: [task],
+      ticks: WORK_BUILD_BED + 5,
+    });
+
+    const completedTask = result.tasks.find(t => t.id === task.id);
+    expect(completedTask?.status).toBe("completed");
+
+    const bed = result.structures.find(
+      s => s.type === "bed" && s.position_x === 5 && s.position_y === 5,
+    );
+    expect(bed).toBeDefined();
+    expect(bed?.completion_pct).toBe(100);
+  });
+
+  it("bed tile is marked in fortress overrides", async () => {
+    const dwarf = makeDwarf({ position_x: 5, position_y: 5, position_z: 0 });
+    const task = makeTask("build_bed", {
+      assigned_dwarf_id: dwarf.id,
+      target_x: 5,
+      target_y: 5,
+      target_z: 0,
+      work_required: WORK_BUILD_BED,
+    });
+    dwarf.current_task_id = task.id;
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      tasks: [task],
+      ticks: WORK_BUILD_BED + 5,
+    });
+
+    const bedTile = result.fortressTileOverrides.find(
+      t => t.x === 5 && t.y === 5 && t.z === 0,
+    );
+    expect(bedTile?.tile_type).toBe("bed");
+  });
+});

--- a/sim/src/__tests__/test-helpers.ts
+++ b/sim/src/__tests__/test-helpers.ts
@@ -1,4 +1,4 @@
-import type { Dwarf, DwarfSkill, Task, Item, Structure } from "@pwarf/shared";
+import type { Dwarf, DwarfSkill, Task, TaskType, Item, Structure } from "@pwarf/shared";
 import type { SimContext } from "../sim-context.js";
 import { createTestContext } from "../sim-context.js";
 import { createRng, DEFAULT_TEST_SEED } from "../rng.js";
@@ -78,6 +78,26 @@ export function makeItem(overrides?: Partial<Item>): Item {
     lore: null,
     properties: {},
     created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+export function makeTask(task_type: TaskType, overrides?: Partial<Task>): Task {
+  return {
+    id: _factoryRng.uuid(),
+    civilization_id: "civ-1",
+    task_type,
+    status: "claimed",
+    priority: 5,
+    assigned_dwarf_id: null,
+    target_x: null,
+    target_y: null,
+    target_z: null,
+    target_item_id: null,
+    work_progress: 0,
+    work_required: 100,
+    created_at: new Date().toISOString(),
+    completed_at: null,
     ...overrides,
   };
 }

--- a/sim/src/run-scenario.ts
+++ b/sim/src/run-scenario.ts
@@ -1,6 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { STEPS_PER_YEAR } from "@pwarf/shared";
-import type { Dwarf, Item, Structure, Monster, Task, WorldEvent } from "@pwarf/shared";
+import type { Dwarf, FortressTile, Item, Structure, Monster, Task, WorldEvent } from "@pwarf/shared";
 import type { SimContext, CachedState } from "./sim-context.js";
 import { createEmptyCachedState, createRng } from "./sim-context.js";
 import { DEFAULT_TEST_SEED } from "./rng.js";
@@ -49,6 +49,8 @@ export interface ScenarioResult {
   ticks: number;
   /** Final in-game year. */
   year: number;
+  /** All fortress tile overrides (mined/built tiles) at end of run. */
+  fortressTileOverrides: FortressTile[];
 }
 
 /**
@@ -127,5 +129,6 @@ export async function runScenario(config: ScenarioConfig): Promise<ScenarioResul
     tasks: state.tasks,
     ticks: stepCount,
     year: currentYear,
+    fortressTileOverrides: [...state.fortressTileOverrides.values()],
   };
 }


### PR DESCRIPTION
Adds end-to-end scenario tests for the two most fundamental dwarf activities: mining and building. Closes #312.

## Changes

### `makeTask()` factory (test-helpers.ts)
Shared test helper for constructing Task objects with sensible defaults. Follows the same pattern as `makeDwarf`, `makeItem`, etc.

### `ScenarioResult.fortressTileOverrides` (run-scenario.ts)
Exposes the fortress tile override map as an array in ScenarioResult so tests can assert on tile state after mining/building.

### Scenario tests (task-scenarios.test.ts)
7 scenario tests using `runScenario()`:

| Scenario | Assertions |
|---|---|
| Mine (adjacent) | task completes, stone block item created |
| Mine (tile state) | tile marked `is_mined=true`, type=`grass` at z=0 |
| Mine (with travel) | dwarf walks from far away, still completes |
| Build wall | tile becomes `constructed_wall` |
| Build floor | tile becomes `constructed_floor` |
| Build bed (structure) | bed structure added with `completion_pct=100` |
| Build bed (tile) | fortress tile type becomes `bed` |

## Verification

Sim logic change — verified with `runScenario()` scenario tests.

```
Test Files: 22 passed (22)
Tests:      265 passed (265)
```

## Claude Cost

**Claude cost:** $0.08 (227k tokens)