### PR TITLE
feat: custom map fixtures for test scenarios

### DIFF
--- a/sim/src/__tests__/map-fixtures.test.ts
+++ b/sim/src/__tests__/map-fixtures.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { runScenario } from "../run-scenario.js";
+import { makeDwarf, makeTask, makeMapTile } from "./test-helpers.js";
+import { WORK_MINE_BASE } from "@pwarf/shared";
+
+/**
+ * Tests for custom map fixture support via ScenarioConfig.fortressTileOverrides.
+ *
+ * Without fixtures, all tiles default to open_air (no deriver). Fixtures let
+ * scenario tests control exactly what tile type is at a given position.
+ */
+
+describe("map fixture: rock tile", () => {
+  it("mining a rock tile produces a stone block", async () => {
+    const dwarf = makeDwarf({ position_x: 1, position_y: 0, position_z: -1 });
+    const task = makeTask("mine", {
+      assigned_dwarf_id: dwarf.id,
+      target_x: 2,
+      target_y: 0,
+      target_z: -1,
+      work_required: WORK_MINE_BASE,
+    });
+    dwarf.current_task_id = task.id;
+
+    const rockTile = makeMapTile(2, 0, -1, "rock");
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      tasks: [task],
+      fortressTileOverrides: [rockTile],
+      ticks: WORK_MINE_BASE + 5,
+    });
+
+    const stone = result.items.find(i => i.name === "Stone block" && i.material === "stone");
+    expect(stone).toBeDefined();
+
+    const minedTile = result.fortressTileOverrides.find(t => t.x === 2 && t.y === 0 && t.z === -1);
+    expect(minedTile?.is_mined).toBe(true);
+    // Underground tiles become open_air after mining
+    expect(minedTile?.tile_type).toBe("open_air");
+  });
+});
+
+describe("map fixture: tree tile", () => {
+  it("mining a tree tile produces a wood log", async () => {
+    const dwarf = makeDwarf({ position_x: 1, position_y: 0, position_z: 0 });
+    const task = makeTask("mine", {
+      assigned_dwarf_id: dwarf.id,
+      target_x: 2,
+      target_y: 0,
+      target_z: 0,
+      work_required: WORK_MINE_BASE,
+    });
+    dwarf.current_task_id = task.id;
+
+    const treeTile = makeMapTile(2, 0, 0, "tree");
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      tasks: [task],
+      fortressTileOverrides: [treeTile],
+      ticks: WORK_MINE_BASE + 5,
+    });
+
+    const log = result.items.find(i => i.name === "Wood log" && i.material === "wood");
+    expect(log).toBeDefined();
+  });
+});
+
+describe("map fixture: multiple tiles", () => {
+  it("tile overrides are applied at scenario start", async () => {
+    // Place a wall tile, run for 1 tick, verify it's still there
+    const rockTile = makeMapTile(5, 5, 0, "rock");
+    const grassTile = makeMapTile(3, 3, 0, "grass");
+
+    const result = await runScenario({
+      dwarves: [],
+      fortressTileOverrides: [rockTile, grassTile],
+      ticks: 1,
+    });
+
+    const rock = result.fortressTileOverrides.find(t => t.x === 5 && t.y === 5);
+    expect(rock?.tile_type).toBe("rock");
+
+    const grass = result.fortressTileOverrides.find(t => t.x === 3 && t.y === 3);
+    expect(grass?.tile_type).toBe("grass");
+  });
+});

--- a/sim/src/__tests__/test-helpers.ts
+++ b/sim/src/__tests__/test-helpers.ts
@@ -1,4 +1,4 @@
-import type { Dwarf, DwarfSkill, Task, TaskType, Item, Structure } from "@pwarf/shared";
+import type { Dwarf, DwarfSkill, FortressTile, FortressTileType, Task, TaskType, Item, Structure } from "@pwarf/shared";
 import type { SimContext } from "../sim-context.js";
 import { createTestContext } from "../sim-context.js";
 import { createRng, DEFAULT_TEST_SEED } from "../rng.js";
@@ -98,6 +98,33 @@ export function makeTask(task_type: TaskType, overrides?: Partial<Task>): Task {
     work_required: 100,
     created_at: new Date().toISOString(),
     completed_at: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Create a fortress tile override for use in ScenarioConfig.fortressTileOverrides.
+ * Useful for controlling tile types in scenario tests — e.g. placing a 'rock' tile
+ * so a mine task produces a stone block, or placing 'tree' to produce wood.
+ */
+export function makeMapTile(
+  x: number,
+  y: number,
+  z: number,
+  tileType: FortressTileType,
+  overrides?: Partial<FortressTile>,
+): FortressTile {
+  return {
+    id: _factoryRng.uuid(),
+    civilization_id: "civ-1",
+    x,
+    y,
+    z,
+    tile_type: tileType,
+    material: null,
+    is_revealed: true,
+    is_mined: false,
+    created_at: new Date().toISOString(),
     ...overrides,
   };
 }

--- a/sim/src/run-scenario.ts
+++ b/sim/src/run-scenario.ts
@@ -29,6 +29,8 @@ export interface ScenarioConfig {
   structures?: Structure[];
   monsters?: Monster[];
   tasks?: Task[];
+  /** Pre-placed fortress tiles — bypasses the fortress deriver for controlled map fixtures. */
+  fortressTileOverrides?: FortressTile[];
   ticks: number;
   seed?: number;
 }
@@ -68,6 +70,11 @@ export async function runScenario(config: ScenarioConfig): Promise<ScenarioResul
   state.structures = config.structures ? config.structures.map(s => ({ ...s })) : [];
   state.monsters = config.monsters ? config.monsters.map(m => ({ ...m })) : [];
   state.tasks = config.tasks ? config.tasks.map(t => ({ ...t })) : [];
+  if (config.fortressTileOverrides) {
+    for (const tile of config.fortressTileOverrides) {
+      state.fortressTileOverrides.set(`${tile.x},${tile.y},${tile.z}`, { ...tile });
+    }
+  }
 
   const ctx: SimContext = {
     supabase: null as unknown as SupabaseClient,


### PR DESCRIPTION
Adds custom map fixture support to the headless test runner. Closes #283.

## Changes

### `makeMapTile()` factory (test-helpers.ts)
Creates a `FortressTile` at a specific position with a specific tile type. Plugs into `ScenarioConfig.fortressTileOverrides` to override what tile the fortress deriver would generate.

### `ScenarioConfig.fortressTileOverrides` (run-scenario.ts)
Optional array of `FortressTile` objects loaded into `state.fortressTileOverrides` at scenario start. The tile-lookup falls back to these before calling the deriver, so tests can control what tile type is at any position.

### Scenario tests (map-fixtures.test.ts)
3 tests demonstrating fixture use cases:

| Scenario | Assertion |
|---|---|
| Rock tile at mine target (z=-1) | Mine produces stone block, tile becomes open_air |
| Tree tile at mine target (z=0) | Mine produces wood log |
| Multiple tiles | Fixtures survive untouched ticks |

## Verification

```
Test Files: 23 passed (23)
Tests:      268 passed (268)
```

## Claude Cost

**Claude cost:** $0.09 (251k tokens)