### PR TITLE
feat: embed live sim stats in hourly digest

### DIFF
--- a/.github/scripts/hourly-digest.mjs
+++ b/.github/scripts/hourly-digest.mjs
@@ -9,7 +9,7 @@
  *   GITHUB_REPOSITORY — "owner/repo" (set automatically by Actions)
  */
 
-import { execSync } from 'node:child_process';
+import { execSync, spawnSync } from 'node:child_process';
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -178,6 +178,51 @@ function commitAndPush(postId) {
   git('git push');
 }
 
+// ── Sim snapshot ───────────────────────────────────────────────────────────
+
+/**
+ * Run the baseline sim scenario and return a stats object.
+ * Returns null on failure so a broken sim doesn't block the digest.
+ */
+function runSimSnapshot() {
+  try {
+    const snapshotScript = join(REPO_ROOT, 'scripts', 'sim-snapshot.mjs');
+    const result = spawnSync(process.execPath, [snapshotScript], {
+      encoding: 'utf8',
+      timeout: 30_000,
+    });
+    if (result.status !== 0) {
+      console.warn('[sim-snapshot] failed:', result.stderr?.trim());
+      return null;
+    }
+    return JSON.parse(result.stdout.trim());
+  } catch (err) {
+    console.warn('[sim-snapshot] error:', err.message);
+    return null;
+  }
+}
+
+/** Format sim stats as a markdown section for the blog post. */
+function formatSimStats(stats) {
+  if (!stats) return '';
+
+  const deathLines = stats.deaths.length === 0
+    ? '  - No deaths'
+    : stats.deaths.map(d => `  - ${d.name}: ${d.cause}`).join('\n');
+
+  return [
+    '## Sim Health Check',
+    '',
+    `Baseline scenario: 3 dwarves, ${stats.ticks} ticks (${stats.days} days)`,
+    '',
+    `- **Dwarves alive:** ${stats.dwarves_alive} / ${stats.dwarves_total}`,
+    `- **Tasks completed:** ${stats.tasks_completed}`,
+    `- **Avg stress:** ${stats.avg_stress}`,
+    `- **Deaths:**`,
+    deathLines,
+  ].join('\n');
+}
+
 // ── Main ───────────────────────────────────────────────────────────────────
 
 async function main() {
@@ -198,6 +243,10 @@ async function main() {
     }),
   );
 
+  console.log('Running sim health check…');
+  const simStats = runSimSnapshot();
+  const simStatsMarkdown = formatSimStats(simStats);
+
   console.log('Summarizing with GitHub Models (gpt-4o-mini)…');
   const summary = await summarize(prData);
 
@@ -208,7 +257,8 @@ async function main() {
     id,
     timestamp: now.toISOString(),
     title: `Digest — ${now.toLocaleString('en-US', { month: 'short', day: 'numeric', year: 'numeric', hour: '2-digit', minute: '2-digit', timeZone: 'UTC', timeZoneName: 'short' })}`,
-    summary,
+    summary: simStatsMarkdown ? `${summary}\n\n${simStatsMarkdown}` : summary,
+    simStats: simStats ?? undefined,
     prs: prData.map(({ pr }) => ({
       number: pr.number,
       title: pr.title,

--- a/.github/workflows/hourly-digest.yml
+++ b/.github/workflows/hourly-digest.yml
@@ -28,6 +28,12 @@ jobs:
         with:
           node-version: 20
 
+      - name: Install dependencies and build sim
+        run: |
+          npm ci
+          npm run build --workspace=shared
+          npm run build --workspace=sim
+
       - name: Generate and commit digest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/sim-snapshot.mjs
+++ b/scripts/sim-snapshot.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * Runs a short baseline sim scenario and prints JSON stats to stdout.
+ * Used by the hourly digest to embed a "fortress health check" in each post.
+ *
+ * Outputs JSON:
+ * {
+ *   "ticks": 500,
+ *   "days": 10,
+ *   "dwarves_alive": 3,
+ *   "dwarves_total": 3,
+ *   "deaths": [],
+ *   "avg_stress": 0.0,
+ *   "tasks_completed": 12
+ * }
+ */
+
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..');
+
+// Import the pre-built packages (requires npm run build first)
+const { runScenario } = await import(`file://${REPO_ROOT}/sim/dist/index.js`);
+const { STEPS_PER_DAY } = await import(`file://${REPO_ROOT}/shared/dist/index.js`);
+
+const TICKS = 500;
+const SEED = 47891; // fixed seed for reproducible baseline
+
+function makeBaseDwarf(name, id) {
+  return {
+    id,
+    civilization_id: 'baseline',
+    name,
+    surname: 'McFortress',
+    status: 'alive',
+    age: 25,
+    gender: 'male',
+    need_food: 90,
+    need_drink: 90,
+    need_sleep: 80,
+    need_social: 60,
+    need_purpose: 50,
+    need_beauty: 50,
+    stress_level: 0,
+    is_in_tantrum: false,
+    health: 100,
+    injuries: [],
+    memories: [],
+    trait_openness: null,
+    trait_conscientiousness: null,
+    trait_extraversion: null,
+    trait_agreeableness: null,
+    trait_neuroticism: null,
+    religious_devotion: 0,
+    faction_id: null,
+    born_year: null,
+    died_year: null,
+    cause_of_death: null,
+    current_task_id: null,
+    position_x: 5,
+    position_y: 5,
+    position_z: 0,
+    created_at: new Date().toISOString(),
+  };
+}
+
+const dwarves = [
+  makeBaseDwarf('Urist', 'd1'),
+  makeBaseDwarf('Bomrek', 'd2'),
+  makeBaseDwarf('Meng', 'd3'),
+];
+
+const result = await runScenario({ dwarves, ticks: TICKS, seed: SEED });
+
+const alive = result.dwarves.filter(d => d.status === 'alive');
+const dead = result.dwarves.filter(d => d.status !== 'alive');
+const avgStress = alive.length > 0
+  ? alive.reduce((sum, d) => sum + d.stress_level, 0) / alive.length
+  : 0;
+
+const completedTasks = result.tasks.filter(t => t.status === 'completed').length;
+
+const stats = {
+  ticks: result.ticks,
+  days: Math.floor(result.ticks / STEPS_PER_DAY),
+  dwarves_alive: alive.length,
+  dwarves_total: result.dwarves.length,
+  deaths: dead.map(d => ({ name: d.name, cause: d.cause_of_death ?? 'unknown' })),
+  avg_stress: Math.round(avgStress * 10) / 10,
+  tasks_completed: completedTasks,
+};
+
+process.stdout.write(JSON.stringify(stats) + '\n');


### PR DESCRIPTION
Adds a fortress health check to every hourly digest post. Closes #305.

## What this does

Every digest now runs a quick headless sim (500 ticks = ~10 in-game days) and appends a `## Sim Health Check` section to the post:

```markdown
## Sim Health Check

Baseline scenario: 3 dwarves, 500 ticks (10 days)

- **Dwarves alive:** 3 / 3
- **Tasks completed:** 174
- **Avg stress:** 0
- **Deaths:**
  - No deaths
```

If the snapshot fails (e.g. broken build), it logs a warning and the digest continues without the stats section — never blocks the digest.

## Changes

### `scripts/sim-snapshot.mjs` (new)
Standalone Node.js script that imports the pre-built sim, runs a reproducible baseline scenario, and prints JSON stats to stdout.

```json
{"ticks":500,"days":10,"dwarves_alive":3,"dwarves_total":3,"deaths":[],"avg_stress":0,"tasks_completed":174}
```

### `.github/scripts/hourly-digest.mjs`
- Calls `sim-snapshot.mjs` via `spawnSync`
- Formats stats as markdown and appends to `post.summary`
- Also stores raw `simStats` object in the post JSON for future frontend use

### `.github/workflows/hourly-digest.yml`
- Adds `npm ci` + `npm run build` steps so `sim/dist/` exists when the digest runs

## Verification

- `node scripts/sim-snapshot.mjs` outputs valid JSON ✓
- `npm test` passes (268 tests) ✓

## Claude Cost

**Claude cost:** $1.22 (3.3M tokens, multi-ticket session)