### PR TITLE
fix: apply material hardness to mine task work rate

### DIFF
--- a/sim/src/__tests__/mine-hardness.test.ts
+++ b/sim/src/__tests__/mine-hardness.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { getTileHardness } from "../phases/task-execution.js";
+import { runScenario } from "../run-scenario.js";
+import { makeDwarf, makeTask, makeMapTile } from "./test-helpers.js";
+import {
+  HARDNESS_SOIL,
+  HARDNESS_STONE,
+  HARDNESS_ORE,
+  HARDNESS_GEM,
+  HARDNESS_IGNITE,
+  WORK_MINE_BASE,
+} from "@pwarf/shared";
+
+// ============================================================
+// getTileHardness unit tests
+// ============================================================
+
+describe("getTileHardness", () => {
+  it("soil has low hardness (fast to mine)", () => {
+    expect(getTileHardness("soil")).toBe(HARDNESS_SOIL);
+  });
+
+  it("rock/default has standard hardness", () => {
+    expect(getTileHardness("rock")).toBe(HARDNESS_STONE);
+    expect(getTileHardness("stone")).toBe(HARDNESS_STONE);
+    expect(getTileHardness(null)).toBe(HARDNESS_STONE);
+    expect(getTileHardness("open_air")).toBe(HARDNESS_STONE);
+  });
+
+  it("ore is harder than stone", () => {
+    expect(getTileHardness("ore")).toBe(HARDNESS_ORE);
+    expect(HARDNESS_ORE).toBeGreaterThan(HARDNESS_STONE);
+  });
+
+  it("gem is harder than ore", () => {
+    expect(getTileHardness("gem")).toBe(HARDNESS_GEM);
+    expect(HARDNESS_GEM).toBeGreaterThan(HARDNESS_ORE);
+  });
+
+  it("lava_stone and cavern_wall have highest hardness", () => {
+    expect(getTileHardness("lava_stone")).toBe(HARDNESS_IGNITE);
+    expect(getTileHardness("cavern_wall")).toBe(HARDNESS_IGNITE);
+    expect(HARDNESS_IGNITE).toBeGreaterThan(HARDNESS_GEM);
+  });
+});
+
+// ============================================================
+// Scenario tests: hardness affects completion time
+// ============================================================
+
+describe("mine hardness scenario", () => {
+  it("soil mines faster than rock (completes in fewer ticks)", async () => {
+    // Soil tile — hardness 0.3 → effective work = WORK_MINE_BASE * 0.3 ticks
+    const soilTicks = Math.ceil(WORK_MINE_BASE * HARDNESS_SOIL) + 2;
+
+    const dwarf1 = makeDwarf({ id: "d1", position_x: 1, position_y: 0, position_z: 0 });
+    const task1 = makeTask("mine", {
+      assigned_dwarf_id: "d1",
+      target_x: 2,
+      target_y: 0,
+      target_z: 0,
+      work_required: WORK_MINE_BASE,
+    });
+    dwarf1.current_task_id = task1.id;
+
+    const soilTile = makeMapTile(2, 0, 0, "soil");
+
+    const result = await runScenario({
+      dwarves: [dwarf1],
+      tasks: [task1],
+      fortressTileOverrides: [soilTile],
+      ticks: soilTicks,
+    });
+
+    const task = result.tasks.find(t => t.id === task1.id);
+    expect(task?.status).toBe("completed");
+  });
+
+  it("soil does NOT complete in fewer ticks than the standard stone would allow", async () => {
+    // With stone hardness (default), would need WORK_MINE_BASE ticks.
+    // With soil hardness (0.3), needs only WORK_MINE_BASE * 0.3 ≈ 30 ticks.
+    // If we run for only 30 ticks, soil should be done but stone would not be.
+    const soilTicks = Math.ceil(WORK_MINE_BASE * HARDNESS_SOIL) + 2;
+
+    // Soil dwarf should complete
+    const soilDwarf = makeDwarf({ id: "soil", position_x: 1, position_y: 0, position_z: 0 });
+    const soilTask = makeTask("mine", {
+      id: "t-soil",
+      assigned_dwarf_id: "soil",
+      target_x: 2,
+      target_y: 0,
+      target_z: 0,
+      work_required: WORK_MINE_BASE,
+    });
+    soilDwarf.current_task_id = soilTask.id;
+
+    // Stone dwarf (default tile = stone hardness) should NOT complete in same ticks
+    const stoneDwarf = makeDwarf({ id: "stone", position_x: 1, position_y: 5, position_z: 0 });
+    const stoneTask = makeTask("mine", {
+      id: "t-stone",
+      assigned_dwarf_id: "stone",
+      target_x: 2,
+      target_y: 5,
+      target_z: 0,
+      work_required: WORK_MINE_BASE,
+    });
+    stoneDwarf.current_task_id = stoneTask.id;
+
+    const result = await runScenario({
+      dwarves: [soilDwarf, stoneDwarf],
+      tasks: [soilTask, stoneTask],
+      fortressTileOverrides: [makeMapTile(2, 0, 0, "soil")],
+      ticks: soilTicks,
+    });
+
+    const finishedSoil = result.tasks.find(t => t.id === soilTask.id);
+    const finishedStone = result.tasks.find(t => t.id === stoneTask.id);
+
+    expect(finishedSoil?.status).toBe("completed");
+    expect(finishedStone?.status).not.toBe("completed"); // stone takes longer
+  });
+});

--- a/sim/src/phases/task-execution.ts
+++ b/sim/src/phases/task-execution.ts
@@ -1,4 +1,13 @@
-import { BASE_WORK_RATE, SLEEP_RESTORE_PER_TICK, MAX_NEED } from "@pwarf/shared";
+import {
+  BASE_WORK_RATE,
+  SLEEP_RESTORE_PER_TICK,
+  MAX_NEED,
+  HARDNESS_SOIL,
+  HARDNESS_STONE,
+  HARDNESS_IGNITE,
+  HARDNESS_ORE,
+  HARDNESS_GEM,
+} from "@pwarf/shared";
 import type { Dwarf, Task } from "@pwarf/shared";
 import type { SimContext } from "../sim-context.js";
 import { getDwarfSkillLevel, getRequiredSkill } from "../task-helpers.js";
@@ -63,7 +72,15 @@ export async function taskExecution(ctx: SimContext): Promise<void> {
     const skillLevel = requiredSkill
       ? getDwarfSkillLevel(dwarf.id, requiredSkill, state.dwarfSkills)
       : 0;
-    const workRate = BASE_WORK_RATE * (1 + skillLevel * 0.1);
+
+    let hardness = 1;
+    if (task.task_type === 'mine' && task.target_x !== null && task.target_y !== null && task.target_z !== null) {
+      const getTile = buildTileLookup(ctx);
+      const tileType = getTile(task.target_x, task.target_y, task.target_z);
+      hardness = getTileHardness(tileType);
+    }
+
+    const workRate = (BASE_WORK_RATE * (1 + skillLevel * 0.1)) / hardness;
 
     task.work_progress += workRate;
     state.dirtyTaskIds.add(task.id);
@@ -116,6 +133,22 @@ function moveTowardTarget(dwarf: Dwarf, task: Task, ctx: SimContext): boolean {
   dwarf.position_z = nextStep.z;
   ctx.state.dirtyDwarfIds.add(dwarf.id);
   return true;
+}
+
+/**
+ * Returns the hardness multiplier for a given tile type.
+ * Higher hardness = more work required to mine.
+ * Exported for unit testing.
+ */
+export function getTileHardness(tileType: string | null): number {
+  switch (tileType) {
+    case 'soil':       return HARDNESS_SOIL;    // 0.3 — fast
+    case 'ore':        return HARDNESS_ORE;     // 1.2
+    case 'gem':        return HARDNESS_GEM;     // 1.4
+    case 'lava_stone':
+    case 'cavern_wall': return HARDNESS_IGNITE; // 1.5 — slow
+    default:           return HARDNESS_STONE;   // 1.0 — rock, open_air, etc.
+  }
 }
 
 function failTask(dwarf: Dwarf, task: Task, state: SimContext['state']): void {


### PR DESCRIPTION
Fixes #316. Dwarves now mine at different speeds based on tile material.

## Problem

`HARDNESS_SOIL`, `HARDNESS_STONE`, `HARDNESS_ORE`, `HARDNESS_GEM`, and `HARDNESS_IGNITE` were defined but never used. All mine tasks took exactly `WORK_MINE_BASE = 100` ticks regardless of what was being mined.

## Fix

Added `getTileHardness(tileType)` helper in `task-execution.ts` that maps tile types to their hardness constants. For `mine` tasks, the effective work rate is divided by the tile hardness:

```
workRate = BASE_WORK_RATE * (1 + skillLevel * 0.1) / hardness
```

| Tile | Hardness | Effective ticks (skill 0) |
|---|---|---|
| soil | 0.3 | ~30 |
| rock/stone/default | 1.0 | 100 |
| ore | 1.2 | 120 |
| gem | 1.4 | 140 |
| lava_stone / cavern_wall | 1.5 | 150 |

## Tests

7 new tests (5 unit, 2 scenario):
- `getTileHardness` returns correct value for each tile type
- Soil mine completes faster than a stone mine in the same tick budget

## Verification

Sim logic change — verified with scenario tests.

```
Test Files: 24 passed (24)
Tests:      275 passed (275)
```

## Claude Cost

**Claude cost:** $0.13 (355k tokens)