### PR TITLE
feat: build_well and build_mushroom_garden task types

### DIFF
--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -191,6 +191,12 @@ export const WORK_BUILD_FLOOR = 50;
 /** Work required to build a bed */
 export const WORK_BUILD_BED = 60;
 
+/** Work required to build a well */
+export const WORK_BUILD_WELL = 120;
+
+/** Work required to build a mushroom garden */
+export const WORK_BUILD_MUSHROOM_GARDEN = 100;
+
 /** Work required to wander (just walking, instant once arrived) */
 export const WORK_WANDER = 1;
 

--- a/shared/src/db-types.ts
+++ b/shared/src/db-types.ts
@@ -159,6 +159,8 @@ export type TaskType =
   | 'build_wall'
   | 'build_floor'
   | 'build_bed'
+  | 'build_well'
+  | 'build_mushroom_garden'
   | 'wander';
 
 export type TaskStatus =

--- a/sim/src/__tests__/build-structures.test.ts
+++ b/sim/src/__tests__/build-structures.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { runScenario } from "../run-scenario.js";
+import { makeDwarf, makeTask } from "./test-helpers.js";
+import { WORK_BUILD_WELL, WORK_BUILD_MUSHROOM_GARDEN } from "@pwarf/shared";
+
+describe("build_well scenario", () => {
+  it("completes and adds a well structure", async () => {
+    const dwarf = makeDwarf({ position_x: 5, position_y: 5, position_z: 0 });
+    const task = makeTask("build_well", {
+      assigned_dwarf_id: dwarf.id,
+      target_x: 5,
+      target_y: 5,
+      target_z: 0,
+      work_required: WORK_BUILD_WELL,
+    });
+    dwarf.current_task_id = task.id;
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      tasks: [task],
+      ticks: WORK_BUILD_WELL + 5,
+    });
+
+    const completedTask = result.tasks.find(t => t.id === task.id);
+    expect(completedTask?.status).toBe("completed");
+
+    const well = result.structures.find(s => s.type === "well");
+    expect(well).toBeDefined();
+    expect(well?.completion_pct).toBe(100);
+    expect(well?.position_x).toBe(5);
+    expect(well?.position_y).toBe(5);
+  });
+
+  it("places a well tile in fortress overrides", async () => {
+    const dwarf = makeDwarf({ position_x: 5, position_y: 5, position_z: 0 });
+    const task = makeTask("build_well", {
+      assigned_dwarf_id: dwarf.id,
+      target_x: 5,
+      target_y: 5,
+      target_z: 0,
+      work_required: WORK_BUILD_WELL,
+    });
+    dwarf.current_task_id = task.id;
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      tasks: [task],
+      ticks: WORK_BUILD_WELL + 5,
+    });
+
+    const wellTile = result.fortressTileOverrides.find(t => t.x === 5 && t.y === 5);
+    expect(wellTile?.tile_type).toBe("well");
+  });
+});
+
+describe("build_mushroom_garden scenario", () => {
+  it("completes and adds a mushroom_garden structure", async () => {
+    const dwarf = makeDwarf({ position_x: 3, position_y: 3, position_z: 0 });
+    const task = makeTask("build_mushroom_garden", {
+      assigned_dwarf_id: dwarf.id,
+      target_x: 3,
+      target_y: 3,
+      target_z: 0,
+      work_required: WORK_BUILD_MUSHROOM_GARDEN,
+    });
+    dwarf.current_task_id = task.id;
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      tasks: [task],
+      ticks: WORK_BUILD_MUSHROOM_GARDEN + 5,
+    });
+
+    const completedTask = result.tasks.find(t => t.id === task.id);
+    expect(completedTask?.status).toBe("completed");
+
+    const garden = result.structures.find(s => s.type === "mushroom_garden");
+    expect(garden).toBeDefined();
+    expect(garden?.completion_pct).toBe(100);
+  });
+
+  it("places a mushroom_garden tile in fortress overrides", async () => {
+    const dwarf = makeDwarf({ position_x: 3, position_y: 3, position_z: 0 });
+    const task = makeTask("build_mushroom_garden", {
+      assigned_dwarf_id: dwarf.id,
+      target_x: 3,
+      target_y: 3,
+      target_z: 0,
+      work_required: WORK_BUILD_MUSHROOM_GARDEN,
+    });
+    dwarf.current_task_id = task.id;
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      tasks: [task],
+      ticks: WORK_BUILD_MUSHROOM_GARDEN + 5,
+    });
+
+    const gardenTile = result.fortressTileOverrides.find(t => t.x === 3 && t.y === 3);
+    expect(gardenTile?.tile_type).toBe("mushroom_garden");
+  });
+});

--- a/sim/src/phases/task-completion.ts
+++ b/sim/src/phases/task-completion.ts
@@ -97,6 +97,14 @@ export function completeTask(dwarf: Dwarf, task: Task, ctx: SimContext): void {
       completeBuildBed(task, ctx);
       awardXp(dwarf.id, 'building', XP_BUILD, state);
       break;
+    case 'build_well':
+      completeBuildStructure(task, ctx, 'well', 'well');
+      awardXp(dwarf.id, 'building', XP_BUILD, state);
+      break;
+    case 'build_mushroom_garden':
+      completeBuildStructure(task, ctx, 'mushroom_garden', 'mushroom_garden');
+      awardXp(dwarf.id, 'building', XP_BUILD, state);
+      break;
   }
 
   // Purpose restoration: work gives dwarves a sense of meaning
@@ -109,7 +117,7 @@ export function completeTask(dwarf: Dwarf, task: Task, ctx: SimContext): void {
  * Exported for unit testing.
  */
 export function restorePurposeNeed(dwarf: Dwarf, taskType: string): void {
-  const SKILLED_TASKS = new Set(['mine', 'build_wall', 'build_floor', 'build_bed', 'farm_till', 'farm_plant', 'farm_harvest']);
+  const SKILLED_TASKS = new Set(['mine', 'build_wall', 'build_floor', 'build_bed', 'build_well', 'build_mushroom_garden', 'farm_till', 'farm_plant', 'farm_harvest']);
   const restore = SKILLED_TASKS.has(taskType)
     ? PURPOSE_RESTORE_SKILLED
     : taskType === 'haul'
@@ -347,6 +355,40 @@ function completeBuildBed(task: Task, ctx: SimContext): void {
 
   // Place bed tile for rendering
   upsertFortressTile(ctx, task.target_x, task.target_y, task.target_z, 'bed', 'wood', false);
+}
+
+/**
+ * Generic handler for structures that don't need special logic beyond
+ * creating a Structure record and placing a tile (well, mushroom_garden, etc.).
+ */
+function completeBuildStructure(
+  task: Task,
+  ctx: SimContext,
+  structureType: string,
+  tileType: FortressTileType,
+): void {
+  if (task.target_x === null || task.target_y === null || task.target_z === null) return;
+
+  const structure: Structure = {
+    id: ctx.rng.uuid(),
+    civilization_id: ctx.civilizationId,
+    name: null,
+    type: structureType,
+    completion_pct: 100,
+    built_year: ctx.year,
+    ruin_id: null,
+    quality: 'standard',
+    notes: null,
+    position_x: task.target_x,
+    position_y: task.target_y,
+    position_z: task.target_z,
+    occupied_by_dwarf_id: null,
+  };
+
+  ctx.state.structures.push(structure);
+  ctx.state.dirtyStructureIds.add(structure.id);
+
+  upsertFortressTile(ctx, task.target_x, task.target_y, task.target_z, tileType, 'stone', false);
 }
 
 function awardXp(dwarfId: string, skillName: string, xpAmount: number, state: SimContext['state']): void {

--- a/sim/src/task-helpers.ts
+++ b/sim/src/task-helpers.ts
@@ -14,6 +14,8 @@ const TASK_SKILL_MAP: Record<TaskType, string | null> = {
   build_wall: 'building',
   build_floor: 'building',
   build_bed: 'building',
+  build_well: 'building',
+  build_mushroom_garden: 'building',
   wander: null,
 };
 

--- a/sim/vitest.config.ts
+++ b/sim/vitest.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     globals: true,
+    exclude: ['dist/**', 'node_modules/**'],
   },
 });


### PR DESCRIPTION
Adds two new buildable structures to make the beauty restoration system reachable. Closes #318. Also fixes #319 (vitest double-counting).

## Changes

### New task types (shared)
- `build_well` — builds a well structure at the target tile
- `build_mushroom_garden` — builds a mushroom garden structure

### New constants (shared)
- `WORK_BUILD_WELL = 120` (heavier construction than a bed)
- `WORK_BUILD_MUSHROOM_GARDEN = 100`

### Sim changes
- `task-helpers.ts`: both types mapped to `building` skill
- `task-completion.ts`: `completeBuildStructure()` generic helper creates a `Structure` record with `completion_pct = 100` + places the corresponding fortress tile
- `restorePurposeNeed()`: both types added to skilled tasks set (restore `PURPOSE_RESTORE_SKILLED`)

### Vitest fix (closes #319)
- Added `exclude: ['dist/**']` to `sim/vitest.config.ts` so compiled `.test.js` files don't get picked up alongside TypeScript sources after a build.

## Before / After

**Before:** Beauty restoration checked for nearby wells/mushroom_gardens, but there was no way to build them. The beauty bonus was unreachable.

**After:** A dwarf can be assigned a `build_well` or `build_mushroom_garden` task, complete it, and other dwarves passing nearby will receive the `BEAUTY_RESTORE_NEAR_STRUCTURE` bonus.

## Tests

4 new scenario tests:
- `build_well` → structure added, tile becomes `well`
- `build_mushroom_garden` → structure added, tile becomes `mushroom_garden`

```
Test Files: 25 passed (25)
Tests:      279 passed (279)
```

## Claude Cost

**Claude cost:** $0.15 (419k tokens)