### PR TITLE
feat: scenario tests for all build task types, add dwarfSkills to ScenarioConfig

### DIFF
--- a/sim/src/run-scenario.test.ts
+++ b/sim/src/run-scenario.test.ts
@@ -1,11 +1,16 @@
 import { describe, it, expect } from "vitest";
 import { runScenario } from "./run-scenario.js";
-import { makeDwarf } from "./__tests__/test-helpers.js";
+import { makeDwarf, makeSkill, makeTask, makeMapTile } from "./__tests__/test-helpers.js";
 import {
   FOOD_DECAY_PER_TICK,
-  DRINK_DECAY_PER_TICK,
   NEED_INTERRUPT_FOOD,
   STEPS_PER_YEAR,
+  WORK_BUILD_WALL,
+  WORK_BUILD_FLOOR,
+  WORK_BUILD_BED,
+  WORK_BUILD_WELL,
+  WORK_BUILD_MUSHROOM_GARDEN,
+  WORK_MINE_BASE,
 } from "@pwarf/shared";
 
 describe("runScenario", () => {
@@ -66,5 +71,219 @@ describe("runScenario", () => {
     const posA = `${a.dwarves[0].position_x},${a.dwarves[0].position_y}`;
     const posB = `${b.dwarves[0].position_x},${b.dwarves[0].position_y}`;
     expect(posA).not.toBe(posB);
+  });
+});
+
+describe("building tasks", () => {
+  // Dwarf starting position — all adjacent/nearby tiles are open_air (no deriver fallback returns open_air)
+  const DX = 10;
+  const DY = 10;
+  const DZ = 0;
+
+  it("build_wall completes and changes tile to constructed_wall", async () => {
+    const dwarf = makeDwarf({ position_x: DX, position_y: DY, position_z: DZ });
+    const skill = makeSkill(dwarf.id, 'building');
+    // Target at (DX, DY+1) — adjacent to dwarf, so no movement needed
+    const task = makeTask('build_wall', {
+      status: 'pending',
+      assigned_dwarf_id: null,
+      target_x: DX,
+      target_y: DY + 1,
+      target_z: DZ,
+      work_required: WORK_BUILD_WALL,
+      work_progress: 0,
+    });
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      dwarfSkills: [skill],
+      tasks: [task],
+      ticks: WORK_BUILD_WALL + 20,
+      seed: 1,
+    });
+
+    const builtTile = result.fortressTileOverrides.find(
+      t => t.x === DX && t.y === DY + 1 && t.z === DZ,
+    );
+    expect(builtTile).toBeDefined();
+    expect(builtTile?.tile_type).toBe('constructed_wall');
+
+    const completedTask = result.tasks.find(t => t.id === task.id);
+    expect(completedTask?.status).toBe('completed');
+  });
+
+  it("build_floor completes and changes tile to constructed_floor", async () => {
+    const dwarf = makeDwarf({ position_x: DX, position_y: DY, position_z: DZ });
+    const skill = makeSkill(dwarf.id, 'building');
+    // Target 3 steps away — dwarf must walk there first (not adjacent task type)
+    const task = makeTask('build_floor', {
+      status: 'pending',
+      assigned_dwarf_id: null,
+      target_x: DX + 3,
+      target_y: DY,
+      target_z: DZ,
+      work_required: WORK_BUILD_FLOOR,
+      work_progress: 0,
+    });
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      dwarfSkills: [skill],
+      tasks: [task],
+      ticks: WORK_BUILD_FLOOR + 20,
+      seed: 1,
+    });
+
+    const builtTile = result.fortressTileOverrides.find(
+      t => t.x === DX + 3 && t.y === DY && t.z === DZ,
+    );
+    expect(builtTile).toBeDefined();
+    expect(builtTile?.tile_type).toBe('constructed_floor');
+  });
+
+  it("build_bed completes and creates a bed structure", async () => {
+    const dwarf = makeDwarf({ position_x: DX, position_y: DY, position_z: DZ });
+    const skill = makeSkill(dwarf.id, 'building');
+    const task = makeTask('build_bed', {
+      status: 'pending',
+      assigned_dwarf_id: null,
+      target_x: DX + 2,
+      target_y: DY,
+      target_z: DZ,
+      work_required: WORK_BUILD_BED,
+      work_progress: 0,
+    });
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      dwarfSkills: [skill],
+      tasks: [task],
+      ticks: WORK_BUILD_BED + 20,
+      seed: 1,
+    });
+
+    const bed = result.structures.find(
+      s => s.type === 'bed' && s.position_x === DX + 2 && s.position_y === DY,
+    );
+    expect(bed).toBeDefined();
+    expect(bed?.completion_pct).toBe(100);
+
+    const builtTile = result.fortressTileOverrides.find(
+      t => t.x === DX + 2 && t.y === DY && t.z === DZ,
+    );
+    expect(builtTile?.tile_type).toBe('bed');
+  });
+
+  it("build_well completes and creates a well structure", async () => {
+    const dwarf = makeDwarf({ position_x: DX, position_y: DY, position_z: DZ });
+    const skill = makeSkill(dwarf.id, 'building');
+    const task = makeTask('build_well', {
+      status: 'pending',
+      assigned_dwarf_id: null,
+      target_x: DX + 2,
+      target_y: DY,
+      target_z: DZ,
+      work_required: WORK_BUILD_WELL,
+      work_progress: 0,
+    });
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      dwarfSkills: [skill],
+      tasks: [task],
+      ticks: WORK_BUILD_WELL + 20,
+      seed: 1,
+    });
+
+    const well = result.structures.find(
+      s => s.type === 'well' && s.position_x === DX + 2 && s.position_y === DY,
+    );
+    expect(well).toBeDefined();
+  });
+
+  it("build_mushroom_garden completes and creates a mushroom_garden structure", async () => {
+    const dwarf = makeDwarf({ position_x: DX, position_y: DY, position_z: DZ });
+    const skill = makeSkill(dwarf.id, 'building');
+    const task = makeTask('build_mushroom_garden', {
+      status: 'pending',
+      assigned_dwarf_id: null,
+      target_x: DX + 2,
+      target_y: DY,
+      target_z: DZ,
+      work_required: WORK_BUILD_MUSHROOM_GARDEN,
+      work_progress: 0,
+    });
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      dwarfSkills: [skill],
+      tasks: [task],
+      ticks: WORK_BUILD_MUSHROOM_GARDEN + 20,
+      seed: 1,
+    });
+
+    const garden = result.structures.find(
+      s => s.type === 'mushroom_garden' && s.position_x === DX + 2 && s.position_y === DY,
+    );
+    expect(garden).toBeDefined();
+  });
+
+  it("mine task completes and changes tile to open_air, creates stone item", async () => {
+    const dwarf = makeDwarf({ position_x: DX, position_y: DY, position_z: DZ });
+    const skill = makeSkill(dwarf.id, 'mining');
+    // Place a stone tile adjacent to the dwarf
+    const stoneTile = makeMapTile(DX, DY + 1, DZ, 'stone');
+    const task = makeTask('mine', {
+      status: 'pending',
+      assigned_dwarf_id: null,
+      target_x: DX,
+      target_y: DY + 1,
+      target_z: DZ,
+      work_required: WORK_MINE_BASE,
+      work_progress: 0,
+    });
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      dwarfSkills: [skill],
+      tasks: [task],
+      fortressTileOverrides: [stoneTile],
+      ticks: WORK_MINE_BASE + 20,
+      seed: 1,
+    });
+
+    const minedTile = result.fortressTileOverrides.find(
+      t => t.x === DX && t.y === DY + 1 && t.z === DZ,
+    );
+    expect(minedTile?.tile_type).toBe('grass'); // z=0 surface mine → grass
+    expect(minedTile?.is_mined).toBe(true);
+
+    const stoneItem = result.items.find(i => i.name === 'Stone block');
+    expect(stoneItem).toBeDefined();
+  });
+
+  it("dwarf without skill cannot claim build task", async () => {
+    // No building skill — task should stay pending
+    const dwarf = makeDwarf({ position_x: DX, position_y: DY, position_z: DZ });
+    const task = makeTask('build_wall', {
+      status: 'pending',
+      assigned_dwarf_id: null,
+      target_x: DX,
+      target_y: DY + 1,
+      target_z: DZ,
+      work_required: WORK_BUILD_WALL,
+      work_progress: 0,
+    });
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      dwarfSkills: [], // no skills
+      tasks: [task],
+      ticks: 50,
+      seed: 1,
+    });
+
+    const pendingTask = result.tasks.find(t => t.id === task.id);
+    expect(pendingTask?.status).toBe('pending');
   });
 });

--- a/sim/src/run-scenario.ts
+++ b/sim/src/run-scenario.ts
@@ -1,6 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { STEPS_PER_YEAR } from "@pwarf/shared";
-import type { Dwarf, FortressTile, Item, Structure, Monster, Task, WorldEvent } from "@pwarf/shared";
+import type { Dwarf, DwarfSkill, FortressTile, Item, Structure, Monster, Task, WorldEvent } from "@pwarf/shared";
 import type { SimContext, CachedState } from "./sim-context.js";
 import { createEmptyCachedState, createRng } from "./sim-context.js";
 import { DEFAULT_TEST_SEED } from "./rng.js";
@@ -25,6 +25,8 @@ import {
 /** Input configuration for a scenario run. */
 export interface ScenarioConfig {
   dwarves?: Dwarf[];
+  /** Dwarf skill records — required for any scenario that tests skilled tasks (build, mine, farm). */
+  dwarfSkills?: DwarfSkill[];
   items?: Item[];
   structures?: Structure[];
   monsters?: Monster[];
@@ -66,6 +68,7 @@ export async function runScenario(config: ScenarioConfig): Promise<ScenarioResul
   const state: CachedState = createEmptyCachedState();
   // Deep-copy all input entities so mutations during the run don't affect the caller's objects
   state.dwarves = config.dwarves ? config.dwarves.map(d => ({ ...d })) : [];
+  state.dwarfSkills = config.dwarfSkills ? config.dwarfSkills.map(s => ({ ...s })) : [];
   state.items = config.items ? config.items.map(i => ({ ...i })) : [];
   state.structures = config.structures ? config.structures.map(s => ({ ...s })) : [];
   state.monsters = config.monsters ? config.monsters.map(m => ({ ...m })) : [];


### PR DESCRIPTION
## Summary

- Added `dwarfSkills` field to `ScenarioConfig` so headless tests can set up dwarves with skills
- Added 7 scenario tests covering every build task type and the mine task
- Tests confirm the full pipeline: task creation → job claiming → path → work → tile/structure effect

## What was missing

`ScenarioConfig` had no `dwarfSkills` field. Since `jobClaiming` gates assignment on dwarf skill records, no build/mine/farm scenario test could ever work — dwarves always failed the skill check and tasks stayed pending forever. Zero coverage for any construction.

## Did this find a bug?

**No.** All 7 new tests pass first try. The sim mechanics for building are correct — the phase ordering, pathfinding, tile updates, and structure creation all work. The production concern ("dwarves never build") is not a sim logic bug.

Most likely culprit in production: the player has to manually use the build menu (`b` key → Wall/Floor/Bed) to designate tiles. No build tasks exist in the DB unless the player explicitly creates them. The UI flow is functional but may not be obvious.

## Test plan

- `build_wall` → tile becomes `constructed_wall`
- `build_floor` → tile becomes `constructed_floor`  
- `build_bed` → structure of type `bed` created, tile type `bed`
- `build_well` → structure of type `well` created
- `build_mushroom_garden` → structure created
- `mine` → stone tile becomes `grass` (z=0), stone block item created
- No-skill guard: dwarf without skill cannot claim build task, task stays `pending`

All 348 sim tests pass.

## Claude Cost

**Claude cost:** $2.19 (6.0M tokens)