### PR TITLE
fix: inject real supabase client into flushToSupabase (closes #339)

### DIFF
--- a/sim/src/state-adapter.ts
+++ b/sim/src/state-adapter.ts
@@ -73,7 +73,9 @@ export class SupabaseStateAdapter implements StateAdapter {
 
   async flush(ctx: SimContext): Promise<void> {
     const { flushToSupabase } = await import('./flush-state.js');
-    await flushToSupabase(ctx);
+    // ctx.supabase is null in SimRunner (adapter holds the real client),
+    // so inject it before delegating to flushToSupabase.
+    await flushToSupabase({ ...ctx, supabase: this.supabase });
   }
 }
 


### PR DESCRIPTION
## Summary

- `SimRunner` sets `ctx.supabase = null` because the `StateAdapter` pattern was meant to abstract all DB access
- But `SupabaseStateAdapter.flush()` called `flushToSupabase(ctx)` which reads `ctx.supabase` directly — crashing every flush with `TypeError: Cannot read properties of null (reading 'from')`
- Fix: inject `this.supabase` (the adapter's real client) into the ctx spread before passing to `flushToSupabase`

## Impact

This was a silent total failure of persistence. Every 15 seconds the flush ran, crashed, and continued. None of the following were ever saved to Supabase:
- Dwarf state changes (positions, needs, deaths)  
- Task completions (build, mine, haul)
- Tile changes from construction/mining
- World events (death notices, build completions → log was always "No events yet")

Building didn't work because the tile change happened in memory but was never flushed. The log showed "No events yet" for the same reason.

## Test plan
- [x] All 341 sim tests pass
- [x] `npm run build` clean
- [x] Playtest: designated a wall → page reload → "Nish Axebeard has finished build wall" appeared in log, `#` tile visible on map ✓

## Claude Cost
**Claude cost:** $0.39 (1.0M tokens)