### PR TITLE
fix: trait values must be 0-1 floats; clamp sim formulas for old DB rows (closes #342)

### DIFF
--- a/app/src/lib/embark.ts
+++ b/app/src/lib/embark.ts
@@ -102,12 +102,12 @@ export async function embark(worldId: string, tileX: number, tileY: number, worl
       position_x: FORTRESS_CENTER + offset.dx,
       position_y: FORTRESS_CENTER + offset.dy,
       position_z: 0,
-      // Personality traits: -3 to +3 (Big Five)
-      trait_openness: Math.floor(Math.random() * 7) - 3,
-      trait_conscientiousness: Math.floor(Math.random() * 7) - 3,
-      trait_extraversion: Math.floor(Math.random() * 7) - 3,
-      trait_agreeableness: Math.floor(Math.random() * 7) - 3,
-      trait_neuroticism: Math.floor(Math.random() * 7) - 3,
+      // Personality traits: 0.0–1.0 (Big Five, where 0.5 = average)
+      trait_openness: Math.random(),
+      trait_conscientiousness: Math.random(),
+      trait_extraversion: Math.random(),
+      trait_agreeableness: Math.random(),
+      trait_neuroticism: Math.random(),
     };
   });
 

--- a/sim/src/phases/needs-decay.ts
+++ b/sim/src/phases/needs-decay.ts
@@ -25,8 +25,9 @@ export async function needsDecay(ctx: SimContext): Promise<void> {
     if (dwarf.status !== "alive") continue;
 
     // trait_extraversion: 0.5=average (no effect), 1.0=extravert (+50% faster decay), 0.0=introvert (-50%)
+    // Clamp to 0.1 minimum to guard against out-of-range trait values.
     const extraversionModifier = dwarf.trait_extraversion !== null
-      ? 1 + (dwarf.trait_extraversion - 0.5) * EXTRAVERSION_SOCIAL_DECAY_MULTIPLIER
+      ? Math.max(0.1, 1 + (dwarf.trait_extraversion - 0.5) * EXTRAVERSION_SOCIAL_DECAY_MULTIPLIER)
       : 1;
 
     dwarf.need_food = Math.max(MIN_NEED, dwarf.need_food - FOOD_DECAY_PER_TICK);

--- a/sim/src/phases/stress-update.ts
+++ b/sim/src/phases/stress-update.ts
@@ -67,8 +67,9 @@ export function calcStressDelta(
 
   // Apply neuroticism modifier to stress gains
   // trait_neuroticism: 0.0=very stable, 0.5=average (no effect), 1.0=very neurotic
+  // Clamp modifier to [0.1, ∞) to guard against out-of-range trait values.
   if (gainDelta > 0 && dwarf.trait_neuroticism !== null) {
-    gainDelta *= 1 + (dwarf.trait_neuroticism - 0.5) * NEUROTICISM_STRESS_MULTIPLIER;
+    gainDelta *= Math.max(0.1, 1 + (dwarf.trait_neuroticism - 0.5) * NEUROTICISM_STRESS_MULTIPLIER);
   }
 
   let recoveryDelta = 0;
@@ -77,9 +78,9 @@ export function calcStressDelta(
   if (needValues.every(n => n > 50)) {
     recoveryDelta -= 0.1;
 
-    // Agreeable dwarves recover additional stress per tick
+    // Agreeable dwarves recover additional stress per tick (clamp to 0..1 range)
     if (dwarf.trait_agreeableness !== null) {
-      recoveryDelta -= dwarf.trait_agreeableness * AGREEABLENESS_RECOVERY_BONUS;
+      recoveryDelta -= Math.max(0, dwarf.trait_agreeableness) * AGREEABLENESS_RECOVERY_BONUS;
     }
   }
 

--- a/sim/src/phases/task-execution.ts
+++ b/sim/src/phases/task-execution.ts
@@ -82,8 +82,9 @@ export async function taskExecution(ctx: SimContext): Promise<void> {
     }
 
     // Apply conscientiousness modifier: trait=0.5 → no effect, 1.0 → +25%, 0.0 → -25%
+    // Clamp to 0.1 minimum to guard against out-of-range trait values (e.g. old -3..3 DB rows).
     const conscientiousnessModifier = dwarf.trait_conscientiousness !== null
-      ? 1 + (dwarf.trait_conscientiousness - 0.5) * CONSCIENTIOUSNESS_WORK_MULTIPLIER
+      ? Math.max(0.1, 1 + (dwarf.trait_conscientiousness - 0.5) * CONSCIENTIOUSNESS_WORK_MULTIPLIER)
       : 1;
     const workRate = (BASE_WORK_RATE * (1 + skillLevel * 0.1) * conscientiousnessModifier) / hardness;
 


### PR DESCRIPTION
## Summary

- `embark.ts` generated personality traits as integers `[-3, 3]` but all sim phase formulas assume `[0, 1]` range
- At `trait_conscientiousness=-3`: `conscientiousnessModifier = 1 + (-3.5) × 0.5 = -0.75` — **negative work rate**
- `task.work_progress += negative_rate` → progress never reaches `work_required` → eat/drink tasks never complete → dwarves die of dehydration every single run

## Fixes

1. **`embark.ts`**: generate traits as `Math.random()` (0.0–1.0 float) instead of `Math.floor(Math.random() * 7) - 3`
2. **`task-execution.ts`**: `Math.max(0.1, conscientiousnessModifier)` — clamps work rate positive for existing DB dwarves with old trait values
3. **`needs-decay.ts`**: same clamp on extraversionModifier
4. **`stress-update.ts`**: clamp neuroticism multiplier and agreeableness bonus

## Test plan
- [x] All 341 sim tests pass
- [`npm run build`] clean
- [x] Headless: dwarf with worst-case trait=-3 survives 1000 ticks ✓
- [x] Headless: average dwarf (trait=0.5) survives 2000 ticks with healthy needs ✓
- [x] Playtest: dwarves survived multiple minutes with new 0-1 traits; build wall completed and showed `#` on map

## Claude Cost
**Claude cost:** $78.91 (212.0M tokens)