### PR TITLE
feat: show build progress on tile and in dwarf modal (closes #344)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -78,6 +78,7 @@ export default function App() {
   // Active tasks — prefer live snapshot, fall back to DB polling
   const polledTasks = useTasks(world.civId);
   const { addOptimistic } = polledTasks;
+  const liveTasks = snapshot?.tasks ?? polledTasks.tasks;
   const designatedTiles = useMemo(() => {
     const AUTONOMOUS: ReadonlySet<string> = new Set(['eat', 'drink', 'sleep', 'wander']);
     const tasks = snapshot?.tasks ?? polledTasks.tasks;
@@ -88,6 +89,23 @@ export default function App() {
       const tz = 'target_z' in t ? t.target_z : null;
       if (tx !== null && ty !== null && tz === zLevel && !AUTONOMOUS.has(t.task_type) && ['pending', 'claimed', 'in_progress'].includes(t.status)) {
         map.set(`${tx},${ty}`, t.task_type);
+      }
+    }
+    return map;
+  }, [snapshot?.tasks, polledTasks.tasks, zLevel]);
+
+  // Build progress for in_progress tasks keyed by "x,y"
+  const buildProgressTiles = useMemo(() => {
+    const AUTONOMOUS: ReadonlySet<string> = new Set(['eat', 'drink', 'sleep', 'wander']);
+    const tasks = snapshot?.tasks ?? polledTasks.tasks;
+    const map = new Map<string, number>();
+    for (const t of tasks) {
+      if (t.status !== 'in_progress' || AUTONOMOUS.has(t.task_type)) continue;
+      const tx = 'target_x' in t ? t.target_x : null;
+      const ty = 'target_y' in t ? t.target_y : null;
+      const tz = 'target_z' in t ? t.target_z : null;
+      if (tx !== null && ty !== null && tz === zLevel && t.work_required > 0) {
+        map.set(`${tx},${ty}`, Math.round((t.work_progress / t.work_required) * 100));
       }
     }
     return map;
@@ -340,8 +358,9 @@ export default function App() {
   const terrainForBar = world.mode === "world" ? (cursorTile?.terrain ?? null) : null;
   const cursorKey = `${viewport.cursorX},${viewport.cursorY}`;
   const cursorDesignation = world.mode === "fortress" ? mergedDesignatedTiles.get(cursorKey) : undefined;
+  const cursorBuildProgress = world.mode === "fortress" ? buildProgressTiles.get(cursorKey) : undefined;
   const fortressTileLabel = world.mode === "fortress" && cursorFortressTile
-    ? formatFortressTileLabel(cursorFortressTile.tileType, cursorFortressTile.material, cursorDesignation)
+    ? formatFortressTileLabel(cursorFortressTile.tileType, cursorFortressTile.material, cursorDesignation, cursorBuildProgress)
     : null;
 
   return (
@@ -412,6 +431,7 @@ export default function App() {
           stockpileTiles={world.mode === "fortress" ? stockpileTiles : undefined}
           groundItems={world.mode === "fortress" ? groundItems : undefined}
           zLevel={zLevel}
+          buildProgressTiles={world.mode === "fortress" ? buildProgressTiles : undefined}
         />
 
         {modalDwarf && (
@@ -420,6 +440,7 @@ export default function App() {
             onClose={() => setModalDwarfId(null)}
             onGoTo={handleGoToDwarf}
             items={liveItems}
+            tasks={liveTasks}
           />
         )}
 
@@ -460,11 +481,14 @@ export default function App() {
   );
 }
 
-function formatFortressTileLabel(tileType: string, material: string | null, designation?: string): string {
+function formatFortressTileLabel(tileType: string, material: string | null, designation?: string, buildProgress?: number): string {
   const label = tileType.replace(/_/g, " ");
   const base = material ? `${label} (${material})` : label;
   if (designation) {
     const desLabel = designation.replace(/_/g, " ");
+    if (buildProgress !== undefined) {
+      return `${base} [building: ${desLabel} ${buildProgress}%]`;
+    }
     return `${base} [designated: ${desLabel}]`;
   }
   return base;

--- a/app/src/components/DwarfModal.tsx
+++ b/app/src/components/DwarfModal.tsx
@@ -3,17 +3,28 @@ import type { DwarfSkill, Item } from "@pwarf/shared";
 import { DWARF_CARRY_CAPACITY } from "@pwarf/shared";
 import { supabase } from "../lib/supabase";
 import type { LiveDwarf, DwarfThought } from "../hooks/useDwarves";
+import type { ActiveTask } from "../hooks/useTasks";
 
 interface DwarfModalProps {
   dwarf: LiveDwarf;
   onClose: () => void;
   onGoTo: (dwarf: LiveDwarf) => void;
   items?: Item[];
+  tasks?: ActiveTask[];
 }
 
-function dwarfJobLabel(d: LiveDwarf): string {
-  if (d.current_task_id) return "Working";
-  return "Idle";
+const AUTONOMOUS_TASK_TYPES: ReadonlySet<string> = new Set(['eat', 'drink', 'sleep', 'wander']);
+
+function dwarfJobLabel(d: LiveDwarf, tasks?: ActiveTask[]): string {
+  if (!d.current_task_id) return "Idle";
+  const task = tasks?.find(t => t.id === d.current_task_id);
+  if (!task) return "Working";
+  const label = task.task_type.replace(/_/g, " ");
+  if (AUTONOMOUS_TASK_TYPES.has(task.task_type) || task.work_required === 0) {
+    return label;
+  }
+  const pct = Math.round((task.work_progress / task.work_required) * 100);
+  return `${label} (${pct}%)`;
 }
 
 function needBar(label: string, value: number, color: string) {
@@ -33,7 +44,7 @@ function needBar(label: string, value: number, color: string) {
   );
 }
 
-export function DwarfModal({ dwarf, onClose, onGoTo, items = [] }: DwarfModalProps) {
+export function DwarfModal({ dwarf, onClose, onGoTo, items = [], tasks }: DwarfModalProps) {
   const [skills, setSkills] = useState<DwarfSkill[]>([]);
 
   useEffect(() => {
@@ -85,7 +96,7 @@ export function DwarfModal({ dwarf, onClose, onGoTo, items = [] }: DwarfModalPro
         </div>
 
         <div className="text-[var(--text)] mb-1 flex gap-3">
-          <span>Status: <span className="text-[var(--green)]">{dwarfJobLabel(dwarf)}</span></span>
+          <span>Status: <span className="text-[var(--green)]">{dwarfJobLabel(dwarf, tasks)}</span></span>
           {dwarf.age != null && (
             <span>Age: <span className="text-[var(--green)]">{dwarf.age}</span></span>
           )}

--- a/app/src/components/MainViewport.tsx
+++ b/app/src/components/MainViewport.tsx
@@ -38,6 +38,8 @@ interface MainViewportProps {
   groundItems?: Map<string, number>;
   /** Current z-level for stockpile rendering */
   zLevel?: number;
+  /** Build progress (0-100) for in_progress build tasks keyed by "x,y" */
+  buildProgressTiles?: Map<string, number>;
 }
 
 // Character cell dimensions (monospace)
@@ -81,6 +83,7 @@ export default function MainViewport({
   stockpileTiles,
   groundItems,
   zLevel = 0,
+  buildProgressTiles,
 }: MainViewportProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -116,6 +119,8 @@ export default function MainViewport({
   groundItemsRef.current = groundItems;
   const zLevelRef = useRef(zLevel);
   zLevelRef.current = zLevel;
+  const buildProgressTilesRef = useRef(buildProgressTiles);
+  buildProgressTilesRef.current = buildProgressTiles;
 
   // Increment to force re-render when data (not offset) changes
   const [dataVersion, setDataVersion] = useState(0);
@@ -125,6 +130,7 @@ export default function MainViewport({
   const prevDesignatedTiles = useRef(designatedTiles);
   const prevStockpileTiles = useRef(stockpileTiles);
   const prevGroundItems = useRef(groundItems);
+  const prevBuildProgressTiles = useRef(buildProgressTiles);
 
   if (
     getWorldTileData !== prevGetWorldTileData.current ||
@@ -132,7 +138,8 @@ export default function MainViewport({
     dwarfPositions !== prevDwarfPositions.current ||
     designatedTiles !== prevDesignatedTiles.current ||
     stockpileTiles !== prevStockpileTiles.current ||
-    groundItems !== prevGroundItems.current
+    groundItems !== prevGroundItems.current ||
+    buildProgressTiles !== prevBuildProgressTiles.current
   ) {
     prevGetWorldTileData.current = getWorldTileData;
     prevGetFortressTileData.current = getFortressTileData;
@@ -140,6 +147,7 @@ export default function MainViewport({
     prevDesignatedTiles.current = designatedTiles;
     prevStockpileTiles.current = stockpileTiles;
     prevGroundItems.current = groundItems;
+    prevBuildProgressTiles.current = buildProgressTiles;
     setDataVersion((v) => v + 1);
   }
 
@@ -181,11 +189,16 @@ export default function MainViewport({
           const glyph = FORTRESS_GLYPHS[tile.tileType] ?? { ch: "?", fg: "#f00" };
           const isStockpile = stockpileTilesRef.current?.has(`${wx},${wy},${zLevelRef.current}`);
           if (taskType) {
+            const buildPct = buildProgressTilesRef.current?.get(key);
+            // Interpolate bg from dark brown (#442200) to amber (#886600) as progress increases
+            const bg = buildPct !== undefined && buildPct > 0
+              ? `rgb(${Math.round(0x44 + (0x88 - 0x44) * buildPct / 100)},${Math.round(0x22 + (0x66 - 0x22) * buildPct / 100)},0)`
+              : "#442200";
             const preview = DESIGNATION_PREVIEW[taskType];
             if (preview) {
-              return { ch: preview.ch, fg: preview.fg, bg: "#442200" };
+              return { ch: preview.ch, fg: preview.fg, bg };
             }
-            return { ...glyph, bg: "#442200" };
+            return { ...glyph, bg };
           }
           if (isStockpile) {
             return { ...glyph, bg: STOCKPILE_GLYPH.bg };

--- a/docs/system-overviews/dwarf-decision-making.md
+++ b/docs/system-overviews/dwarf-decision-making.md
@@ -1,0 +1,131 @@
+# Dwarf Decision-Making
+
+This document explains how dwarves decide what to do each simulation tick.
+
+## Overview
+
+Every simulation tick runs these phases in order:
+
+1. **needsDecay** — all needs (food, drink, sleep, etc.) tick down
+2. **taskExecution** — dwarves with a task make progress on it
+3. **needsSatisfaction** — dwarves check if a completed eat/drink/sleep task restored needs
+4. **idleWandering** — dwarves with no task are given a wander task
+5. **jobClaiming** — idle dwarves claim the highest-scoring pending task
+
+---
+
+## 1. Needs Decay
+
+Each tick, every living dwarf's needs drop by fixed amounts:
+
+| Need | Decay per tick | Trait modifier |
+|------|---------------|----------------|
+| Food | `FOOD_DECAY_PER_TICK` | — |
+| Drink | `DRINK_DECAY_PER_TICK` | — |
+| Sleep | `SLEEP_DECAY_PER_TICK` | — |
+| Social | `SOCIAL_DECAY_PER_TICK` | `trait_extraversion` (extraverts decay faster) |
+| Purpose | `PURPOSE_DECAY_PER_TICK` | — |
+| Beauty | `BEAUTY_DECAY_PER_TICK` | — |
+
+When a need reaches 0 for too long, the dwarf dies. Food and drink deprivation cause death; sleep deprivation causes tantrums.
+
+---
+
+## 2. Task Execution
+
+For each dwarf with a `current_task_id`:
+
+1. **Move toward the task site** (one BFS step per tick). Mining and build_wall tasks require the dwarf to stand *adjacent* to the target; all others require standing *on* the target.
+2. **Do work** — increment `task.work_progress` by the work rate:
+   ```
+   workRate = (BASE_WORK_RATE × (1 + skillLevel × 0.1) × conscientiousnessModifier) / hardness
+   ```
+   - `BASE_WORK_RATE = 1`
+   - Skill modifier: +10% per skill level in the relevant skill
+   - `conscientiousnessModifier`: 0.75x (lazy) → 1.25x (diligent) based on `trait_conscientiousness`
+   - `hardness`: 0.3 for soil, 1.0 for stone, 1.2–1.5 for ore/gem/lava
+3. **Complete the task** when `work_progress >= work_required`. Side effects:
+   - `eat` / `drink` → restore the need, increment XP
+   - `sleep` → restore `need_sleep` (also ticks up every tick while sleeping)
+   - `mine` → change the tile to `open_air`, add ore/gem items, award XP
+   - `build_*` → place the constructed tile (wall, floor, bed, well, etc.), award XP
+   - `haul` → move an item to the stockpile
+   - `wander` → just cancels, no effect
+
+If the dwarf can't find a path to the task, the task reverts to `pending` and the dwarf becomes idle. Wander tasks are marked `completed` instead of reverting.
+
+---
+
+## 3. Needs Satisfaction Check
+
+After task execution, the sim checks whether any recently-completed eat/drink tasks should grant need restoration. This phase handles the case where need values need to be updated after a task completes.
+
+---
+
+## 4. Idle Wandering
+
+Dwarves with no current task are assigned a `wander` task to a random walkable tile within `WANDER_RADIUS` tiles. This prevents dwarves from standing still while waiting for work. The wander task takes 1 tick of work to complete (just movement).
+
+---
+
+## 5. Job Claiming
+
+This is where the real decision-making happens.
+
+### Eligibility
+
+A dwarf can claim a task if:
+- The task status is `pending`
+- The task is not autonomous (eat/drink/sleep/wander tasks are self-claimed only)
+- The dwarf has the required skill, if any (mine requires `mining`; build_* requires `building`; farm_* requires `farming`)
+- The dwarf is not over carry capacity for mine tasks
+
+Autonomous tasks (eat, drink, sleep) are pre-assigned to a specific dwarf. They enter the queue via the needs-satisfaction or other phases and can only be claimed by `assigned_dwarf_id`.
+
+### Scoring
+
+For each (dwarf, task) pair, the sim computes a score:
+
+```
+score = (task.priority × SCORE_PRIORITY_WEIGHT)
+      + (skillLevel × SCORE_SKILL_WEIGHT)
+      + (hasRequiredSkill ? SCORE_BEST_SKILL_BONUS : 0)
+      - (distanceToTask × SCORE_DISTANCE_WEIGHT)
+```
+
+| Constant | Value | Effect |
+|----------|-------|--------|
+| `SCORE_PRIORITY_WEIGHT` | 3 | Higher-priority tasks win |
+| `SCORE_SKILL_WEIGHT` | 2 | Skilled dwarves prefer matching tasks |
+| `SCORE_BEST_SKILL_BONUS` | 5 | Big bonus for having the right skill |
+| `SCORE_DISTANCE_WEIGHT` | 0.5 | Nearby tasks are slightly preferred |
+
+The idle dwarf is assigned the highest-scoring task. Multiple dwarves can't claim the same task in one tick — a task transitions from `pending` → `claimed` when assigned, preventing double-assignment.
+
+### Task priority
+
+Default priorities are configured in TaskPriorities (player-adjustable). High priority tasks are worth 3× as much as low priority ones. The player can raise mining priority so dwarves prefer digging over hauling, for example.
+
+---
+
+## Task Status Flow
+
+```
+pending → claimed → in_progress → completed
+                               ↘ failed (no path found, reset to pending)
+```
+
+Wander tasks: `pending → in_progress → completed` (never reverted, never re-queued by the player).
+
+---
+
+## Personality Trait Effects
+
+| Trait | Range | Effect |
+|-------|-------|--------|
+| `trait_conscientiousness` | 0–1 | Work rate multiplier (0 = 0.75×, 0.5 = 1×, 1 = 1.25×) |
+| `trait_extraversion` | 0–1 | Social need decays faster for extraverts |
+| `trait_neuroticism` | 0–1 | Stress increases faster for neurotic dwarves |
+| `trait_agreeableness` | 0–1 | Agreeable dwarves recover stress faster when comfortable |
+
+All traits are 0–1 floats with 0.5 as the neutral/average value.


### PR DESCRIPTION
## Summary

- Canvas designation overlay: color interpolates from dark brown → amber as construction progresses (pending stays dark, 100% complete = gold background)
- BottomBar tile label shows `[building: build wall 73%]` when a task is `in_progress` at that tile
- Dwarf modal Status line shows `build wall (73%)` instead of just `Working`; autonomous tasks (eat/drink/sleep/wander) show the task name without %
- Added `docs/system-overviews/dwarf-decision-making.md` explaining the full job-claiming pipeline, scoring formula, need decay, and trait effects

## Test plan
- [x] `npm run build` clean
- [ ] Playtest: designate a wall, watch a dwarf build it — tile should darken → amber; BottomBar should show %; dwarf modal should show task name + %

## Claude Cost
**Claude cost:** $81.06 (217.4M tokens)