### PR TITLE
fix: sidebar shows task label+% matching modal; halve build work constants (closes #349, closes #351)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -398,6 +398,7 @@ export default function App() {
           dwarves={liveDwarves}
           onDwarfClick={world.mode === "fortress" ? (id: string) => setModalDwarfId(id) : undefined}
           items={liveItems}
+          tasks={world.mode === "fortress" ? liveTasks : undefined}
           selectedFortressTile={world.mode === "fortress" ? selectedFortressTile : undefined}
           stockpileTiles={world.mode === "fortress" ? stockpileTiles : undefined}
           zLevel={zLevel}

--- a/app/src/components/LeftPanel.tsx
+++ b/app/src/components/LeftPanel.tsx
@@ -1,5 +1,8 @@
 import type { WorldTile, Item } from "@pwarf/shared";
 import type { LiveDwarf } from "../hooks/useDwarves";
+import type { ActiveTask } from "../hooks/useTasks";
+
+const AUTONOMOUS_TASK_TYPES: ReadonlySet<string> = new Set(['eat', 'drink', 'sleep', 'wander']);
 
 interface LeftPanelProps {
   mode: "fortress" | "world";
@@ -10,17 +13,23 @@ interface LeftPanelProps {
   dwarves?: LiveDwarf[];
   onDwarfClick?: (dwarfId: string) => void;
   items?: Item[];
+  tasks?: ActiveTask[];
   selectedFortressTile?: { x: number; y: number } | null;
   stockpileTiles?: Set<string>;
   zLevel?: number;
 }
 
-function dwarfJobLabel(d: LiveDwarf): string {
-  if (d.current_task_id) return "Working";
-  return "Idle";
+function dwarfJobLabel(d: LiveDwarf, tasks?: ActiveTask[]): string {
+  if (!d.current_task_id) return "Idle";
+  const task = tasks?.find(t => t.id === d.current_task_id);
+  if (!task) return "Working";
+  const label = task.task_type.replace(/_/g, " ");
+  if (AUTONOMOUS_TASK_TYPES.has(task.task_type) || task.work_required === 0) return label;
+  const pct = Math.round((task.work_progress / task.work_required) * 100);
+  return `${label} (${pct}%)`;
 }
 
-export default function LeftPanel({ mode, collapsed, onToggle, cursorTile, onEmbark, dwarves = [], onDwarfClick, items = [], selectedFortressTile, stockpileTiles, zLevel = 0 }: LeftPanelProps) {
+export default function LeftPanel({ mode, collapsed, onToggle, cursorTile, onEmbark, dwarves = [], onDwarfClick, items = [], tasks, selectedFortressTile, stockpileTiles, zLevel = 0 }: LeftPanelProps) {
   const isOcean = cursorTile?.terrain === "ocean";
 
   return (
@@ -86,7 +95,7 @@ export default function LeftPanel({ mode, collapsed, onToggle, cursorTile, onEmb
                       <span className="text-[var(--green)]">{d.name}</span>
                       <span className="text-[var(--text)]">
                         <span className="text-[var(--border)] mr-1">z{d.position_z}</span>
-                        {dwarfJobLabel(d)}
+                        {dwarfJobLabel(d, tasks)}
                       </span>
                     </li>
                   ))}

--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -252,19 +252,19 @@ export const WORK_SLEEP = 16;
 export const SLEEP_RESTORE_PER_TICK = SLEEP_RESTORE_AMOUNT / WORK_SLEEP;
 
 /** Work required to build a wall */
-export const WORK_BUILD_WALL = 80;
+export const WORK_BUILD_WALL = 40;
 
 /** Work required to build a floor */
-export const WORK_BUILD_FLOOR = 50;
+export const WORK_BUILD_FLOOR = 25;
 
 /** Work required to build a bed */
-export const WORK_BUILD_BED = 60;
+export const WORK_BUILD_BED = 30;
 
 /** Work required to build a well */
-export const WORK_BUILD_WELL = 120;
+export const WORK_BUILD_WELL = 60;
 
 /** Work required to build a mushroom garden */
-export const WORK_BUILD_MUSHROOM_GARDEN = 100;
+export const WORK_BUILD_MUSHROOM_GARDEN = 50;
 
 /** Work required to wander (just walking, instant once arrived) */
 export const WORK_WANDER = 1;


### PR DESCRIPTION
## Summary

- **#349 — Sidebar status**: `LeftPanel` now accepts `tasks` and shows the same task label as `DwarfModal` — e.g. `mine (73%)`, `eat`, `wander` — instead of always showing `Working`.
- **#351 — Build speed**: Halved all `WORK_BUILD_*` constants (wall 80→40, floor 50→25, bed 60→30, well 120→60, mushroom garden 100→50). At base work rate (1/tick, 10 ticks/s) this takes walls from ~8s to ~4s.

## Test plan

- [x] `npm run build` — no type errors
- [x] `npm test` — 357 tests pass

## Claude Cost

**Claude cost:** $1.27 (3.4M tokens)