### PR TITLE
fix: correct tick count in personality-traits test

### DIFF
--- a/sim/src/__tests__/personality-traits.test.ts
+++ b/sim/src/__tests__/personality-traits.test.ts
@@ -29,9 +29,10 @@ describe("conscientiousness affects work speed", () => {
     });
     lazyDwarf.current_task_id = lazyTask.id;
 
-    // Use enough ticks for the lazy dwarf to almost but not quite finish
-    // WORK_BUILD_FLOOR=50, lazy modifier=0.75, so lazy needs ~67 ticks
-    const TICKS = 60;
+    // Use enough ticks for the lazy dwarf to almost but not quite finish.
+    // WORK_BUILD_FLOOR=25, diligent modifier=1.25 → done in 20 ticks,
+    // lazy modifier=0.75 → needs 34 ticks.
+    const TICKS = 25;
 
     const [diligentResult, lazyResult] = await Promise.all([
       runScenario({ dwarves: [diligentDwarf], tasks: [diligentTask], ticks: TICKS }),


### PR DESCRIPTION
## Summary
Test comment said `WORK_BUILD_FLOOR=50` but the constant is 25. With `TICKS=60` both dwarves finished, making the `not.toBe('completed')` assertion fail. Updated to `TICKS=25` — diligent dwarf finishes in 20 ticks, lazy needs 34.

## Test plan
- [x] `npm test --workspace=sim` — 357 tests pass

## Claude Cost
**Claude cost:** $3.03 (6.5M tokens)