### PR TITLE
feat: yearly immigration — new dwarves arrive each year

### DIFF
--- a/app/src/lib/dwarf-names.ts
+++ b/app/src/lib/dwarf-names.ts
@@ -1,17 +1,10 @@
-export const DWARF_NAMES = [
-  'Urist', 'Doren', 'Kadol', 'Aban', 'Likot', 'Morul', 'Fikod',
-  'Bomrek', 'Ducim', 'Erith', 'Goden', 'Ingiz', 'Kumil', 'Litast',
-  'Mosus', 'Nish', 'Olon', 'Rigoth', 'Sodel', 'Tekkud',
-];
+import { DWARF_FIRST_NAMES, DWARF_SURNAMES } from '@pwarf/shared';
 
-export const SURNAMES = [
-  'Hammerstone', 'Ironpick', 'Deepdelve', 'Coppervein', 'Granitearm',
-  'Boulderfist', 'Axebeard', 'Goldseam', 'Rockjaw', 'Tunnelborn',
-];
+export { DWARF_FIRST_NAMES as DWARF_NAMES, DWARF_SURNAMES as SURNAMES };
 
 /** Pick `count` unique names from the name list */
 export function pickUniqueNames(count: number): string[] {
-  const pool = [...DWARF_NAMES];
+  const pool = [...DWARF_FIRST_NAMES];
   const picked: string[] = [];
   for (let i = 0; i < count && pool.length > 0; i++) {
     const idx = Math.floor(Math.random() * pool.length);

--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -146,6 +146,29 @@ export const ELDER_DEATH_AGE = 80;
 export const ELDER_DEATH_CHANCE_PER_YEAR = 0.1;
 
 // ============================================================
+// Immigration
+// ============================================================
+
+/** Probability of an immigration wave arriving each year (starting year 2). */
+export const IMMIGRATION_CHANCE_PER_YEAR = 0.6;
+
+/** Maximum number of immigrants that can arrive in a single wave. */
+export const IMMIGRATION_MAX_ARRIVALS = 3;
+
+/** Dwarf first names — shared between sim (immigration) and app (embark). */
+export const DWARF_FIRST_NAMES = [
+  'Urist', 'Doren', 'Kadol', 'Aban', 'Likot', 'Morul', 'Fikod',
+  'Bomrek', 'Ducim', 'Erith', 'Goden', 'Ingiz', 'Kumil', 'Litast',
+  'Mosus', 'Nish', 'Olon', 'Rigoth', 'Sodel', 'Tekkud',
+];
+
+/** Dwarf clan surnames — shared between sim (immigration) and app (embark). */
+export const DWARF_SURNAMES = [
+  'Hammerstone', 'Ironpick', 'Deepdelve', 'Coppervein', 'Granitearm',
+  'Boulderfist', 'Axebeard', 'Goldseam', 'Rockjaw', 'Tunnelborn',
+];
+
+// ============================================================
 // Stress severity tiers
 // ============================================================
 

--- a/sim/src/__tests__/immigration.test.ts
+++ b/sim/src/__tests__/immigration.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { yearlyRollup } from '../phases/yearly-rollup.js';
+import { createRng } from '../rng.js';
+import { createTestContext } from '../sim-context.js';
+import { IMMIGRATION_CHANCE_PER_YEAR } from '@pwarf/shared';
+
+describe('yearly immigration', () => {
+  it('does not add immigrants in year 1', async () => {
+    const ctx = createTestContext();
+    ctx.year = 1;
+    const before = ctx.state.dwarves.length;
+    await yearlyRollup(ctx);
+    expect(ctx.state.dwarves.length).toBe(before);
+  });
+
+  it('can add immigrants starting from year 2', async () => {
+    // Use a seed that guarantees the immigration roll passes
+    // IMMIGRATION_CHANCE_PER_YEAR = 0.6, so most seeds will trigger it
+    let arrived = false;
+    for (let seed = 0; seed < 20; seed++) {
+      const ctx = createTestContext();
+      ctx.rng = createRng(seed);
+      ctx.year = 2;
+      const before = ctx.state.dwarves.length;
+      await yearlyRollup(ctx);
+      if (ctx.state.dwarves.length > before) {
+        arrived = true;
+        break;
+      }
+    }
+    expect(arrived).toBe(true);
+  });
+
+  it('adds 1–3 immigrants per wave', async () => {
+    // Try many seeds and confirm all waves are size 1–3
+    for (let seed = 0; seed < 50; seed++) {
+      const ctx = createTestContext();
+      ctx.rng = createRng(seed);
+      ctx.year = 5;
+      const before = ctx.state.dwarves.length;
+      await yearlyRollup(ctx);
+      const arrived = ctx.state.dwarves.length - before;
+      if (arrived > 0) {
+        expect(arrived).toBeGreaterThanOrEqual(1);
+        expect(arrived).toBeLessThanOrEqual(3);
+      }
+    }
+  });
+
+  it('fires a migration event when immigrants arrive', async () => {
+    let migrationEventFired = false;
+    for (let seed = 0; seed < 20; seed++) {
+      const ctx = createTestContext();
+      ctx.rng = createRng(seed);
+      ctx.year = 2;
+      await yearlyRollup(ctx);
+      if (ctx.state.pendingEvents.some(e => e.category === 'migration')) {
+        migrationEventFired = true;
+        break;
+      }
+    }
+    expect(migrationEventFired).toBe(true);
+  });
+
+  it('marks new immigrants as dirty', async () => {
+    for (let seed = 0; seed < 20; seed++) {
+      const ctx = createTestContext();
+      ctx.rng = createRng(seed);
+      ctx.year = 3;
+      const beforeIds = new Set(ctx.state.dwarves.map(d => d.id));
+      await yearlyRollup(ctx);
+      const newDwarves = ctx.state.dwarves.filter(d => !beforeIds.has(d.id));
+      if (newDwarves.length > 0) {
+        for (const d of newDwarves) {
+          expect(ctx.state.dirtyDwarfIds.has(d.id)).toBe(true);
+        }
+        break;
+      }
+    }
+  });
+
+  it(`immigration probability is ${IMMIGRATION_CHANCE_PER_YEAR}`, () => {
+    expect(IMMIGRATION_CHANCE_PER_YEAR).toBe(0.6);
+  });
+});

--- a/sim/src/dwarf-factory.test.ts
+++ b/sim/src/dwarf-factory.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { createImmigrantDwarf } from './dwarf-factory.js';
+import { createRng } from './rng.js';
+import { SURFACE_Z, DWARF_FIRST_NAMES, DWARF_SURNAMES } from '@pwarf/shared';
+
+describe('createImmigrantDwarf', () => {
+  const rng = createRng(42);
+
+  it('creates an alive dwarf at the specified spawn position', () => {
+    const d = createImmigrantDwarf(rng, 'civ-1', 3, 100, 200);
+    expect(d.status).toBe('alive');
+    expect(d.position_x).toBe(100);
+    expect(d.position_y).toBe(200);
+    expect(d.position_z).toBe(SURFACE_Z);
+    expect(d.civilization_id).toBe('civ-1');
+  });
+
+  it('assigns a name from the shared name lists', () => {
+    const rng2 = createRng(7);
+    const d = createImmigrantDwarf(rng2, 'civ-1', 2, 50, 50);
+    expect(DWARF_FIRST_NAMES).toContain(d.name);
+    expect(DWARF_SURNAMES).toContain(d.surname);
+  });
+
+  it('assigns age 20–40', () => {
+    const rng3 = createRng(99);
+    for (let i = 0; i < 20; i++) {
+      const d = createImmigrantDwarf(rng3, 'civ-1', 5, 0, 0);
+      expect(d.age).toBeGreaterThanOrEqual(20);
+      expect(d.age).toBeLessThanOrEqual(40);
+    }
+  });
+
+  it('assigns personality traits as floats in [0, 1]', () => {
+    const rng4 = createRng(13);
+    const d = createImmigrantDwarf(rng4, 'civ-1', 2, 0, 0);
+    for (const trait of [d.trait_openness, d.trait_conscientiousness, d.trait_extraversion, d.trait_agreeableness, d.trait_neuroticism]) {
+      expect(trait).not.toBeNull();
+      expect(trait!).toBeGreaterThanOrEqual(0);
+      expect(trait!).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('assigns full needs on arrival', () => {
+    const rng5 = createRng(1);
+    const d = createImmigrantDwarf(rng5, 'civ-1', 2, 0, 0);
+    expect(d.need_food).toBe(80);
+    expect(d.need_drink).toBe(80);
+    expect(d.need_sleep).toBe(80);
+  });
+
+  it('has no current task and zero stress', () => {
+    const rng6 = createRng(2);
+    const d = createImmigrantDwarf(rng6, 'civ-1', 2, 0, 0);
+    expect(d.current_task_id).toBeNull();
+    expect(d.stress_level).toBe(0);
+    expect(d.is_in_tantrum).toBe(false);
+  });
+});

--- a/sim/src/dwarf-factory.ts
+++ b/sim/src/dwarf-factory.ts
@@ -1,0 +1,58 @@
+import type { Dwarf } from '@pwarf/shared';
+import { DWARF_FIRST_NAMES, DWARF_SURNAMES, SURFACE_Z } from '@pwarf/shared';
+import type { Rng } from './rng.js';
+
+/**
+ * Create a single immigrant dwarf arriving at the fortress.
+ *
+ * Immigrants spawn at the fortress surface (z=0) near the center of the map.
+ * Names, gender, age, and personality traits are randomised.
+ */
+export function createImmigrantDwarf(
+  rng: Rng,
+  civilizationId: string,
+  year: number,
+  spawnX: number,
+  spawnY: number,
+): Dwarf {
+  const name = DWARF_FIRST_NAMES[rng.int(0, DWARF_FIRST_NAMES.length - 1)] ?? 'Urist';
+  const surname = DWARF_SURNAMES[rng.int(0, DWARF_SURNAMES.length - 1)] ?? 'Ironpick';
+  const gender = rng.random() < 0.5 ? 'male' : 'female';
+  const age = 20 + rng.int(0, 20); // 20–40
+
+  return {
+    id: rng.uuid(),
+    civilization_id: civilizationId,
+    name,
+    surname,
+    status: 'alive',
+    age,
+    gender,
+    born_year: year - age,
+    died_year: null,
+    cause_of_death: null,
+    need_food: 80,
+    need_drink: 80,
+    need_sleep: 80,
+    need_social: 60,
+    need_purpose: 60,
+    need_beauty: 50,
+    stress_level: 0,
+    is_in_tantrum: false,
+    health: 100,
+    injuries: [],
+    memories: [],
+    trait_openness: rng.random(),
+    trait_conscientiousness: rng.random(),
+    trait_extraversion: rng.random(),
+    trait_agreeableness: rng.random(),
+    trait_neuroticism: rng.random(),
+    religious_devotion: 0,
+    faction_id: null,
+    current_task_id: null,
+    position_x: spawnX,
+    position_y: spawnY,
+    position_z: SURFACE_Z,
+    created_at: new Date().toISOString(),
+  };
+}

--- a/sim/src/phases/yearly-rollup.ts
+++ b/sim/src/phases/yearly-rollup.ts
@@ -1,17 +1,25 @@
-import { ELDER_DEATH_AGE, ELDER_DEATH_CHANCE_PER_YEAR } from "@pwarf/shared";
+import {
+  ELDER_DEATH_AGE,
+  ELDER_DEATH_CHANCE_PER_YEAR,
+  IMMIGRATION_CHANCE_PER_YEAR,
+  IMMIGRATION_MAX_ARRIVALS,
+  FORTRESS_SIZE,
+} from "@pwarf/shared";
 import type { SimContext } from "../sim-context.js";
 import { dwarfName } from "../dwarf-utils.js";
+import { createImmigrantDwarf } from "../dwarf-factory.js";
 
 /**
  * Yearly Rollup Phase
  *
  * Runs once every STEPS_PER_YEAR steps. Handles long-cadence updates:
  * - Aging: increments dwarf ages, triggers old-age death checks
+ * - Immigration: new dwarves may arrive each year (starting year 2)
  *
- * Not yet implemented: skill ups, immigration, faction drift, disease, ruin decay.
+ * Not yet implemented: skill ups, faction drift, disease, ruin decay.
  */
 export async function yearlyRollup(ctx: SimContext): Promise<void> {
-  const { state } = ctx;
+  const { state, rng, year, civilizationId } = ctx;
 
   for (const dwarf of state.dwarves) {
     if (dwarf.status !== 'alive') continue;
@@ -24,9 +32,9 @@ export async function yearlyRollup(ctx: SimContext): Promise<void> {
     // Each year past ELDER_DEATH_AGE rolls independently
     if (dwarf.age > ELDER_DEATH_AGE) {
       const yearsOverLimit = dwarf.age - ELDER_DEATH_AGE;
-      if (ctx.rng.random() < ELDER_DEATH_CHANCE_PER_YEAR * yearsOverLimit) {
+      if (rng.random() < ELDER_DEATH_CHANCE_PER_YEAR * yearsOverLimit) {
         dwarf.status = 'dead';
-        dwarf.died_year = ctx.year;
+        dwarf.died_year = year;
         dwarf.cause_of_death = 'unknown';
 
         if (dwarf.current_task_id) {
@@ -39,11 +47,11 @@ export async function yearlyRollup(ctx: SimContext): Promise<void> {
         }
 
         state.pendingEvents.push({
-          id: ctx.rng.uuid(),
+          id: rng.uuid(),
           world_id: '',
-          year: ctx.year,
+          year,
           category: 'death',
-          civilization_id: ctx.civilizationId,
+          civilization_id: civilizationId,
           ruin_id: null,
           dwarf_id: dwarf.id,
           item_id: null,
@@ -55,5 +63,37 @@ export async function yearlyRollup(ctx: SimContext): Promise<void> {
         });
       }
     }
+  }
+
+  // Immigration — new dwarves arrive starting from year 2
+  if (year >= 2 && rng.random() < IMMIGRATION_CHANCE_PER_YEAR) {
+    const count = rng.int(1, IMMIGRATION_MAX_ARRIVALS);
+    const center = Math.floor(FORTRESS_SIZE / 2);
+    const immigrants = Array.from({ length: count }, (_, i) =>
+      createImmigrantDwarf(rng, civilizationId, year, center + i, center)
+    );
+
+    for (const immigrant of immigrants) {
+      state.dwarves.push(immigrant);
+      state.dirtyDwarfIds.add(immigrant.id);
+    }
+
+    const names = immigrants.map(d => dwarfName(d)).join(', ');
+    const noun = count === 1 ? 'dwarf has' : 'dwarves have';
+    state.pendingEvents.push({
+      id: rng.uuid(),
+      world_id: '',
+      year,
+      category: 'migration',
+      civilization_id: civilizationId,
+      ruin_id: null,
+      dwarf_id: null,
+      item_id: null,
+      faction_id: null,
+      monster_id: null,
+      description: `${count} new ${noun} arrived at the fortress: ${names}.`,
+      event_data: { count, names: immigrants.map(d => dwarfName(d)) },
+      created_at: new Date().toISOString(),
+    });
   }
 }


### PR DESCRIPTION
## Summary

- Starting from year 2, there's a **60% chance per year** that 1–3 new dwarves migrate to the fortress
- Each immigrant is randomly generated: name (from shared name list), gender, age 20–40, all 5 OCEAN personality traits
- Immigrants spawn at the fortress center (z=0) and appear immediately in the UI
- A `migration` world event is fired: `"3 new dwarves have arrived at the fortress: Urist Ironpick, Doren Hammerstone, Kadol Deepdelve."`
- `DWARF_FIRST_NAMES` and `DWARF_SURNAMES` moved from `app/src/lib/dwarf-names.ts` to `@pwarf/shared` — eliminates duplicate constants

Closes #370

## Test plan

- Sim logic only — verified with `runScenario()`-style unit tests
- [ ] `src/dwarf-factory.test.ts` — 6 tests for immigrant dwarf creation
- [ ] `src/__tests__/immigration.test.ts` — 5 tests for yearly immigration logic

429/429 tests pass.

## Claude Cost
**Claude cost:** $0.41 (1.1M tokens)