### PR TITLE
feat: crafting tasks — smooth, engrave, brew, cook, smith

### DIFF
--- a/app/src/components/tile-glyphs.ts
+++ b/app/src/components/tile-glyphs.ts
@@ -42,6 +42,9 @@ export const FORTRESS_GLYPHS: Record<FortressTileType, { ch: string; fg: string 
   ice:                { ch: "≈",  fg: "#aaddff" },
   mud:                { ch: "≈",  fg: "#665533" },
   cave_entrance:      { ch: "\u25BC", fg: "#886644" },
+  smooth_stone:       { ch: "\u2591", fg: "#aaa" },
+  engraved_stone:     { ch: "\u2593", fg: "#ddbbaa" },
+  engraved_floor:     { ch: "+",  fg: "#ddbbaa" },
   empty:              { ch: " ",  fg: "#000" },
 };
 

--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -272,6 +272,21 @@ export const WORK_DECONSTRUCT = 30;
 /** Work required to wander (just walking, instant once arrived) */
 export const WORK_WANDER = 1;
 
+/** Work required to smooth a stone tile */
+export const WORK_SMOOTH = 80;
+
+/** Work required to engrave a smoothed tile */
+export const WORK_ENGRAVE = 60;
+
+/** Work required to brew a batch of ale */
+export const WORK_BREW = 50;
+
+/** Work required to cook a meal */
+export const WORK_COOK = 40;
+
+/** Work required to smith an item */
+export const WORK_SMITH = 70;
+
 /** Max distance a dwarf will wander from current position */
 export const WANDER_RADIUS = 8;
 
@@ -295,6 +310,11 @@ export const XP_FARM_PLANT = 10;
 export const XP_FARM_HARVEST = 10;
 export const XP_BUILD = 12;
 export const XP_HAUL = 5;
+export const XP_SMOOTH = 8;
+export const XP_ENGRAVE = 10;
+export const XP_BREW = 12;
+export const XP_COOK = 12;
+export const XP_SMITH = 15;
 
 // ============================================================
 // Inventory & stockpile

--- a/shared/src/db-types.ts
+++ b/shared/src/db-types.ts
@@ -162,7 +162,12 @@ export type TaskType =
   | 'build_well'
   | 'build_mushroom_garden'
   | 'deconstruct'
-  | 'wander';
+  | 'wander'
+  | 'smooth'
+  | 'engrave'
+  | 'brew'
+  | 'cook'
+  | 'smith';
 
 export type TaskStatus =
   | 'pending'
@@ -197,6 +202,9 @@ export type FortressTileType =
   | 'ice'
   | 'mud'
   | 'cave_entrance'
+  | 'smooth_stone'
+  | 'engraved_stone'
+  | 'engraved_floor'
   | 'empty';
 
 // ============================================================

--- a/sim/src/__tests__/crafting.test.ts
+++ b/sim/src/__tests__/crafting.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from "vitest";
+import { createTestContext } from "../sim-context.js";
+import { makeDwarf, makeTask, makeItem } from "./test-helpers.js";
+import {
+  completeBrew,
+  completeCook,
+  completeSmith,
+  restorePurposeNeed,
+  SMOOTHABLE_TILES,
+} from "../phases/task-completion.js";
+
+// ---------------------------------------------------------------------------
+// completeBrew
+// ---------------------------------------------------------------------------
+
+describe("completeBrew", () => {
+  it("consumes a plant item at the target tile and creates a drink", () => {
+    const ctx = createTestContext();
+    const dwarf = makeDwarf({ position_x: 5, position_y: 5 });
+    ctx.state.dwarves = [dwarf];
+
+    const plant = makeItem({
+      category: "raw_material",
+      material: "plant",
+      position_x: 5,
+      position_y: 5,
+      position_z: 0,
+    });
+    ctx.state.items = [plant];
+
+    const task = makeTask("brew", {
+      target_x: 5,
+      target_y: 5,
+      target_z: 0,
+    });
+
+    completeBrew(dwarf, task, ctx);
+
+    // Plant item should be consumed
+    expect(ctx.state.items.find(i => i.id === plant.id)).toBeUndefined();
+
+    // A drink item should be created at the target location
+    const ale = ctx.state.items.find(i => i.category === "drink");
+    expect(ale).toBeDefined();
+    expect(ale?.position_x).toBe(5);
+    expect(ale?.position_y).toBe(5);
+  });
+
+  it("creates a drink even if no plant ingredient is available", () => {
+    const ctx = createTestContext();
+    const dwarf = makeDwarf();
+    const task = makeTask("brew", { target_x: 0, target_y: 0, target_z: 0 });
+
+    completeBrew(dwarf, task, ctx);
+
+    const ale = ctx.state.items.find(i => i.category === "drink");
+    expect(ale).toBeDefined();
+  });
+
+  it("consumes a plant held by the dwarf if none at tile", () => {
+    const ctx = createTestContext();
+    const dwarf = makeDwarf({ id: "dwarf-1" });
+    ctx.state.dwarves = [dwarf];
+
+    const plant = makeItem({
+      category: "raw_material",
+      material: "plant",
+      held_by_dwarf_id: "dwarf-1",
+    });
+    ctx.state.items = [plant];
+
+    const task = makeTask("brew", { target_x: 1, target_y: 1, target_z: 0 });
+    completeBrew(dwarf, task, ctx);
+
+    expect(ctx.state.items.find(i => i.id === plant.id)).toBeUndefined();
+    expect(ctx.state.items.find(i => i.category === "drink")).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// completeCook
+// ---------------------------------------------------------------------------
+
+describe("completeCook", () => {
+  it("consumes a food item and creates a prepared meal", () => {
+    const ctx = createTestContext();
+    const dwarf = makeDwarf({ position_x: 3, position_y: 3 });
+    ctx.state.dwarves = [dwarf];
+
+    const food = makeItem({
+      category: "food",
+      position_x: 3,
+      position_y: 3,
+      position_z: 0,
+    });
+    ctx.state.items = [food];
+
+    const task = makeTask("cook", { target_x: 3, target_y: 3, target_z: 0 });
+    completeCook(dwarf, task, ctx);
+
+    expect(ctx.state.items.find(i => i.id === food.id)).toBeUndefined();
+    const meal = ctx.state.items.find(i => i.name === "Prepared meal");
+    expect(meal).toBeDefined();
+    expect(meal?.quality).toBe("fine");
+    expect(meal?.value).toBeGreaterThan(2);
+  });
+
+  it("creates a meal even without an ingredient", () => {
+    const ctx = createTestContext();
+    const dwarf = makeDwarf();
+    const task = makeTask("cook", { target_x: 0, target_y: 0, target_z: 0 });
+    completeCook(dwarf, task, ctx);
+    expect(ctx.state.items.find(i => i.name === "Prepared meal")).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// completeSmith
+// ---------------------------------------------------------------------------
+
+describe("completeSmith", () => {
+  it("consumes a raw_material and creates a tool", () => {
+    const ctx = createTestContext();
+    const dwarf = makeDwarf({ position_x: 2, position_y: 2 });
+
+    const ore = makeItem({
+      category: "raw_material",
+      material: "iron",
+      position_x: 2,
+      position_y: 2,
+      position_z: 0,
+    });
+    ctx.state.items = [ore];
+
+    const task = makeTask("smith", { target_x: 2, target_y: 2, target_z: 0 });
+    completeSmith(dwarf, task, ctx);
+
+    expect(ctx.state.items.find(i => i.id === ore.id)).toBeUndefined();
+    const tool = ctx.state.items.find(i => i.category === "tool");
+    expect(tool).toBeDefined();
+    expect(tool?.material).toBe("iron");
+  });
+
+  it("creates a tool with stone material if no ore available", () => {
+    const ctx = createTestContext();
+    const dwarf = makeDwarf();
+    const task = makeTask("smith", { target_x: 0, target_y: 0, target_z: 0 });
+    completeSmith(dwarf, task, ctx);
+    const tool = ctx.state.items.find(i => i.category === "tool");
+    expect(tool).toBeDefined();
+    expect(tool?.material).toBe("stone");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// restorePurposeNeed — crafting tasks are SKILLED_TASKS
+// ---------------------------------------------------------------------------
+
+describe("restorePurposeNeed for crafting tasks", () => {
+  it.each(["smooth", "engrave", "brew", "cook", "smith"] as const)(
+    "%s restores purpose like a skilled task",
+    (taskType) => {
+      const dwarf = makeDwarf({ need_purpose: 50 });
+      restorePurposeNeed(dwarf, taskType);
+      expect(dwarf.need_purpose).toBeGreaterThan(50);
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// SMOOTHABLE_TILES constant
+// ---------------------------------------------------------------------------
+
+describe("SMOOTHABLE_TILES", () => {
+  it("contains rock and stone", () => {
+    expect(SMOOTHABLE_TILES.has("rock")).toBe(true);
+    expect(SMOOTHABLE_TILES.has("stone")).toBe(true);
+  });
+
+  it("does not contain open_air", () => {
+    expect(SMOOTHABLE_TILES.has("open_air")).toBe(false);
+  });
+});

--- a/sim/src/phases/task-completion.ts
+++ b/sim/src/phases/task-completion.ts
@@ -9,6 +9,11 @@ import {
   XP_FARM_HARVEST,
   XP_BUILD,
   XP_HAUL,
+  XP_SMOOTH,
+  XP_ENGRAVE,
+  XP_BREW,
+  XP_COOK,
+  XP_SMITH,
   PURPOSE_RESTORE_SKILLED,
   PURPOSE_RESTORE_HAUL,
   PURPOSE_RESTORE_DEFAULT,
@@ -110,6 +115,26 @@ export function completeTask(dwarf: Dwarf, task: Task, ctx: SimContext): void {
       completeDeconstruct(task, ctx);
       awardXp(dwarf.id, 'building', XP_BUILD, state);
       break;
+    case 'smooth':
+      completeSmooth(task, ctx);
+      awardXp(dwarf.id, 'building', XP_SMOOTH, state);
+      break;
+    case 'engrave':
+      completeEngrave(task, ctx);
+      awardXp(dwarf.id, 'engraving', XP_ENGRAVE, state);
+      break;
+    case 'brew':
+      completeBrew(dwarf, task, ctx);
+      awardXp(dwarf.id, 'brewing', XP_BREW, state);
+      break;
+    case 'cook':
+      completeCook(dwarf, task, ctx);
+      awardXp(dwarf.id, 'cooking', XP_COOK, state);
+      break;
+    case 'smith':
+      completeSmith(dwarf, task, ctx);
+      awardXp(dwarf.id, 'smithing', XP_SMITH, state);
+      break;
   }
 
   // Purpose restoration: work gives dwarves a sense of meaning
@@ -122,7 +147,7 @@ export function completeTask(dwarf: Dwarf, task: Task, ctx: SimContext): void {
  * Exported for unit testing.
  */
 export function restorePurposeNeed(dwarf: Dwarf, taskType: string): void {
-  const SKILLED_TASKS = new Set(['mine', 'build_wall', 'build_floor', 'build_bed', 'build_well', 'build_mushroom_garden', 'deconstruct', 'farm_till', 'farm_plant', 'farm_harvest']);
+  const SKILLED_TASKS = new Set(['mine', 'build_wall', 'build_floor', 'build_bed', 'build_well', 'build_mushroom_garden', 'deconstruct', 'farm_till', 'farm_plant', 'farm_harvest', 'smooth', 'engrave', 'brew', 'cook', 'smith']);
   const restore = SKILLED_TASKS.has(taskType)
     ? PURPOSE_RESTORE_SKILLED
     : taskType === 'haul'
@@ -449,6 +474,179 @@ function completeDeconstruct(task: Task, ctx: SimContext): void {
 
   // Restore tile to open_air
   upsertFortressTile(ctx, task.target_x, task.target_y, task.target_z, 'open_air', null, false);
+}
+
+/** Smoothable source tile types (can be designated for smoothing). */
+export const SMOOTHABLE_TILES = new Set<string>([
+  'rock', 'stone', 'cavern_wall', 'cavern_floor', 'constructed_wall', 'constructed_floor',
+]);
+
+function completeSmooth(task: Task, ctx: SimContext): void {
+  if (task.target_x === null || task.target_y === null || task.target_z === null) return;
+
+  const key = `${task.target_x},${task.target_y},${task.target_z}`;
+  const existing = ctx.state.fortressTileOverrides.get(key);
+  const currentType = existing?.tile_type ?? null;
+
+  // Floors become engraved_floor candidate; walls become smooth_stone
+  const resultType: FortressTileType =
+    currentType === 'cavern_floor' || currentType === 'constructed_floor' ? 'smooth_stone' : 'smooth_stone';
+
+  upsertFortressTile(ctx, task.target_x, task.target_y, task.target_z, resultType, existing?.material ?? null, existing?.is_mined ?? false);
+}
+
+function completeEngrave(task: Task, ctx: SimContext): void {
+  if (task.target_x === null || task.target_y === null || task.target_z === null) return;
+
+  const key = `${task.target_x},${task.target_y},${task.target_z}`;
+  const existing = ctx.state.fortressTileOverrides.get(key);
+  const currentType = existing?.tile_type;
+
+  // Only engrave smooth stone or constructed floors
+  if (currentType !== 'smooth_stone') return;
+
+  upsertFortressTile(ctx, task.target_x, task.target_y, task.target_z, 'engraved_stone', existing?.material ?? null, existing?.is_mined ?? false);
+}
+
+/**
+ * Brew: consumes a plant item at the target tile, creates an ale (drink item).
+ * Exported for unit testing.
+ */
+export function completeBrew(dwarf: Dwarf, task: Task, ctx: SimContext): void {
+  if (task.target_x === null || task.target_y === null || task.target_z === null) return;
+
+  // Consume a plant (raw_material) item at the target tile (or anywhere in inventory)
+  const plant = findItemAt(ctx, task.target_x, task.target_y, task.target_z, 'raw_material') ??
+    findItemHeldBy(ctx, dwarf.id, 'raw_material');
+  if (plant) {
+    const idx = ctx.state.items.findIndex(i => i.id === plant.id);
+    if (idx !== -1) ctx.state.items.splice(idx, 1);
+    ctx.state.dirtyItemIds.add(plant.id);
+  }
+
+  // Produce ale drink item
+  const ale: Item = {
+    id: ctx.rng.uuid(),
+    name: 'Plump helmet brew',
+    category: 'drink',
+    quality: 'standard',
+    material: 'plant',
+    weight: 1,
+    value: 3,
+    is_artifact: false,
+    created_by_dwarf_id: dwarf.id,
+    created_in_civ_id: ctx.civilizationId,
+    created_year: ctx.year,
+    held_by_dwarf_id: null,
+    located_in_civ_id: ctx.civilizationId,
+    located_in_ruin_id: null,
+    position_x: task.target_x,
+    position_y: task.target_y,
+    position_z: task.target_z,
+    lore: null,
+    properties: {},
+    created_at: new Date().toISOString(),
+  };
+  ctx.state.items.push(ale);
+  ctx.state.dirtyItemIds.add(ale.id);
+}
+
+/**
+ * Cook: consumes a food item at the target tile, creates a prepared meal (higher value).
+ * Exported for unit testing.
+ */
+export function completeCook(dwarf: Dwarf, task: Task, ctx: SimContext): void {
+  if (task.target_x === null || task.target_y === null || task.target_z === null) return;
+
+  const ingredient = findItemAt(ctx, task.target_x, task.target_y, task.target_z, 'food') ??
+    findItemHeldBy(ctx, dwarf.id, 'food');
+  if (ingredient) {
+    const idx = ctx.state.items.findIndex(i => i.id === ingredient.id);
+    if (idx !== -1) ctx.state.items.splice(idx, 1);
+    ctx.state.dirtyItemIds.add(ingredient.id);
+  }
+
+  const meal: Item = {
+    id: ctx.rng.uuid(),
+    name: 'Prepared meal',
+    category: 'food',
+    quality: 'fine',
+    material: 'cooked',
+    weight: 1,
+    value: 5,
+    is_artifact: false,
+    created_by_dwarf_id: dwarf.id,
+    created_in_civ_id: ctx.civilizationId,
+    created_year: ctx.year,
+    held_by_dwarf_id: null,
+    located_in_civ_id: ctx.civilizationId,
+    located_in_ruin_id: null,
+    position_x: task.target_x,
+    position_y: task.target_y,
+    position_z: task.target_z,
+    lore: null,
+    properties: {},
+    created_at: new Date().toISOString(),
+  };
+  ctx.state.items.push(meal);
+  ctx.state.dirtyItemIds.add(meal.id);
+}
+
+/**
+ * Smith: consumes an ore/metal raw_material item, creates a tool.
+ * Exported for unit testing.
+ */
+export function completeSmith(dwarf: Dwarf, task: Task, ctx: SimContext): void {
+  if (task.target_x === null || task.target_y === null || task.target_z === null) return;
+
+  const ore = findItemAt(ctx, task.target_x, task.target_y, task.target_z, 'raw_material') ??
+    findItemHeldBy(ctx, dwarf.id, 'raw_material');
+  if (ore) {
+    const idx = ctx.state.items.findIndex(i => i.id === ore.id);
+    if (idx !== -1) ctx.state.items.splice(idx, 1);
+    ctx.state.dirtyItemIds.add(ore.id);
+  }
+
+  const tool: Item = {
+    id: ctx.rng.uuid(),
+    name: 'Stone pick',
+    category: 'tool',
+    quality: 'standard',
+    material: ore?.material ?? 'stone',
+    weight: 3,
+    value: 8,
+    is_artifact: false,
+    created_by_dwarf_id: dwarf.id,
+    created_in_civ_id: ctx.civilizationId,
+    created_year: ctx.year,
+    held_by_dwarf_id: null,
+    located_in_civ_id: ctx.civilizationId,
+    located_in_ruin_id: null,
+    position_x: task.target_x,
+    position_y: task.target_y,
+    position_z: task.target_z,
+    lore: null,
+    properties: {},
+    created_at: new Date().toISOString(),
+  };
+  ctx.state.items.push(tool);
+  ctx.state.dirtyItemIds.add(tool.id);
+}
+
+/** Find the first item at a given tile position with the given category. */
+function findItemAt(ctx: SimContext, x: number, y: number, z: number, category: string): Item | undefined {
+  return ctx.state.items.find(
+    i => i.category === category
+      && i.position_x === x
+      && i.position_y === y
+      && i.position_z === z
+      && i.held_by_dwarf_id === null,
+  );
+}
+
+/** Find the first item held by a dwarf with the given category. */
+function findItemHeldBy(ctx: SimContext, dwarfId: string, category: string): Item | undefined {
+  return ctx.state.items.find(i => i.category === category && i.held_by_dwarf_id === dwarfId);
 }
 
 function awardXp(dwarfId: string, skillName: string, xpAmount: number, state: SimContext['state']): void {

--- a/sim/src/task-helpers.ts
+++ b/sim/src/task-helpers.ts
@@ -18,6 +18,11 @@ const TASK_SKILL_MAP: Record<TaskType, string | null> = {
   build_mushroom_garden: 'building',
   deconstruct: 'building',
   wander: null,
+  smooth: 'building',
+  engrave: 'engraving',
+  brew: 'brewing',
+  cook: 'cooking',
+  smith: 'smithing',
 };
 
 /** Get the skill name required for a task type, or null if no skill needed. */

--- a/supabase/migrations/00017_crafting_task_types.sql
+++ b/supabase/migrations/00017_crafting_task_types.sql
@@ -1,0 +1,10 @@
+-- ============================================================
+-- CRAFTING TASK TYPES
+-- Adds brew, cook, smith, smooth, and engrave task types
+-- ============================================================
+
+ALTER TYPE task_type ADD VALUE IF NOT EXISTS 'smooth';
+ALTER TYPE task_type ADD VALUE IF NOT EXISTS 'engrave';
+ALTER TYPE task_type ADD VALUE IF NOT EXISTS 'brew';
+ALTER TYPE task_type ADD VALUE IF NOT EXISTS 'cook';
+ALTER TYPE task_type ADD VALUE IF NOT EXISTS 'smith';


### PR DESCRIPTION
## Summary

- **5 new task types**: `smooth`, `engrave`, `brew`, `cook`, `smith`
- **smooth**: designate a stone/rock/cavern tile → dwarf works it into `smooth_stone`
- **engrave**: designate a `smooth_stone` tile → becomes `engraved_stone` (higher beauty)
- **brew**: consumes a plant item at the target → creates a drink (ale)
- **cook**: consumes a food item at the target → creates a prepared meal (fine quality, higher value)
- **smith**: consumes a raw_material (ore) at the target → creates a tool
- New tile types `smooth_stone`, `engraved_stone`, `engraved_floor` with distinct glyphs
- Skill mappings: smooth→building, engrave→engraving, brew→brewing, cook→cooking, smith→smithing
- DB migration `00017_crafting_task_types.sql` adds 5 new values to `task_type` enum (applied to production)

closes #218

## Playtest report

Sim logic only — no new UI. Verified via:
- `npm test --workspace=sim`: 431 tests pass including 14 new crafting tests
- `npm run build`: clean, no type errors
- DB migration applied to production via Supabase MCP

## Claude Cost
**Claude cost:** $24.53 (69.1M tokens)