### PR TITLE
feat: fire skill level-up events and flush skills to DB

### DIFF
--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -197,6 +197,34 @@ export const TANTRUM_DURATION_SEVERE = 200;
 /** Maximum achievable skill level for any dwarf skill */
 export const MAX_SKILL_LEVEL = 20;
 
+/**
+ * Dwarf Fortress-style skill tier names indexed by skill level (0–20).
+ * Level 0 = Dabbling, level 20 = Legendary+4.
+ */
+export const SKILL_TIER_NAMES: readonly string[] = [
+  'Dabbling',     // 0
+  'Novice',       // 1
+  'Apprentice',   // 2
+  'Journeyman',   // 3
+  'Competent',    // 4
+  'Skilled',      // 5
+  'Proficient',   // 6
+  'Talented',     // 7
+  'Adept',        // 8
+  'Expert',       // 9
+  'Professional', // 10
+  'Accomplished', // 11
+  'Great',        // 12
+  'Master',       // 13
+  'High Master',  // 14
+  'Grand Master', // 15
+  'Legendary',    // 16
+  'Legendary+1',  // 17
+  'Legendary+2',  // 18
+  'Legendary+3',  // 19
+  'Legendary+4',  // 20
+];
+
 // ============================================================
 // Task dispatch
 // ============================================================

--- a/sim/src/flush-state.ts
+++ b/sim/src/flush-state.ts
@@ -95,6 +95,22 @@ export async function flushToSupabase(ctx: SimContext): Promise<void> {
     );
   }
 
+  if (state.dirtyDwarfSkillIds.size > 0) {
+    const dirtySkills = state.dwarfSkills.filter((s) =>
+      state.dirtyDwarfSkillIds.has(s.id),
+    );
+    if (dirtySkills.length > 0) {
+      promises.push(
+        supabase
+          .from("dwarf_skills")
+          .upsert(dirtySkills)
+          .then(({ error }) => {
+            if (error) console.warn(`[flush] dwarf_skills upsert failed: ${error.message}`);
+          }),
+      );
+    }
+  }
+
   if (state.dirtyFortressTileKeys.size > 0) {
     const dirtyTiles = [...state.dirtyFortressTileKeys]
       .map((key) => state.fortressTileOverrides.get(key))
@@ -133,6 +149,7 @@ export async function flushToSupabase(ctx: SimContext): Promise<void> {
   state.dirtyStructureIds.clear();
   state.dirtyMonsterIds.clear();
   state.dirtyTaskIds.clear();
+  state.dirtyDwarfSkillIds.clear();
   state.dirtyFortressTileKeys.clear();
   state.newTasks = [];
   state.pendingEvents = [];

--- a/sim/src/load-state.ts
+++ b/sim/src/load-state.ts
@@ -85,6 +85,7 @@ export async function loadStateFromSupabase(
     dirtyStructureIds: new Set(),
     dirtyMonsterIds: new Set(),
     dirtyTaskIds: new Set(),
+    dirtyDwarfSkillIds: new Set(),
     newTasks: [],
     pendingEvents: [],
     stockpileTiles,

--- a/sim/src/phases/skill-levelup.test.ts
+++ b/sim/src/phases/skill-levelup.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import { SKILL_TIER_NAMES } from "@pwarf/shared";
+import { completeTask } from "./task-completion.js";
+import { makeDwarf, makeSkill, makeTask, makeContext } from "../__tests__/test-helpers.js";
+
+describe("SKILL_TIER_NAMES", () => {
+  it("has 21 entries covering levels 0–20", () => {
+    expect(SKILL_TIER_NAMES).toHaveLength(21);
+  });
+
+  it("starts with Dabbling at level 0", () => {
+    expect(SKILL_TIER_NAMES[0]).toBe("Dabbling");
+  });
+
+  it("ends with Legendary+4 at level 20", () => {
+    expect(SKILL_TIER_NAMES[20]).toBe("Legendary+4");
+  });
+
+  it("has Legendary at level 16", () => {
+    expect(SKILL_TIER_NAMES[16]).toBe("Legendary");
+  });
+});
+
+describe("skill level-up event", () => {
+  it("fires a discovery event when a dwarf levels up a skill", () => {
+    const dwarf = makeDwarf({ id: "d1" });
+    // 90 XP → level 0. After +15 XP → 105 XP → level 1 (Novice)
+    const skill = makeSkill("d1", "mining", 0, 90);
+    const task = makeTask("mine", {
+      assigned_dwarf_id: "d1",
+      work_progress: 100,
+      work_required: 100,
+      target_x: 0,
+      target_y: 0,
+      target_z: 0,
+    });
+
+    const ctx = makeContext({ dwarves: [dwarf], skills: [skill], tasks: [task] });
+
+    completeTask(dwarf, task, ctx);
+
+    const levelUpEvent = ctx.state.pendingEvents.find(
+      (e) => e.event_data && (e.event_data as Record<string, unknown>).skill_name === "mining",
+    );
+    expect(levelUpEvent).toBeDefined();
+    expect(levelUpEvent?.description).toContain("Novice");
+    expect(levelUpEvent?.description).toContain("mining");
+    expect(levelUpEvent?.dwarf_id).toBe("d1");
+    expect(levelUpEvent?.category).toBe("discovery");
+  });
+
+  it("does not fire a level-up event when XP increases but level stays the same", () => {
+    const dwarf = makeDwarf({ id: "d2" });
+    // 10 XP → after +15 XP → 25 XP → still level 0, no level-up
+    const skill = makeSkill("d2", "mining", 0, 10);
+    const task = makeTask("mine", {
+      assigned_dwarf_id: "d2",
+      work_progress: 100,
+      work_required: 100,
+      target_x: 0,
+      target_y: 0,
+      target_z: 0,
+    });
+
+    const ctx = makeContext({ dwarves: [dwarf], skills: [skill], tasks: [task] });
+
+    completeTask(dwarf, task, ctx);
+
+    const levelUpEvent = ctx.state.pendingEvents.find(
+      (e) => e.event_data && (e.event_data as Record<string, unknown>).skill_name === "mining",
+    );
+    expect(levelUpEvent).toBeUndefined();
+  });
+
+  it("marks skill dirty when level increases", () => {
+    const dwarf = makeDwarf({ id: "d3" });
+    const skill = makeSkill("d3", "mining", 0, 90);
+    const task = makeTask("mine", {
+      assigned_dwarf_id: "d3",
+      work_progress: 100,
+      work_required: 100,
+      target_x: 0,
+      target_y: 0,
+      target_z: 0,
+    });
+
+    const ctx = makeContext({ dwarves: [dwarf], skills: [skill], tasks: [task] });
+
+    completeTask(dwarf, task, ctx);
+
+    expect(ctx.state.dirtyDwarfSkillIds.has(skill.id)).toBe(true);
+  });
+
+  it("does not mark skill dirty when no level-up occurs", () => {
+    const dwarf = makeDwarf({ id: "d4" });
+    const skill = makeSkill("d4", "mining", 0, 10);
+    const task = makeTask("mine", {
+      assigned_dwarf_id: "d4",
+      work_progress: 100,
+      work_required: 100,
+      target_x: 0,
+      target_y: 0,
+      target_z: 0,
+    });
+
+    const ctx = makeContext({ dwarves: [dwarf], skills: [skill], tasks: [task] });
+
+    completeTask(dwarf, task, ctx);
+
+    expect(ctx.state.dirtyDwarfSkillIds.has(skill.id)).toBe(false);
+  });
+
+  it("includes new_level and tier in event_data", () => {
+    const dwarf = makeDwarf({ id: "d5" });
+    const skill = makeSkill("d5", "building", 0, 90);
+    const task = makeTask("build_wall", {
+      assigned_dwarf_id: "d5",
+      work_progress: 100,
+      work_required: 100,
+      target_x: 0,
+      target_y: 0,
+      target_z: 0,
+    });
+
+    const ctx = makeContext({ dwarves: [dwarf], skills: [skill], tasks: [task] });
+
+    completeTask(dwarf, task, ctx);
+
+    const levelUpEvent = ctx.state.pendingEvents.find(
+      (e) => e.event_data && (e.event_data as Record<string, unknown>).skill_name === "building",
+    );
+    expect(levelUpEvent).toBeDefined();
+    const data = levelUpEvent?.event_data as Record<string, unknown>;
+    expect(data.new_level).toBe(1);
+    expect(data.tier).toBe("Novice");
+  });
+});

--- a/sim/src/phases/task-completion.ts
+++ b/sim/src/phases/task-completion.ts
@@ -17,6 +17,7 @@ import {
   PURPOSE_RESTORE_SKILLED,
   PURPOSE_RESTORE_HAUL,
   PURPOSE_RESTORE_DEFAULT,
+  SKILL_TIER_NAMES,
 } from "@pwarf/shared";
 import type { Dwarf, FortressTile, FortressTileType, Task, Item, Structure } from "@pwarf/shared";
 import type { SimContext } from "../sim-context.js";
@@ -69,21 +70,21 @@ export function completeTask(dwarf: Dwarf, task: Task, ctx: SimContext): void {
   switch (task.task_type) {
     case 'mine':
       completeMine(dwarf, task, ctx);
-      awardXp(dwarf.id, 'mining', XP_MINE, state);
+      awardXp(dwarf.id, 'mining', XP_MINE, ctx, dwarf);
       break;
     case 'haul':
       completeHaul(dwarf, task, ctx);
-      awardXp(dwarf.id, 'hauling', XP_HAUL, state);
+      awardXp(dwarf.id, 'hauling', XP_HAUL, ctx, dwarf);
       break;
     case 'farm_till':
-      awardXp(dwarf.id, 'farming', XP_FARM_TILL, state);
+      awardXp(dwarf.id, 'farming', XP_FARM_TILL, ctx, dwarf);
       break;
     case 'farm_plant':
-      awardXp(dwarf.id, 'farming', XP_FARM_PLANT, state);
+      awardXp(dwarf.id, 'farming', XP_FARM_PLANT, ctx, dwarf);
       break;
     case 'farm_harvest':
       completeFarmHarvest(task, ctx);
-      awardXp(dwarf.id, 'farming', XP_FARM_HARVEST, state);
+      awardXp(dwarf.id, 'farming', XP_FARM_HARVEST, ctx, dwarf);
       break;
     case 'eat':
       completeEat(dwarf, task, ctx);
@@ -97,43 +98,43 @@ export function completeTask(dwarf: Dwarf, task: Task, ctx: SimContext): void {
     case 'build_wall':
     case 'build_floor':
       completeBuild(task, ctx);
-      awardXp(dwarf.id, 'building', XP_BUILD, state);
+      awardXp(dwarf.id, 'building', XP_BUILD, ctx, dwarf);
       break;
     case 'build_bed':
       completeBuildBed(task, ctx);
-      awardXp(dwarf.id, 'building', XP_BUILD, state);
+      awardXp(dwarf.id, 'building', XP_BUILD, ctx, dwarf);
       break;
     case 'build_well':
       completeBuildStructure(task, ctx, 'well', 'well');
-      awardXp(dwarf.id, 'building', XP_BUILD, state);
+      awardXp(dwarf.id, 'building', XP_BUILD, ctx, dwarf);
       break;
     case 'build_mushroom_garden':
       completeBuildStructure(task, ctx, 'mushroom_garden', 'mushroom_garden');
-      awardXp(dwarf.id, 'building', XP_BUILD, state);
+      awardXp(dwarf.id, 'building', XP_BUILD, ctx, dwarf);
       break;
     case 'deconstruct':
       completeDeconstruct(task, ctx);
-      awardXp(dwarf.id, 'building', XP_BUILD, state);
+      awardXp(dwarf.id, 'building', XP_BUILD, ctx, dwarf);
       break;
     case 'smooth':
       completeSmooth(task, ctx);
-      awardXp(dwarf.id, 'building', XP_SMOOTH, state);
+      awardXp(dwarf.id, 'building', XP_SMOOTH, ctx, dwarf);
       break;
     case 'engrave':
       completeEngrave(task, ctx);
-      awardXp(dwarf.id, 'engraving', XP_ENGRAVE, state);
+      awardXp(dwarf.id, 'engraving', XP_ENGRAVE, ctx, dwarf);
       break;
     case 'brew':
       completeBrew(dwarf, task, ctx);
-      awardXp(dwarf.id, 'brewing', XP_BREW, state);
+      awardXp(dwarf.id, 'brewing', XP_BREW, ctx, dwarf);
       break;
     case 'cook':
       completeCook(dwarf, task, ctx);
-      awardXp(dwarf.id, 'cooking', XP_COOK, state);
+      awardXp(dwarf.id, 'cooking', XP_COOK, ctx, dwarf);
       break;
     case 'smith':
       completeSmith(dwarf, task, ctx);
-      awardXp(dwarf.id, 'smithing', XP_SMITH, state);
+      awardXp(dwarf.id, 'smithing', XP_SMITH, ctx, dwarf);
       break;
   }
 
@@ -649,13 +650,33 @@ function findItemHeldBy(ctx: SimContext, dwarfId: string, category: string): Ite
   return ctx.state.items.find(i => i.category === category && i.held_by_dwarf_id === dwarfId);
 }
 
-function awardXp(dwarfId: string, skillName: string, xpAmount: number, state: SimContext['state']): void {
+function awardXp(dwarfId: string, skillName: string, xpAmount: number, ctx: SimContext, dwarf: Dwarf): void {
+  const { state } = ctx;
   const skill = state.dwarfSkills.find(s => s.dwarf_id === dwarfId && s.skill_name === skillName);
   if (skill) {
     skill.xp += xpAmount;
     const newLevel = Math.floor(skill.xp / 100);
     if (newLevel > skill.level && newLevel <= 20) {
       skill.level = newLevel;
+      state.dirtyDwarfSkillIds.add(skill.id);
+      const tierName = SKILL_TIER_NAMES[newLevel] ?? `Level ${newLevel}`;
+      const dwarfLabel = dwarfName(dwarf);
+      const readableSkill = skillName.replace(/_/g, ' ');
+      state.pendingEvents.push({
+        id: ctx.rng.uuid(),
+        world_id: '',
+        year: ctx.year,
+        category: 'discovery',
+        civilization_id: ctx.civilizationId,
+        ruin_id: null,
+        dwarf_id: dwarf.id,
+        item_id: null,
+        faction_id: null,
+        monster_id: null,
+        description: `${dwarfLabel} has become a ${tierName} ${readableSkill}!`,
+        event_data: { skill_name: skillName, new_level: newLevel, tier: tierName },
+        created_at: new Date().toISOString(),
+      });
     }
   }
 }

--- a/sim/src/sim-context.ts
+++ b/sim/src/sim-context.ts
@@ -29,6 +29,7 @@ export interface CachedState {
   dirtyStructureIds: Set<string>;
   dirtyMonsterIds: Set<string>;
   dirtyTaskIds: Set<string>;
+  dirtyDwarfSkillIds: Set<string>;
 
   /** New tasks created this tick that need to be inserted (not upserted). */
   newTasks: Task[];
@@ -73,6 +74,7 @@ export function createEmptyCachedState(): CachedState {
     dirtyStructureIds: new Set(),
     dirtyMonsterIds: new Set(),
     dirtyTaskIds: new Set(),
+    dirtyDwarfSkillIds: new Set(),
     newTasks: [],
     pendingEvents: [],
     stockpileTiles: new Map(),


### PR DESCRIPTION
## Summary

- Adds `SKILL_TIER_NAMES` (21 Dwarf Fortress-style tier strings) to `@pwarf/shared` constants
- `awardXp()` now fires a `discovery` event when a dwarf gains a skill level (e.g. "Urist has become a Novice miner!")
- Adds `dirtyDwarfSkillIds` to `CachedState` and flushes changed skills to the `dwarf_skills` table on each flush cycle — skills previously persisted only in memory and were lost on restart
- 9 new tests: 4 for SKILL_TIER_NAMES correctness, 5 for level-up event firing and dirty tracking

Closes #374

## Playtest report

Sim-only change (no UI). Verified via test suite — 457 tests pass (includes new crafting tests from rebased #373), `npm run build` clean.

## Claude Cost
**Claude cost:** $26.71 (75.3M tokens)