### PR TITLE
feat: year-end summary event in activity log

### DIFF
--- a/sim/src/phases/yearly-rollup.test.ts
+++ b/sim/src/phases/yearly-rollup.test.ts
@@ -90,9 +90,81 @@ describe("yearlyRollup", () => {
 
       await yearlyRollup(ctx);
 
-      expect(ctx.state.pendingEvents.length).toBe(1);
-      expect(ctx.state.pendingEvents[0].category).toBe("death");
-      expect(ctx.state.pendingEvents[0].description).toContain("old age");
+      const deathEvent = ctx.state.pendingEvents.find(e => e.category === "death");
+      expect(deathEvent).toBeDefined();
+      expect(deathEvent?.description).toContain("old age");
+    });
+  });
+
+  describe("year-end summary event", () => {
+    it("fires a discovery event at the end of every year", async () => {
+      const dwarf = makeDwarf({ age: 30 });
+      const ctx = makeContext({ dwarves: [dwarf] });
+      ctx.year = 3;
+
+      await yearlyRollup(ctx);
+
+      const summaryEvent = ctx.state.pendingEvents.find(
+        e => e.category === "discovery" && typeof e.event_data === "object" &&
+          (e.event_data as Record<string, unknown>).type === "year_rollup",
+      );
+      expect(summaryEvent).toBeDefined();
+      expect(summaryEvent?.description).toContain("Year 3 ends");
+    });
+
+    it("includes population count in the summary", async () => {
+      const d1 = makeDwarf({ age: 30 });
+      const d2 = makeDwarf({ age: 25 });
+      const ctx = makeContext({ dwarves: [d1, d2] });
+      ctx.year = 5;
+
+      await yearlyRollup(ctx);
+
+      const summaryEvent = ctx.state.pendingEvents.find(
+        e => (e.event_data as Record<string, unknown>)?.type === "year_rollup",
+      );
+      expect(summaryEvent?.description).toContain("Population: 2 dwarves");
+    });
+
+    it("reports deaths in the summary when a dwarf dies", async () => {
+      const dwarf = makeDwarf({ age: 99 });
+      const ctx = makeContext({ dwarves: [dwarf] });
+      ctx.year = 10;
+
+      await yearlyRollup(ctx);
+
+      const summaryEvent = ctx.state.pendingEvents.find(
+        e => (e.event_data as Record<string, unknown>)?.type === "year_rollup",
+      );
+      expect(summaryEvent?.description).toContain("1 dwarf died this year");
+    });
+
+    it("reports no deaths when no dwarf dies", async () => {
+      const dwarf = makeDwarf({ age: 30 });
+      // year 1 skips immigration so only the year-end summary fires
+      const ctx1 = makeContext({ dwarves: [dwarf] });
+      ctx1.year = 1;
+      await yearlyRollup(ctx1);
+
+      const summaryEvent = ctx1.state.pendingEvents.find(
+        e => (e.event_data as Record<string, unknown>)?.type === "year_rollup",
+      );
+      expect(summaryEvent?.description).toContain("No dwarves died");
+    });
+
+    it("event_data includes population, deaths, migrants fields", async () => {
+      const dwarf = makeDwarf({ age: 30 });
+      const ctx = makeContext({ dwarves: [dwarf] });
+
+      await yearlyRollup(ctx);
+
+      const summaryEvent = ctx.state.pendingEvents.find(
+        e => (e.event_data as Record<string, unknown>)?.type === "year_rollup",
+      );
+      const data = summaryEvent?.event_data as Record<string, unknown>;
+      expect(data.population).toBeTypeOf("number");
+      expect(data.deaths).toBeTypeOf("number");
+      expect(data.migrants).toBeTypeOf("number");
     });
   });
 });

--- a/sim/src/phases/yearly-rollup.ts
+++ b/sim/src/phases/yearly-rollup.ts
@@ -21,6 +21,8 @@ import { createImmigrantDwarf } from "../dwarf-factory.js";
 export async function yearlyRollup(ctx: SimContext): Promise<void> {
   const { state, rng, year, civilizationId } = ctx;
 
+  let deathsThisYear = 0;
+
   for (const dwarf of state.dwarves) {
     if (dwarf.status !== 'alive') continue;
 
@@ -36,6 +38,7 @@ export async function yearlyRollup(ctx: SimContext): Promise<void> {
         dwarf.status = 'dead';
         dwarf.died_year = year;
         dwarf.cause_of_death = 'unknown';
+        deathsThisYear += 1;
 
         if (dwarf.current_task_id) {
           const task = state.tasks.find(t => t.id === dwarf.current_task_id);
@@ -66,8 +69,10 @@ export async function yearlyRollup(ctx: SimContext): Promise<void> {
   }
 
   // Immigration — new dwarves arrive starting from year 2
+  let migrantsThisYear = 0;
   if (year >= 2 && rng.random() < IMMIGRATION_CHANCE_PER_YEAR) {
     const count = rng.int(1, IMMIGRATION_MAX_ARRIVALS);
+    migrantsThisYear = count;
     const center = Math.floor(FORTRESS_SIZE / 2);
     const immigrants = Array.from({ length: count }, (_, i) =>
       createImmigrantDwarf(rng, civilizationId, year, center + i, center)
@@ -96,4 +101,28 @@ export async function yearlyRollup(ctx: SimContext): Promise<void> {
       created_at: new Date().toISOString(),
     });
   }
+
+  // Year-end summary event
+  const population = state.dwarves.filter(d => d.status === 'alive').length;
+  const deathClause = deathsThisYear === 0
+    ? 'No dwarves died.'
+    : deathsThisYear === 1 ? '1 dwarf died this year.' : `${deathsThisYear} dwarves died this year.`;
+  const migrantClause = migrantsThisYear === 0
+    ? ''
+    : migrantsThisYear === 1 ? ' 1 migrant arrived.' : ` ${migrantsThisYear} migrants arrived.`;
+  state.pendingEvents.push({
+    id: rng.uuid(),
+    world_id: '',
+    year,
+    category: 'discovery',
+    civilization_id: civilizationId,
+    ruin_id: null,
+    dwarf_id: null,
+    item_id: null,
+    faction_id: null,
+    monster_id: null,
+    description: `Year ${year} ends. Population: ${population} dwarves. ${deathClause}${migrantClause}`,
+    event_data: { type: 'year_rollup', population, deaths: deathsThisYear, migrants: migrantsThisYear },
+    created_at: new Date().toISOString(),
+  });
 }


### PR DESCRIPTION
## Summary

At the end of each year (in `yearlyRollup`), push a `discovery` event summarising the year in the activity log:

- **Format**: `"Year 3 ends. Population: 11 dwarves. 1 dwarf died this year. 3 migrants arrived."`
- Tracks `deathsThisYear` and `migrantsThisYear` as local counters within `yearlyRollup`
- No new constants or DB changes needed (uses existing `discovery` event category)
- Adds 5 new tests in `yearly-rollup.test.ts`; existing tests updated to use `.find()` instead of array index

closes #375

## Playtest report

Sim-only change. Verified via:
- `npm test --workspace=sim`: 462 tests pass (5 new year-end summary tests)
- `npm run build`: clean, no type errors

## Claude Cost
**Claude cost:** $0.10 (270k tokens)