### PR TITLE
feat: ghosts haunt fortress until memorialized (closes #379)

### DIFF
--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -206,6 +206,19 @@ export const DISEASE_RECOVERY_CHANCE = 0.5;
 export const DISEASE_SPREAD_RADIUS = 4;
 
 // ============================================================
+// Ghosts
+// ============================================================
+
+/** Stress applied per tick to alive dwarves within haunting radius of a ghost */
+export const GHOST_STRESS_PER_TICK = 0.3;
+
+/** Manhattan-distance radius within which a ghost haunts nearby dwarves */
+export const GHOST_HAUNTING_RADIUS = 5;
+
+/** Work required to engrave a memorial slab */
+export const MEMORIAL_WORK_REQUIRED = 200;
+
+// ============================================================
 // Stress severity tiers
 // ============================================================
 

--- a/shared/src/db-types.ts
+++ b/shared/src/db-types.ts
@@ -167,7 +167,8 @@ export type TaskType =
   | 'engrave'
   | 'brew'
   | 'cook'
-  | 'smith';
+  | 'smith'
+  | 'engrave_memorial';
 
 export type TaskStatus =
   | 'pending'

--- a/sim/src/load-state.ts
+++ b/sim/src/load-state.ts
@@ -104,5 +104,7 @@ export async function loadStateFromSupabase(
     tantrumTicks: new Map(),
     infectedDwarfIds: new Set(),
     warnedNeedIds: new Map(),
+    ghostDwarfIds: new Set(),
+    ghostPositions: new Map(),
   };
 }

--- a/sim/src/phases/deprivation.ts
+++ b/sim/src/phases/deprivation.ts
@@ -47,6 +47,14 @@ export function killDwarf(dwarf: Dwarf, cause: string, ctx: SimContext): void {
   state.dirtyDwarfIds.add(dwarf.id);
   state.warnedNeedIds.delete(dwarf.id);
 
+  // Add to ghost tracking — dwarf haunts until memorialized
+  state.ghostDwarfIds.add(dwarf.id);
+  state.ghostPositions.set(dwarf.id, {
+    x: dwarf.position_x,
+    y: dwarf.position_y,
+    z: dwarf.position_z,
+  });
+
   // Fail any task assigned to this dwarf
   if (dwarf.current_task_id) {
     const task = state.tasks.find(t => t.id === dwarf.current_task_id);

--- a/sim/src/phases/disease.ts
+++ b/sim/src/phases/disease.ts
@@ -108,6 +108,8 @@ export function diseasePhase(ctx: SimContext): void {
       dwarf.died_year = year;
       dwarf.cause_of_death = 'disease';
       state.infectedDwarfIds.delete(dwarf.id);
+      state.ghostDwarfIds.add(dwarf.id);
+      state.ghostPositions.set(dwarf.id, { x: dwarf.position_x, y: dwarf.position_y, z: dwarf.position_z });
       state.pendingEvents.push({
         id: rng.uuid(),
         world_id: '',

--- a/sim/src/phases/haunting.test.ts
+++ b/sim/src/phases/haunting.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { haunting } from "./haunting.js";
+import { createTestContext } from "../sim-context.js";
+import { makeDwarf } from "../__tests__/test-helpers.js";
+import { GHOST_STRESS_PER_TICK, GHOST_HAUNTING_RADIUS } from "@pwarf/shared";
+
+describe("haunting", () => {
+  it("does nothing when no ghosts exist", () => {
+    const dwarf = makeDwarf({ stress_level: 0, position_x: 0, position_y: 0, position_z: 0 });
+    const ctx = createTestContext({ dwarves: [dwarf] });
+    haunting(ctx);
+    expect(dwarf.stress_level).toBe(0);
+    expect(ctx.state.dirtyDwarfIds.size).toBe(0);
+  });
+
+  it("applies stress to alive dwarves within haunting radius", () => {
+    const dwarf = makeDwarf({ id: 'd1', stress_level: 10, position_x: 2, position_y: 2, position_z: 0 });
+    const ctx = createTestContext({ dwarves: [dwarf] });
+    // Ghost at (0, 0, 0) — distance 4 from dwarf, within GHOST_HAUNTING_RADIUS (5)
+    ctx.state.ghostDwarfIds.add('ghost1');
+    ctx.state.ghostPositions.set('ghost1', { x: 0, y: 0, z: 0 });
+
+    haunting(ctx);
+
+    expect(dwarf.stress_level).toBeCloseTo(10 + GHOST_STRESS_PER_TICK);
+    expect(ctx.state.dirtyDwarfIds.has('d1')).toBe(true);
+  });
+
+  it("does not apply stress to dwarves beyond haunting radius", () => {
+    const farDwarf = makeDwarf({ id: 'd1', stress_level: 10, position_x: 10, position_y: 10, position_z: 0 });
+    const ctx = createTestContext({ dwarves: [farDwarf] });
+    ctx.state.ghostDwarfIds.add('ghost1');
+    ctx.state.ghostPositions.set('ghost1', { x: 0, y: 0, z: 0 });
+
+    haunting(ctx);
+
+    // Manhattan distance = 20 > GHOST_HAUNTING_RADIUS (5)
+    expect(farDwarf.stress_level).toBe(10);
+    expect(ctx.state.dirtyDwarfIds.size).toBe(0);
+  });
+
+  it("does not apply stress to dwarves on different z-levels", () => {
+    const dwarf = makeDwarf({ id: 'd1', stress_level: 10, position_x: 1, position_y: 1, position_z: 1 });
+    const ctx = createTestContext({ dwarves: [dwarf] });
+    ctx.state.ghostDwarfIds.add('ghost1');
+    ctx.state.ghostPositions.set('ghost1', { x: 1, y: 1, z: 0 }); // same x,y but different z
+
+    haunting(ctx);
+
+    expect(dwarf.stress_level).toBe(10);
+    expect(ctx.state.dirtyDwarfIds.size).toBe(0);
+  });
+
+  it("caps stress at 100", () => {
+    const dwarf = makeDwarf({ id: 'd1', stress_level: 99.9, position_x: 0, position_y: 0, position_z: 0 });
+    const ctx = createTestContext({ dwarves: [dwarf] });
+    ctx.state.ghostDwarfIds.add('ghost1');
+    ctx.state.ghostPositions.set('ghost1', { x: 0, y: 0, z: 0 });
+
+    haunting(ctx);
+
+    expect(dwarf.stress_level).toBe(100);
+  });
+
+  it("applies stress from multiple ghosts", () => {
+    const dwarf = makeDwarf({ id: 'd1', stress_level: 0, position_x: 2, position_y: 0, position_z: 0 });
+    const ctx = createTestContext({ dwarves: [dwarf] });
+    // Two ghosts both within radius
+    ctx.state.ghostDwarfIds.add('ghost1');
+    ctx.state.ghostPositions.set('ghost1', { x: 0, y: 0, z: 0 });
+    ctx.state.ghostDwarfIds.add('ghost2');
+    ctx.state.ghostPositions.set('ghost2', { x: 3, y: 0, z: 0 });
+
+    haunting(ctx);
+
+    expect(dwarf.stress_level).toBeCloseTo(GHOST_STRESS_PER_TICK * 2);
+  });
+
+  it("ghost at exactly haunting radius boundary still haunts", () => {
+    const dwarf = makeDwarf({
+      id: 'd1',
+      stress_level: 0,
+      position_x: GHOST_HAUNTING_RADIUS,
+      position_y: 0,
+      position_z: 0,
+    });
+    const ctx = createTestContext({ dwarves: [dwarf] });
+    ctx.state.ghostDwarfIds.add('ghost1');
+    ctx.state.ghostPositions.set('ghost1', { x: 0, y: 0, z: 0 });
+
+    haunting(ctx);
+
+    expect(dwarf.stress_level).toBeCloseTo(GHOST_STRESS_PER_TICK);
+  });
+
+  it("does not affect dead dwarves", () => {
+    const dead = makeDwarf({ id: 'd1', status: 'dead', stress_level: 0, position_x: 0, position_y: 0, position_z: 0 });
+    const ctx = createTestContext({ dwarves: [dead] });
+    ctx.state.ghostDwarfIds.add('ghost1');
+    ctx.state.ghostPositions.set('ghost1', { x: 0, y: 0, z: 0 });
+
+    haunting(ctx);
+
+    expect(dead.stress_level).toBe(0);
+    expect(ctx.state.dirtyDwarfIds.size).toBe(0);
+  });
+});

--- a/sim/src/phases/haunting.ts
+++ b/sim/src/phases/haunting.ts
@@ -1,0 +1,34 @@
+import { GHOST_STRESS_PER_TICK, GHOST_HAUNTING_RADIUS } from "@pwarf/shared";
+import type { SimContext } from "../sim-context.js";
+
+/**
+ * Haunting Phase
+ *
+ * Each tick, dwarves who died without a memorial (tracked in ghostDwarfIds)
+ * apply passive stress to nearby living dwarves. The player can put ghosts
+ * to rest by engraving a memorial slab near the ghost's death location.
+ */
+export function haunting(ctx: SimContext): void {
+  const { state } = ctx;
+
+  if (state.ghostDwarfIds.size === 0) return;
+
+  const aliveDwarves = state.dwarves.filter(d => d.status === 'alive');
+  if (aliveDwarves.length === 0) return;
+
+  for (const ghostId of state.ghostDwarfIds) {
+    const pos = state.ghostPositions.get(ghostId);
+    if (!pos) continue;
+
+    for (const dwarf of aliveDwarves) {
+      if (dwarf.position_z !== pos.z) continue;
+      const dist =
+        Math.abs(dwarf.position_x - pos.x) +
+        Math.abs(dwarf.position_y - pos.y);
+      if (dist <= GHOST_HAUNTING_RADIUS) {
+        dwarf.stress_level = Math.min(100, dwarf.stress_level + GHOST_STRESS_PER_TICK);
+        state.dirtyDwarfIds.add(dwarf.id);
+      }
+    }
+  }
+}

--- a/sim/src/phases/index.ts
+++ b/sim/src/phases/index.ts
@@ -21,3 +21,4 @@ export { thoughtGeneration } from "./thought-generation.js";
 export { haulAssignment } from "./haul-assignment.js";
 export { beautyRestoration } from "./beauty-restoration.js";
 export { diseasePhase, hasWell } from "./disease.js";
+export { haunting } from "./haunting.js";

--- a/sim/src/phases/task-completion.ts
+++ b/sim/src/phases/task-completion.ts
@@ -137,6 +137,10 @@ export function completeTask(dwarf: Dwarf, task: Task, ctx: SimContext): void {
       completeSmith(dwarf, task, ctx);
       awardXp(dwarf.id, 'smithing', XP_SMITH, ctx, dwarf);
       break;
+    case 'engrave_memorial':
+      completeMemorial(task, ctx, dwarf);
+      awardXp(dwarf.id, 'engraving', XP_ENGRAVE, ctx, dwarf);
+      break;
   }
 
   // Purpose restoration: work gives dwarves a sense of meaning
@@ -495,6 +499,49 @@ function completeSmooth(task: Task, ctx: SimContext): void {
     currentType === 'cavern_floor' || currentType === 'constructed_floor' ? 'smooth_stone' : 'smooth_stone';
 
   upsertFortressTile(ctx, task.target_x, task.target_y, task.target_z, resultType, existing?.material ?? null, existing?.is_mined ?? false);
+}
+
+function completeMemorial(task: Task, ctx: SimContext, dwarf: Dwarf): void {
+  if (task.target_x === null || task.target_y === null || task.target_z === null) return;
+  if (ctx.state.ghostDwarfIds.size === 0) return;
+
+  // Find the nearest ghost to the memorial location (on the same z-level)
+  let nearestGhostId: string | null = null;
+  let nearestDist = Infinity;
+  for (const [ghostId, pos] of ctx.state.ghostPositions) {
+    if (pos.z !== task.target_z) continue;
+    const dist =
+      Math.abs(pos.x - task.target_x) +
+      Math.abs(pos.y - task.target_y);
+    if (dist < nearestDist) {
+      nearestDist = dist;
+      nearestGhostId = ghostId;
+    }
+  }
+
+  if (!nearestGhostId) return;
+
+  ctx.state.ghostDwarfIds.delete(nearestGhostId);
+  ctx.state.ghostPositions.delete(nearestGhostId);
+
+  const ghostDwarf = ctx.state.dwarves.find(d => d.id === nearestGhostId);
+  const ghostName = ghostDwarf ? dwarfName(ghostDwarf) : 'the departed';
+
+  ctx.state.pendingEvents.push({
+    id: ctx.rng.uuid(),
+    world_id: '',
+    year: ctx.year,
+    category: 'discovery',
+    civilization_id: ctx.civilizationId,
+    ruin_id: null,
+    dwarf_id: dwarf.id,
+    item_id: null,
+    faction_id: null,
+    monster_id: null,
+    description: `${dwarfName(dwarf)} has engraved a memorial for ${ghostName}. The spirit is at rest.`,
+    event_data: { action: 'memorial', ghost_dwarf_id: nearestGhostId },
+    created_at: new Date().toISOString(),
+  });
 }
 
 function completeEngrave(task: Task, ctx: SimContext, dwarf: Dwarf): void {

--- a/sim/src/phases/yearly-rollup.ts
+++ b/sim/src/phases/yearly-rollup.ts
@@ -40,6 +40,8 @@ export async function yearlyRollup(ctx: SimContext): Promise<void> {
         dwarf.died_year = year;
         dwarf.cause_of_death = 'unknown';
         deathsThisYear += 1;
+        state.ghostDwarfIds.add(dwarf.id);
+        state.ghostPositions.set(dwarf.id, { x: dwarf.position_x, y: dwarf.position_y, z: dwarf.position_z });
 
         if (dwarf.current_task_id) {
           const task = state.tasks.find(t => t.id === dwarf.current_task_id);

--- a/sim/src/sim-context.ts
+++ b/sim/src/sim-context.ts
@@ -60,6 +60,19 @@ export interface CachedState {
    * Cleared when the need recovers above the warning threshold.
    */
   warnedNeedIds: Map<string, Set<string>>;
+
+  /**
+   * IDs of dwarves who have died without a memorial and now haunt the fortress.
+   * Populated when a dwarf dies; cleared when a memorial is engraved nearby.
+   * Not persisted across sim restarts (in-memory only).
+   */
+  ghostDwarfIds: Set<string>;
+
+  /**
+   * Position of each ghost at the time of death. Keyed by dwarf ID.
+   * Used to determine haunting radius and memorial targeting.
+   */
+  ghostPositions: Map<string, { x: number; y: number; z: number }>;
 }
 
 /** Returns a fresh CachedState with empty arrays and sets. */
@@ -88,6 +101,8 @@ export function createEmptyCachedState(): CachedState {
     tantrumTicks: new Map(),
     infectedDwarfIds: new Set(),
     warnedNeedIds: new Map(),
+    ghostDwarfIds: new Set(),
+    ghostPositions: new Map(),
   };
 }
 

--- a/sim/src/sim-runner.ts
+++ b/sim/src/sim-runner.ts
@@ -22,6 +22,7 @@ import {
   thoughtGeneration,
   haulAssignment,
   beautyRestoration,
+  haunting,
 } from "./phases/index.js";
 
 /** Snapshot of sim state emitted after every tick for live UI rendering. */
@@ -169,6 +170,7 @@ export class SimRunner {
     await eventFiring(this.ctx);
     await thoughtGeneration(this.ctx);
     await beautyRestoration(this.ctx);
+    haunting(this.ctx);
 
     if (this.stepCount % STEPS_PER_YEAR === 0) {
       this.currentYear++;

--- a/sim/src/task-helpers.ts
+++ b/sim/src/task-helpers.ts
@@ -23,6 +23,7 @@ const TASK_SKILL_MAP: Record<TaskType, string | null> = {
   brew: 'brewing',
   cook: 'cooking',
   smith: 'smithing',
+  engrave_memorial: 'engraving',
 };
 
 /** Get the skill name required for a task type, or null if no skill needed. */

--- a/supabase/migrations/00018_engrave_memorial_task_type.sql
+++ b/supabase/migrations/00018_engrave_memorial_task_type.sql
@@ -1,0 +1,2 @@
+-- Add engrave_memorial task type for putting ghosts to rest
+ALTER TYPE task_type ADD VALUE IF NOT EXISTS 'engrave_memorial';


### PR DESCRIPTION
## Summary
- Dead dwarves become ghosts that haunt the fortress until memorialized
- Each tick, ghosts within 5 tiles apply 0.3 stress to nearby alive dwarves (same z-level only)
- Ghost tracking is in-memory: `ghostDwarfIds: Set<string>` and `ghostPositions: Map` on `CachedState`
- All death paths (deprivation, disease, old age, monster attack) register ghosts
- New `engrave_memorial` task type: completes to put the nearest ghost to rest, fires discovery event
- DB migration: adds `engrave_memorial` to `task_type` enum (applied to production)
- Constants: `GHOST_STRESS_PER_TICK = 0.3`, `GHOST_HAUNTING_RADIUS = 5`, `MEMORIAL_WORK_REQUIRED = 200`

## Test plan
- [x] No haunting when no ghosts exist
- [x] Stress applied to dwarves within radius
- [x] No stress beyond haunting radius
- [x] No stress across z-levels
- [x] Stress capped at 100
- [x] Multiple ghosts stack stress
- [x] Ghost at exact boundary still haunts
- [x] Dead dwarves not affected
- [x] `npm run build` passes
- [x] All 1111 tests pass

## Playtest
Sim logic only — no UI changes. Verified with unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Claude Cost
**Claude cost:** $55.40 (151.4M tokens)