### PR TITLE
feat: witness stress when a nearby dwarf dies (closes #386)

### DIFF
--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -206,6 +206,16 @@ export const DISEASE_RECOVERY_CHANCE = 0.5;
 export const DISEASE_SPREAD_RADIUS = 4;
 
 // ============================================================
+// Witness stress (death trauma)
+// ============================================================
+
+/** Stress applied to alive dwarves who witness a nearby death */
+export const WITNESS_DEATH_STRESS = 8;
+
+/** Manhattan-distance radius within which a death is "witnessed" */
+export const WITNESS_DEATH_RADIUS = 5;
+
+// ============================================================
 // Ghosts
 // ============================================================
 

--- a/sim/src/__tests__/deprivation.test.ts
+++ b/sim/src/__tests__/deprivation.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { STARVATION_TICKS, DEHYDRATION_TICKS } from "@pwarf/shared";
-import { handleDeprivationDeaths, killDwarf } from "../phases/deprivation.js";
+import { STARVATION_TICKS, DEHYDRATION_TICKS, WITNESS_DEATH_STRESS, WITNESS_DEATH_RADIUS } from "@pwarf/shared";
+import { handleDeprivationDeaths, killDwarf, applyWitnessStress } from "../phases/deprivation.js";
 import { createTask } from "../task-helpers.js";
 import { makeDwarf, makeContext } from "./test-helpers.js";
 
@@ -109,5 +109,92 @@ describe("killDwarf", () => {
 
     const fallen = ctx.state.pendingEvents.filter(e => e.category === "fortress_fallen");
     expect(fallen).toHaveLength(0);
+  });
+});
+
+describe("applyWitnessStress", () => {
+  it("applies stress to alive dwarves within witness radius", () => {
+    const deceased = makeDwarf({ position_x: 0, position_y: 0, position_z: 0 });
+    const witness = makeDwarf({ stress_level: 10, position_x: 2, position_y: 2, position_z: 0 });
+    const ctx = makeContext({ dwarves: [deceased, witness] });
+
+    applyWitnessStress(deceased, ctx.state);
+
+    // Manhattan distance = 4 <= WITNESS_DEATH_RADIUS (5)
+    expect(witness.stress_level).toBe(10 + WITNESS_DEATH_STRESS);
+    expect(ctx.state.dirtyDwarfIds.has(witness.id)).toBe(true);
+  });
+
+  it("does not apply stress to dwarves beyond witness radius", () => {
+    const deceased = makeDwarf({ position_x: 0, position_y: 0, position_z: 0 });
+    const farDwarf = makeDwarf({ stress_level: 10, position_x: 10, position_y: 0, position_z: 0 });
+    const ctx = makeContext({ dwarves: [deceased, farDwarf] });
+
+    applyWitnessStress(deceased, ctx.state);
+
+    // Manhattan distance = 10 > WITNESS_DEATH_RADIUS (5)
+    expect(farDwarf.stress_level).toBe(10);
+    expect(ctx.state.dirtyDwarfIds.size).toBe(0);
+  });
+
+  it("does not apply stress across z-levels", () => {
+    const deceased = makeDwarf({ position_x: 0, position_y: 0, position_z: 0 });
+    const aboveDwarf = makeDwarf({ stress_level: 10, position_x: 0, position_y: 0, position_z: 1 });
+    const ctx = makeContext({ dwarves: [deceased, aboveDwarf] });
+
+    applyWitnessStress(deceased, ctx.state);
+
+    expect(aboveDwarf.stress_level).toBe(10);
+  });
+
+  it("does not apply stress to dead dwarves", () => {
+    const deceased = makeDwarf({ position_x: 0, position_y: 0, position_z: 0 });
+    const deadNearby = makeDwarf({ status: 'dead', stress_level: 0, position_x: 1, position_y: 0, position_z: 0 });
+    const ctx = makeContext({ dwarves: [deceased, deadNearby] });
+
+    applyWitnessStress(deceased, ctx.state);
+
+    expect(deadNearby.stress_level).toBe(0);
+  });
+
+  it("does not apply stress to the deceased itself", () => {
+    const deceased = makeDwarf({ stress_level: 50, position_x: 0, position_y: 0, position_z: 0 });
+    const ctx = makeContext({ dwarves: [deceased] });
+
+    applyWitnessStress(deceased, ctx.state);
+
+    expect(deceased.stress_level).toBe(50);
+  });
+
+  it("caps witness stress at 100", () => {
+    const deceased = makeDwarf({ position_x: 0, position_y: 0, position_z: 0 });
+    const witness = makeDwarf({ stress_level: 98, position_x: 1, position_y: 0, position_z: 0 });
+    const ctx = makeContext({ dwarves: [deceased, witness] });
+
+    applyWitnessStress(deceased, ctx.state);
+
+    expect(witness.stress_level).toBe(100);
+  });
+
+  it("applies stress to all witnesses within radius, not just the nearest", () => {
+    const deceased = makeDwarf({ position_x: 5, position_y: 0, position_z: 0 });
+    const witness1 = makeDwarf({ stress_level: 0, position_x: 3, position_y: 0, position_z: 0 });
+    const witness2 = makeDwarf({ stress_level: 0, position_x: 7, position_y: 0, position_z: 0 });
+    const ctx = makeContext({ dwarves: [deceased, witness1, witness2] });
+
+    applyWitnessStress(deceased, ctx.state);
+
+    expect(witness1.stress_level).toBe(WITNESS_DEATH_STRESS);
+    expect(witness2.stress_level).toBe(WITNESS_DEATH_STRESS);
+  });
+
+  it("killDwarf triggers witness stress on nearby dwarves", () => {
+    const victim = makeDwarf({ position_x: 0, position_y: 0, position_z: 0 });
+    const bystander = makeDwarf({ stress_level: 10, position_x: 1, position_y: 0, position_z: 0 });
+    const ctx = makeContext({ dwarves: [victim, bystander] });
+
+    killDwarf(victim, 'starvation', ctx);
+
+    expect(bystander.stress_level).toBe(10 + WITNESS_DEATH_STRESS);
   });
 });

--- a/sim/src/phases/deprivation.ts
+++ b/sim/src/phases/deprivation.ts
@@ -1,6 +1,6 @@
-import { STARVATION_TICKS, DEHYDRATION_TICKS } from "@pwarf/shared";
+import { STARVATION_TICKS, DEHYDRATION_TICKS, WITNESS_DEATH_STRESS, WITNESS_DEATH_RADIUS } from "@pwarf/shared";
 import type { Dwarf } from "@pwarf/shared";
-import type { SimContext } from "../sim-context.js";
+import type { CachedState, SimContext } from "../sim-context.js";
 
 /**
  * Handles starvation and dehydration death tracking for all alive dwarves.
@@ -74,7 +74,11 @@ export function killDwarf(dwarf: Dwarf, cause: string, ctx: SimContext): void {
     }
   }
 
+  // Apply witness stress to nearby alive dwarves
+  applyWitnessStress(dwarf, state);
+
   // Check if all dwarves are dead — fortress falls
+  // Note: dwarf.status is already 'dead' at this point, so filter it out
   const aliveDwarves = state.dwarves.filter(d => d.status === 'alive');
   if (aliveDwarves.length === 0) {
     state.pendingEvents.push({
@@ -92,5 +96,24 @@ export function killDwarf(dwarf: Dwarf, cause: string, ctx: SimContext): void {
       event_data: { cause },
       created_at: new Date().toISOString(),
     });
+  }
+}
+
+/**
+ * Applies stress to alive dwarves who are close enough to witness the death.
+ * Exported for unit testing.
+ */
+export function applyWitnessStress(deceased: Dwarf, state: CachedState): void {
+  for (const witness of state.dwarves) {
+    if (witness.id === deceased.id) continue;
+    if (witness.status !== 'alive') continue;
+    if (witness.position_z !== deceased.position_z) continue;
+    const dist =
+      Math.abs(witness.position_x - deceased.position_x) +
+      Math.abs(witness.position_y - deceased.position_y);
+    if (dist <= WITNESS_DEATH_RADIUS) {
+      witness.stress_level = Math.min(100, witness.stress_level + WITNESS_DEATH_STRESS);
+      state.dirtyDwarfIds.add(witness.id);
+    }
   }
 }

--- a/sim/src/phases/disease.ts
+++ b/sim/src/phases/disease.ts
@@ -8,6 +8,7 @@ import {
 } from "@pwarf/shared";
 import type { SimContext } from "../sim-context.js";
 import { dwarfName } from "../dwarf-utils.js";
+import { applyWitnessStress } from "./deprivation.js";
 
 /**
  * Returns true if the fortress has at least one completed well structure.
@@ -110,6 +111,7 @@ export function diseasePhase(ctx: SimContext): void {
       state.infectedDwarfIds.delete(dwarf.id);
       state.ghostDwarfIds.add(dwarf.id);
       state.ghostPositions.set(dwarf.id, { x: dwarf.position_x, y: dwarf.position_y, z: dwarf.position_z });
+      applyWitnessStress(dwarf, state);
       state.pendingEvents.push({
         id: rng.uuid(),
         world_id: '',

--- a/sim/src/phases/index.ts
+++ b/sim/src/phases/index.ts
@@ -1,7 +1,7 @@
 export { needsDecay } from "./needs-decay.js";
 export { taskExecution } from "./task-execution.js";
 export { completeTask } from "./task-completion.js";
-export { handleDeprivationDeaths, killDwarf } from "./deprivation.js";
+export { handleDeprivationDeaths, killDwarf, applyWitnessStress } from "./deprivation.js";
 export { needSatisfaction } from "./need-satisfaction.js";
 export { stressUpdate } from "./stress-update.js";
 export { tantrumCheck } from "./tantrum-check.js";

--- a/sim/src/phases/yearly-rollup.ts
+++ b/sim/src/phases/yearly-rollup.ts
@@ -9,6 +9,7 @@ import type { SimContext } from "../sim-context.js";
 import { dwarfName } from "../dwarf-utils.js";
 import { createImmigrantDwarf } from "../dwarf-factory.js";
 import { diseasePhase } from "./disease.js";
+import { applyWitnessStress } from "./deprivation.js";
 
 /**
  * Yearly Rollup Phase
@@ -42,6 +43,7 @@ export async function yearlyRollup(ctx: SimContext): Promise<void> {
         deathsThisYear += 1;
         state.ghostDwarfIds.add(dwarf.id);
         state.ghostPositions.set(dwarf.id, { x: dwarf.position_x, y: dwarf.position_y, z: dwarf.position_z });
+        applyWitnessStress(dwarf, state);
 
         if (dwarf.current_task_id) {
           const task = state.tasks.find(t => t.id === dwarf.current_task_id);


### PR DESCRIPTION
## Summary
- Alive dwarves within 5 tiles of a death gain 8 stress from witnessing it
- Applies to all death paths: `killDwarf()` (starvation, dehydration, monster combat), old-age deaths in yearly rollup, and disease deaths
- `applyWitnessStress(deceased, state)` is a pure helper exported for testing
- No DB schema changes

## Constants
- `WITNESS_DEATH_STRESS = 8` — stress applied per witnessed death
- `WITNESS_DEATH_RADIUS = 5` — Manhattan distance radius, same z-level only

## Test plan
- [x] Stress applied within radius (distance 4 ≤ 5)
- [x] No stress beyond radius (distance 10 > 5)
- [x] No stress across z-levels
- [x] Dead dwarves not affected
- [x] Deceased not stressed by own death
- [x] Stress capped at 100
- [x] All witnesses in radius receive stress (not just nearest)
- [x] `killDwarf` triggers witness stress integration test
- [x] `npm run build` passes
- [x] All 1127 tests pass

## Playtest
Sim logic only — no UI changes. Verified with unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Claude Cost
**Claude cost:** $59.39 (163.4M tokens)