### PR TITLE
feat: legends tab shows real world history grouped by year (closes #396)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -213,6 +213,7 @@ export default function App() {
           id: e.id,
           description: e.description,
           category: e.category,
+          year: e.year,
           created_at: e.created_at ?? new Date().toISOString(),
         }));
     }

--- a/app/src/components/RightPanel.test.ts
+++ b/app/src/components/RightPanel.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { groupConsecutiveEvents } from "./RightPanel";
+import { groupConsecutiveEvents, groupEventsByYear } from "./RightPanel";
 import type { LiveEvent } from "../hooks/useEvents";
 
-function makeEvent(id: string, description: string, category = "discovery"): LiveEvent {
-  return { id, description, category, created_at: new Date().toISOString() } as LiveEvent;
+function makeEvent(id: string, description: string, category = "discovery", year = 1): LiveEvent {
+  return { id, description, category, year, created_at: new Date().toISOString() };
 }
 
 describe("groupConsecutiveEvents", () => {
@@ -58,5 +58,42 @@ describe("groupConsecutiveEvents", () => {
     expect(groups[0]).toEqual({ event: events[0], count: 2 });
     expect(groups[1]).toEqual({ event: events[2], count: 3 });
     expect(groups[2]).toEqual({ event: events[5], count: 1 });
+  });
+});
+
+describe("groupEventsByYear", () => {
+  it("returns empty for no events", () => {
+    expect(groupEventsByYear([])).toEqual([]);
+  });
+
+  it("filters out non-legend categories (year_rollup, etc.)", () => {
+    const e = makeEvent("1", "Year ends", "year_rollup", 3);
+    expect(groupEventsByYear([e])).toEqual([]);
+  });
+
+  it("groups significant events by year newest first", () => {
+    const e1 = makeEvent("1", "A dwarf died", "death", 1);
+    const e2 = makeEvent("2", "Migrants arrived", "migration", 2);
+    const e3 = makeEvent("3", "Another death", "death", 1);
+    const groups = groupEventsByYear([e1, e2, e3]);
+    expect(groups).toHaveLength(2);
+    expect(groups[0].year).toBe(2);
+    expect(groups[1].year).toBe(1);
+    expect(groups[1].events).toHaveLength(2);
+  });
+
+  it("includes artifact_created and discovery categories", () => {
+    const e1 = makeEvent("1", "Artifact forged", "artifact_created", 5);
+    const e2 = makeEvent("2", "A discovery", "discovery", 5);
+    const groups = groupEventsByYear([e1, e2]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].events).toHaveLength(2);
+  });
+
+  it("includes fortress_fallen category", () => {
+    const e = makeEvent("1", "Fortress fallen", "fortress_fallen", 7);
+    const groups = groupEventsByYear([e]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].year).toBe(7);
   });
 });

--- a/app/src/components/RightPanel.tsx
+++ b/app/src/components/RightPanel.tsx
@@ -10,12 +10,22 @@ interface RightPanelProps {
 const TABS = ["Log", "Legends"] as const;
 type Tab = (typeof TABS)[number];
 
-const PLACEHOLDER_LEGENDS = [
-  "Year 201 — Stonegear founded",
-  "Year 202 — First goblin siege",
-  "Year 203 — Discovered adamantine",
-  "Year 204 — Great flood",
-];
+/** Categories that appear in the Legends tab (significant history). */
+const LEGEND_CATEGORIES = new Set(['death', 'fortress_fallen', 'migration', 'discovery', 'artifact_created']);
+
+/** Group significant events by year, newest year first. */
+export function groupEventsByYear(events: LiveEvent[]): Array<{ year: number; events: LiveEvent[] }> {
+  const byYear = new Map<number, LiveEvent[]>();
+  for (const event of events) {
+    if (!LEGEND_CATEGORIES.has(event.category)) continue;
+    const list = byYear.get(event.year) ?? [];
+    list.push(event);
+    byYear.set(event.year, list);
+  }
+  return [...byYear.entries()]
+    .sort((a, b) => b[0] - a[0])
+    .map(([year, evts]) => ({ year, events: evts }));
+}
 
 /** Group consecutive events with the same description into (event, count) pairs. */
 export function groupConsecutiveEvents(events: LiveEvent[]): Array<{ event: LiveEvent; count: number }> {
@@ -109,13 +119,25 @@ export default function RightPanel({ collapsed, onToggle, events }: RightPanelPr
                 </ul>
               )
             ) : (
-              <ul className="space-y-0.5">
-                {PLACEHOLDER_LEGENDS.map((entry, i) => (
-                  <li key={i} className="text-[var(--amber)]">
-                    {entry}
-                  </li>
-                ))}
-              </ul>
+              groupEventsByYear(events).length === 0 ? (
+                <p className="text-[var(--text)] opacity-50 italic">No history yet.</p>
+              ) : (
+                <div className="space-y-2">
+                  {groupEventsByYear(events).map(({ year, events: yearEvents }) => (
+                    <div key={year}>
+                      <div className="text-[var(--amber)] font-bold mb-0.5">Year {year}</div>
+                      <ul className="space-y-0.5 pl-1">
+                        {yearEvents.map((event) => (
+                          <li key={event.id} className="text-[var(--text)]">
+                            <span style={{ color: categoryColor(event.category) }} className="mr-1">*</span>
+                            {event.description}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ))}
+                </div>
+              )
             )}
           </div>
         </>

--- a/app/src/hooks/useEvents.ts
+++ b/app/src/hooks/useEvents.ts
@@ -6,6 +6,7 @@ export interface LiveEvent {
   id: string;
   description: string;
   category: string;
+  year: number;
   created_at: string;
 }
 
@@ -28,7 +29,7 @@ export function useEvents(civId: string | null): LiveEvent[] {
     async function poll() {
       const query = supabase
         .from('world_events')
-        .select('id, description, category, created_at')
+        .select('id, description, category, year, created_at')
         .eq('civilization_id', civId)
         .order('created_at', { ascending: false })
         .limit(MAX_EVENTS);


### PR DESCRIPTION
## Summary

- Replaced placeholder text in the Legends tab with real world event history
- Added \`year: number\` to the \`LiveEvent\` interface and Supabase query
- Legends tab groups significant events by year (newest year first), with year headers
- Only significant categories shown: \`death\`, \`fortress_fallen\`, \`migration\`, \`discovery\`, \`artifact_created\`
- Shows "No history yet." when no significant events exist
- Added \`groupEventsByYear\` pure function with 5 unit tests

## Test plan

- [x] \`npm run build\` — passes (56 test files, 646 tests)
- [x] \`npm test\` — all pass including new \`groupEventsByYear\` tests
- Unit tests: empty input, non-legend category filtering, multi-year grouping (newest first), artifact/discovery categories, fortress_fallen

## Playtest

UI change — needs screenshot. This PR changes the Legends tab from static placeholder to live data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


**Claude cost:** $3.80 (10.5M tokens) (Ralph overnight run delta from snapshot $76.04)\n\n## Claude Cost\n**Claude cost:** $57.98 (165.2M tokens) — Ralph overnight session (multiple tickets)

## Playtest Notes

Chrome browser extension not available during overnight run. UI change is straightforward (replacing static placeholder with live data binding). Logic is fully covered by unit tests including edge cases (empty state, category filtering, year grouping). The visual change will be verified on next manual session.