### PR TITLE
fix: sync civilization population and wealth each yearly rollup (closes #399)

### DIFF
--- a/sim/src/flush-state.ts
+++ b/sim/src/flush-state.ts
@@ -153,6 +153,18 @@ export async function flushToSupabase(ctx: SimContext): Promise<void> {
     );
   }
 
+  if (state.civDirty) {
+    promises.push(
+      supabase
+        .from("civilizations")
+        .update({ population: state.civPopulation, wealth: state.civWealth })
+        .eq("id", ctx.civilizationId)
+        .then(({ error }) => {
+          if (error) console.warn(`[flush] civilizations update failed: ${error.message}`);
+        }),
+    );
+  }
+
   if (events.length > 0) {
     // Stamp world_id on events (phases leave it empty)
     const worldId = ctx.worldId;
@@ -181,4 +193,5 @@ export async function flushToSupabase(ctx: SimContext): Promise<void> {
   state.newTasks = [];
   state.newDwarfRelationships = [];
   state.pendingEvents = [];
+  state.civDirty = false;
 }

--- a/sim/src/load-state.ts
+++ b/sim/src/load-state.ts
@@ -13,7 +13,7 @@ export async function loadStateFromSupabase(
   civilizationId: string,
   worldId: string,
 ): Promise<CachedState> {
-  const [dwarvesResult, itemsResult, structuresResult, monstersResult, tasksResult, skillsResult, stockpileResult, eventsResult] =
+  const [dwarvesResult, itemsResult, structuresResult, monstersResult, tasksResult, skillsResult, stockpileResult, eventsResult, civResult] =
     await Promise.all([
       supabase
         .from("dwarves")
@@ -52,6 +52,11 @@ export async function loadStateFromSupabase(
         .eq("civilization_id", civilizationId)
         .order("created_at", { ascending: false })
         .limit(WORLD_EVENTS_RECENT_LIMIT),
+      supabase
+        .from("civilizations")
+        .select("population,wealth")
+        .eq("id", civilizationId)
+        .single(),
     ]);
 
   // Load relationships after dwarves — need alive dwarf IDs
@@ -123,5 +128,8 @@ export async function loadStateFromSupabase(
     ghostDwarfIds: new Set(),
     strangeMoodDwarfIds: new Set(),
     warnedNeedIds: new Map(),
+    civPopulation: (civResult.data as { population: number } | null)?.population ?? 0,
+    civWealth: (civResult.data as { wealth: number } | null)?.wealth ?? 0,
+    civDirty: false,
   };
 }

--- a/sim/src/phases/yearly-rollup.test.ts
+++ b/sim/src/phases/yearly-rollup.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { yearlyRollup } from "./yearly-rollup.js";
-import { makeDwarf, makeTask, makeContext } from "../__tests__/test-helpers.js";
+import { makeDwarf, makeTask, makeItem, makeContext } from "../__tests__/test-helpers.js";
 import { ELDER_DEATH_AGE } from "@pwarf/shared";
 
 describe("yearlyRollup", () => {
@@ -150,6 +150,48 @@ describe("yearlyRollup", () => {
         e => (e.event_data as Record<string, unknown>)?.type === "year_rollup",
       );
       expect(summaryEvent?.description).toContain("No dwarves died");
+    });
+
+    it("updates civPopulation and civWealth and sets civDirty when values change", async () => {
+      const dwarf = makeDwarf({ age: 30, civilization_id: "civ-1" });
+      const item = makeItem({ value: 50, located_in_civ_id: "civ-1" });
+      const ctx = makeContext({ dwarves: [dwarf], items: [item] });
+      ctx.state.civPopulation = 0;
+      ctx.state.civWealth = 0;
+      ctx.state.civDirty = false;
+
+      await yearlyRollup(ctx);
+
+      expect(ctx.state.civPopulation).toBe(1);
+      expect(ctx.state.civWealth).toBe(50);
+      expect(ctx.state.civDirty).toBe(true);
+    });
+
+    it("does not set civDirty when population and wealth are unchanged", async () => {
+      const dwarf = makeDwarf({ age: 30, civilization_id: "civ-1" });
+      const item = makeItem({ value: 10, located_in_civ_id: "civ-1" });
+      const ctx = makeContext({ dwarves: [dwarf], items: [item] });
+      ctx.state.civPopulation = 1;
+      ctx.state.civWealth = 10;
+      ctx.state.civDirty = false;
+      ctx.year = 1; // year 1: no immigration
+
+      await yearlyRollup(ctx);
+
+      expect(ctx.state.civDirty).toBe(false);
+    });
+
+    it("excludes items not in this civilization from wealth", async () => {
+      const dwarf = makeDwarf({ age: 30, civilization_id: "civ-1" });
+      const ownItem = makeItem({ value: 100, located_in_civ_id: "civ-1" });
+      const otherItem = makeItem({ value: 999, located_in_civ_id: "civ-other" });
+      const ctx = makeContext({ dwarves: [dwarf], items: [ownItem, otherItem] });
+      ctx.state.civPopulation = 0;
+      ctx.state.civWealth = 0;
+
+      await yearlyRollup(ctx);
+
+      expect(ctx.state.civWealth).toBe(100);
     });
 
     it("event_data includes population, deaths, migrants fields", async () => {

--- a/sim/src/phases/yearly-rollup.ts
+++ b/sim/src/phases/yearly-rollup.ts
@@ -123,8 +123,18 @@ export async function yearlyRollup(ctx: SimContext): Promise<void> {
     decayMemories(dwarf, year, state);
   }
 
-  // Year-end summary event
+  // Year-end civilization metadata sync
   const population = state.dwarves.filter(d => d.status === 'alive').length;
+  const wealth = state.items
+    .filter(i => i.located_in_civ_id === civilizationId)
+    .reduce((sum, i) => sum + i.value, 0);
+  if (population !== state.civPopulation || wealth !== state.civWealth) {
+    state.civPopulation = population;
+    state.civWealth = wealth;
+    state.civDirty = true;
+  }
+
+  // Year-end summary event
   const deathClause = deathsThisYear === 0
     ? 'No dwarves died.'
     : deathsThisYear === 1 ? '1 dwarf died this year.' : `${deathsThisYear} dwarves died this year.`;

--- a/sim/src/sim-context.ts
+++ b/sim/src/sim-context.ts
@@ -82,6 +82,15 @@ export interface CachedState {
    * In-memory only; not persisted across sim restarts.
    */
   strangeMoodDwarfIds: Set<string>;
+
+  /** Cached civilization population, updated each yearly rollup. */
+  civPopulation: number;
+
+  /** Cached civilization wealth (sum of located item values), updated each yearly rollup. */
+  civWealth: number;
+
+  /** Whether civPopulation or civWealth changed this year and need flushing. */
+  civDirty: boolean;
 }
 
 /** Returns a fresh CachedState with empty arrays and sets. */
@@ -115,6 +124,9 @@ export function createEmptyCachedState(): CachedState {
     ghostDwarfIds: new Set(),
     strangeMoodDwarfIds: new Set(),
     warnedNeedIds: new Map(),
+    civPopulation: 0,
+    civWealth: 0,
+    civDirty: false,
   };
 }
 


### PR DESCRIPTION
## Summary

- `civilizations.population` and `civilizations.wealth` now update each year-end
- Population = count of alive dwarves; Wealth = sum of `items.value` for items in the civ
- Added `civPopulation`, `civWealth`, `civDirty` to `CachedState`
- `load-state.ts` loads current population/wealth from DB at sim start
- `yearly-rollup.ts` recalculates both, sets `civDirty = true` only when values change
- `flush-state.ts` issues `UPDATE civilizations SET population=..., wealth=...` when dirty
- No schema changes needed — columns already exist

## Test plan

- [x] `npm run build` — passes
- [x] `npm test --workspace=sim` — 570 tests pass (46 test files)
- 3 new unit tests in `yearly-rollup.test.ts`:
  - Updates civPopulation and civWealth and sets civDirty when values change
  - Does not set civDirty when population and wealth are unchanged (no unnecessary writes)
  - Excludes items not in this civilization from wealth calculation

## Playtest

Sim logic only — no UI changes. Verified via unit tests.

closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Claude Cost
**Claude cost:** $2.49 (7.1M tokens)

## Claude Cost
$83.72 (230.3M tokens) — Ralph overnight session; see PR description for per-ticket delta