### PR TITLE
feat: color-code dwarf names by stress level in left panel

### DIFF
--- a/app/src/components/LeftPanel.test.ts
+++ b/app/src/components/LeftPanel.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { stressColor } from "./LeftPanel";
+
+describe("stressColor", () => {
+  it("returns green for low stress (0)", () => {
+    expect(stressColor(0)).toBe("var(--green)");
+  });
+
+  it("returns green for stress at upper low boundary (33)", () => {
+    expect(stressColor(33)).toBe("var(--green)");
+  });
+
+  it("returns amber for medium stress (34)", () => {
+    expect(stressColor(34)).toBe("var(--amber)");
+  });
+
+  it("returns amber for stress at upper medium boundary (66)", () => {
+    expect(stressColor(66)).toBe("var(--amber)");
+  });
+
+  it("returns red for high stress (67)", () => {
+    expect(stressColor(67)).toBe("var(--red)");
+  });
+
+  it("returns red for max stress (100)", () => {
+    expect(stressColor(100)).toBe("var(--red)");
+  });
+});

--- a/app/src/components/LeftPanel.tsx
+++ b/app/src/components/LeftPanel.tsx
@@ -4,6 +4,13 @@ import type { ActiveTask } from "../hooks/useTasks";
 
 const AUTONOMOUS_TASK_TYPES: ReadonlySet<string> = new Set(['eat', 'drink', 'sleep', 'wander']);
 
+/** Returns a CSS color for a dwarf's name based on their stress level (0–100). */
+export function stressColor(stressLevel: number): string {
+  if (stressLevel >= 67) return "var(--red)";
+  if (stressLevel >= 34) return "var(--amber)";
+  return "var(--green)";
+}
+
 interface LeftPanelProps {
   mode: "fortress" | "world";
   collapsed: boolean;
@@ -92,7 +99,7 @@ export default function LeftPanel({ mode, collapsed, onToggle, cursorTile, onEmb
                       className="flex justify-between hover:bg-[var(--bg-hover)] px-1 cursor-pointer"
                       onClick={() => onDwarfClick?.(d.id)}
                     >
-                      <span className="text-[var(--green)]">{d.name}</span>
+                      <span style={{ color: stressColor(d.stress_level) }}>{d.name}</span>
                       <span className="text-[var(--text)]">
                         <span className="text-[var(--border)] mr-1">z{d.position_z}</span>
                         {dwarfJobLabel(d, tasks)}


### PR DESCRIPTION
Closes #401

## Summary
- Adds `stressColor(stressLevel)` pure function to LeftPanel
- Low (0–33): green, medium (34–66): amber, high (67–100): red
- Applied to dwarf name span in the fortress roster

## Playtest
UI-only change. The stress_level field is already populated by the sim. Colors will appear live during fortress play as dwarves accumulate stress.

No schema changes, no sim changes.

## Tests
6 unit tests for `stressColor` covering boundary values.

## Claude Cost
**Claude cost:** $85.57 (235.7M tokens)