### PR TITLE
fix: skip designation overlay when tile is already built

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -521,7 +521,10 @@ const AUTONOMOUS_TASK_TYPES: ReadonlySet<string> = new Set(['eat', 'drink', 'sle
 function formatFortressTileLabel(tileType: string, material: string | null, designation?: string, buildProgress?: number): string {
   const label = tileType.replace(/_/g, " ");
   const base = material ? `${label} (${material})` : label;
-  if (designation) {
+  // Don't show designation suffix if tile is already in a built state —
+  // task list may lag behind tile update (race condition between polls).
+  const tileIsBuilt = tileType === 'constructed_wall' || tileType === 'constructed_floor';
+  if (designation && !tileIsBuilt) {
     const desLabel = designation.replace(/_/g, " ");
     if (buildProgress !== undefined) {
       return `${base} [building: ${desLabel} ${buildProgress}%]`;

--- a/app/src/components/MainViewport.tsx
+++ b/app/src/components/MainViewport.tsx
@@ -201,7 +201,10 @@ export default function MainViewport({
         if (tile) {
           const glyph = FORTRESS_GLYPHS[tile.tileType] ?? { ch: "?", fg: "#f00" };
           const isStockpile = stockpileTilesRef.current?.has(`${wx},${wy},${zLevelRef.current}`);
-          if (taskType) {
+          // If the tile is already in a built state, skip the designation overlay —
+          // the task list may lag behind the tile update (race condition between polls).
+          const tileIsBuilt = tile.tileType === 'constructed_wall' || tile.tileType === 'constructed_floor';
+          if (taskType && !tileIsBuilt) {
             const buildPct = buildProgressTilesRef.current?.get(key);
             // Interpolate bg from dark brown (#442200) to amber (#886600) as progress increases
             const bg = buildPct !== undefined && buildPct > 0


### PR DESCRIPTION
Closes #404

## Summary
- Race condition between tile type poll and task status poll caused built walls to render with their designation overlay and show a confusing tooltip like "constructed wall [designated: build wall]"
- Fix: both the glyph renderer (`MainViewport.tsx`) and tooltip formatter (`App.tsx`) now skip the designation overlay when the tile type is already `constructed_wall` or `constructed_floor`
- The tile's actual state takes priority over stale task list entries

## Playtest
Pure UI rendering fix — no sim logic or DB schema changes. The bug was intermittent (race condition), so it's hard to screenshot. Verified build passes and all 570 sim tests pass.

## Claude Cost
TBD

## Claude Cost
**Claude cost:** $66.46 (187.6M tokens)

## Claude Cost
**Claude cost:** $0.19 (533k tokens)