### PR TITLE
feat: show civilization wealth in toolbar

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -188,6 +188,14 @@ export default function App() {
   // Live items from snapshot
   const liveItems: Item[] = useMemo(() => snapshot?.items ?? [], [snapshot]);
 
+  // Civilization wealth — sum of value for items located in this civ
+  const civWealth = useMemo(() =>
+    liveItems
+      .filter(i => i.located_in_civ_id === world.civId)
+      .reduce((sum, i) => sum + i.value, 0),
+    [liveItems, world.civId],
+  );
+
   // Ground items map for rendering (items not held by a dwarf at current z-level)
   const groundItems = useMemo(() => {
     const map = new Map<string, number>();
@@ -420,6 +428,7 @@ export default function App() {
         year={snapshot?.year ?? 1}
         civName={world.mode === "fortress" ? (world.civName ?? undefined) : undefined}
         items={liveItems}
+        wealth={civWealth}
       />
 
       <div className="flex flex-1 min-h-0 relative">

--- a/app/src/components/Toolbar.tsx
+++ b/app/src/components/Toolbar.tsx
@@ -15,9 +15,10 @@ interface ToolbarProps {
   year?: number;
   civName?: string;
   items?: Item[];
+  wealth?: number;
 }
 
-export default function Toolbar({ mode, onSignOut, onRestart, onTogglePause, isPaused = false, speed = 1, onSetSpeed, population = 0, year = 1, civName, items = [] }: ToolbarProps) {
+export default function Toolbar({ mode, onSignOut, onRestart, onTogglePause, isPaused = false, speed = 1, onSetSpeed, population = 0, year = 1, civName, items = [], wealth = 0 }: ToolbarProps) {
   return (
     <header className="flex items-center justify-between px-3 py-1 border-b border-[var(--border)] bg-[var(--bg-panel)] text-xs select-none shrink-0">
       <div className="flex gap-4 items-center">
@@ -32,6 +33,7 @@ export default function Toolbar({ mode, onSignOut, onRestart, onTogglePause, isP
 
       <div className="flex gap-4 items-center">
         <span>Pop: {population}</span>
+        {mode === "fortress" && <span className="text-[var(--amber)]">§ {wealth.toLocaleString()}</span>}
         {mode === "fortress" && items.length > 0 && <ResourceCounter items={items} />}
         <span className="text-[var(--amber)]">No alerts</span>
         {mode === "fortress" && onTogglePause && (


### PR DESCRIPTION
## Summary
- Adds `wealth` prop to `Toolbar` component
- Computes `civWealth` in `App.tsx` from `liveItems` (sum of `value` for items `located_in_civ_id === civId`)
- Shows `§ NNN` in toolbar alongside population when in fortress mode

## Test plan
- [x] `npm run build` — passes
- [x] `npm test --workspace=@pwarf/app` — 60 tests pass
- [ ] UI change — requires `/playtest` with before/after screenshots

## Playtest
UI change — Chrome playtest needed to verify wealth displays in the toolbar. Automated session — browser not available.

closes #409

## Claude Cost
Ralph overnight session (rebased).