### PR TITLE
feat: add well and mushroom garden to build menu

### DIFF
--- a/app/src/components/BuildMenu.tsx
+++ b/app/src/components/BuildMenu.tsx
@@ -10,6 +10,8 @@ const BUILD_OPTIONS: BuildOption[] = [
   { label: "Wall", key: "w", taskType: "build_wall" },
   { label: "Floor", key: "f", taskType: "build_floor" },
   { label: "Bed", key: "e", taskType: "build_bed" },
+  { label: "Well", key: "l", taskType: "build_well" },
+  { label: "Mushroom Garden", key: "m", taskType: "build_mushroom_garden" },
 ];
 
 interface BuildMenuProps {

--- a/app/src/hooks/useDesignation.ts
+++ b/app/src/hooks/useDesignation.ts
@@ -8,18 +8,22 @@ import {
   WORK_BUILD_WALL,
   WORK_BUILD_FLOOR,
   WORK_BUILD_BED,
+  WORK_BUILD_WELL,
+  WORK_BUILD_MUSHROOM_GARDEN,
   WORK_DECONSTRUCT,
 } from "@pwarf/shared";
 import { supabase } from "../lib/supabase";
 import type { FortressViewTile } from "./useFortressTiles";
 import type { OptimisticDesignation } from "./useTasks";
 
-export type DesignationMode = "none" | "mine" | "build_wall" | "build_floor" | "build_bed" | "stockpile" | "deconstruct";
+export type DesignationMode = "none" | "mine" | "build_wall" | "build_floor" | "build_bed" | "build_well" | "build_mushroom_garden" | "stockpile" | "deconstruct";
 
 const BUILD_WORK: Record<string, number> = {
   build_wall: WORK_BUILD_WALL,
   build_floor: WORK_BUILD_FLOOR,
   build_bed: WORK_BUILD_BED,
+  build_well: WORK_BUILD_WELL,
+  build_mushroom_garden: WORK_BUILD_MUSHROOM_GARDEN,
 };
 
 /** Tile types that can be deconstructed. */


### PR DESCRIPTION
Closes #412

## Summary
- Adds **Well** (key: `l`) and **Mushroom Garden** (key: `m`) to the build menu
- Adds `build_well` and `build_mushroom_garden` to `DesignationMode` type
- Adds their work constants to the `BUILD_WORK` map in `useDesignation.ts`

Both task types were already fully handled by the sim (completion logic in `task-completion.ts`, work constants in `shared/constants.ts`) but had no UI entry point.

## Playtest
UI change — build menu now shows two additional options. No schema changes, no sim changes.

## Tests
All 58 app tests pass. No new test needed — this is a data-only change to a menu options array and a string union type.

## Claude Cost
**Claude cost:** $0.17 (470k tokens)