### PR TITLE
feat: game over epitaph screen when civilization falls

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -20,6 +20,7 @@ import { useStockpileTiles } from "./hooks/useStockpileTiles";
 import BuildMenu, { BUILD_OPTIONS } from "./components/BuildMenu";
 import TaskPriorities from "./components/TaskPriorities";
 import { DwarfModal } from "./components/DwarfModal";
+import { EpitaphScreen } from "./components/EpitaphScreen";
 import { SURFACE_Z, CAVE_Z } from "@pwarf/shared";
 import type { Item } from "@pwarf/shared";
 import type { LiveDwarf } from "./hooks/useDwarves";
@@ -409,6 +410,13 @@ export default function App() {
       />
 
       <div className="flex flex-1 min-h-0 relative">
+        {snapshot?.civFallen && world.mode === "fortress" && (
+          <EpitaphScreen
+            year={snapshot.year}
+            events={events.map(e => ({ text: e.description, category: e.category }))}
+            onRestart={world.handleRestart}
+          />
+        )}
         {designation.buildMenuOpen && (
           <BuildMenu
             onSelect={designation.handleBuildSelect}

--- a/app/src/components/EpitaphScreen.tsx
+++ b/app/src/components/EpitaphScreen.tsx
@@ -1,0 +1,48 @@
+interface EpitaphScreenProps {
+  year: number;
+  events: Array<{ text: string; category?: string; tick?: number }>;
+  onRestart: () => void;
+}
+
+/**
+ * Full-screen overlay shown when the civilization falls (all dwarves dead).
+ * Displays the year the fortress fell, the cause, and recent history.
+ */
+export function EpitaphScreen({ year, events, onRestart }: EpitaphScreenProps) {
+  const fallEvent = events.find(e => e.category === 'fortress_fallen');
+  const recentEvents = events
+    .filter(e => e.category !== 'fortress_fallen')
+    .slice(-6);
+
+  return (
+    <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/80">
+      <div className="border border-[var(--red,#f87171)] p-8 max-w-md w-full text-center space-y-4 bg-[var(--bg-panel)]">
+        <div className="text-[#f87171] font-bold text-xl tracking-widest">
+          THE FORTRESS HAS FALLEN
+        </div>
+        <div className="text-[var(--text)] text-sm">
+          Year <span className="text-[var(--amber)]">{year}</span>
+        </div>
+        {fallEvent && (
+          <div className="text-[var(--text)] text-xs italic border-t border-[var(--border)] pt-3">
+            {fallEvent.text}
+          </div>
+        )}
+        {recentEvents.length > 0 && (
+          <div className="border-t border-[var(--border)] pt-3 text-left space-y-1">
+            <div className="text-[var(--amber)] text-xs font-bold mb-1">Final Days</div>
+            {recentEvents.map((e, i) => (
+              <div key={i} className="text-[var(--text)] text-xs">· {e.text}</div>
+            ))}
+          </div>
+        )}
+        <button
+          onClick={onRestart}
+          className="mt-4 border border-[var(--amber)] text-[var(--amber)] hover:text-[var(--green)] hover:border-[var(--green)] px-6 py-2 text-sm cursor-pointer"
+        >
+          Start Over
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/sim/src/sim-runner.ts
+++ b/sim/src/sim-runner.ts
@@ -36,6 +36,7 @@ export interface SimSnapshot {
   fortressTileOverrides: FortressTile[];
   monsters: Monster[];
   year: number;
+  civFallen: boolean;
 }
 
 /**
@@ -197,6 +198,7 @@ export class SimRunner {
         fortressTileOverrides: [...this.ctx.state.fortressTileOverrides.values()],
         monsters: this.ctx.state.monsters,
         year: this.currentYear,
+        civFallen: this.ctx.state.civFallen,
       });
     }
   }


### PR DESCRIPTION
Closes #408

## Summary
- Added `civFallen: boolean` to `SimSnapshot` so the frontend knows when the sim has stopped due to fortress collapse
- New `EpitaphScreen` component renders a full-screen overlay with: year fallen, the `fortress_fallen` event message (cause), final log entries, and a "Start Over" button
- Overlay shown in fortress mode when `snapshot.civFallen === true`

## Playtest
UI change on fortress fall condition — hard to trigger on demand, but the logic is straightforward. Build passes, all 579 sim tests pass.

## Claude Cost
TBD

## Claude Cost
**Claude cost:** $71.08 (201.2M tokens)