### PR TITLE
feat: add smooth and engrave designation modes to fortress UI

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -259,6 +259,12 @@ export default function App() {
         case "designate_deconstruct":
           if (world.mode === "fortress") designation.toggleDeconstruct();
           break;
+        case "designate_smooth":
+          if (world.mode === "fortress") designation.toggleSmooth();
+          break;
+        case "designate_engrave":
+          if (world.mode === "fortress") designation.toggleEngrave();
+          break;
         case "cancel_designation":
           designation.cancelDesignation();
           setFollowedDwarfId(null);

--- a/app/src/components/BottomBar.tsx
+++ b/app/src/components/BottomBar.tsx
@@ -54,6 +54,12 @@ export default function BottomBar({ mode, cursorX, cursorY, terrain, zLevel, for
               <kbd className="text-[var(--amber)]">D</kbd> deconstruct
             </span>
             <span>
+              <kbd className="text-[var(--amber)]">O</kbd> smooth
+            </span>
+            <span>
+              <kbd className="text-[var(--amber)]">E</kbd> engrave
+            </span>
+            <span>
               <kbd className="text-[var(--amber)]">p</kbd> priorities
             </span>
           </>

--- a/app/src/hooks/useDesignation.ts
+++ b/app/src/hooks/useDesignation.ts
@@ -11,12 +11,14 @@ import {
   WORK_BUILD_WELL,
   WORK_BUILD_MUSHROOM_GARDEN,
   WORK_DECONSTRUCT,
+  WORK_SMOOTH,
+  WORK_ENGRAVE,
 } from "@pwarf/shared";
 import { supabase } from "../lib/supabase";
 import type { FortressViewTile } from "./useFortressTiles";
 import type { OptimisticDesignation } from "./useTasks";
 
-export type DesignationMode = "none" | "mine" | "build_wall" | "build_floor" | "build_bed" | "build_well" | "build_mushroom_garden" | "stockpile" | "deconstruct";
+export type DesignationMode = "none" | "mine" | "build_wall" | "build_floor" | "build_bed" | "build_well" | "build_mushroom_garden" | "smooth" | "engrave" | "stockpile" | "deconstruct";
 
 const BUILD_WORK: Record<string, number> = {
   build_wall: WORK_BUILD_WALL,
@@ -24,11 +26,23 @@ const BUILD_WORK: Record<string, number> = {
   build_bed: WORK_BUILD_BED,
   build_well: WORK_BUILD_WELL,
   build_mushroom_garden: WORK_BUILD_MUSHROOM_GARDEN,
+  smooth: WORK_SMOOTH,
+  engrave: WORK_ENGRAVE,
 };
 
 /** Tile types that can be deconstructed. */
 const DECONSTRUCTIBLE: ReadonlySet<string> = new Set([
   'constructed_wall', 'constructed_floor', 'bed', 'well', 'mushroom_garden',
+]);
+
+/** Tile types that can be smoothed. */
+const SMOOTHABLE: ReadonlySet<string> = new Set([
+  'stone', 'cavern_wall', 'rock',
+]);
+
+/** Tile types that can be engraved (only already-smoothed stone). */
+const ENGRAVABLE: ReadonlySet<string> = new Set([
+  'smooth_stone',
 ]);
 
 export function useDesignation(opts: {
@@ -90,6 +104,8 @@ export function useDesignation(opts: {
     const buildable: string[] = ['open_air', 'grass', 'constructed_floor', 'cavern_floor'];
     const isMine = designationMode === 'mine';
     const isDeconstruct = designationMode === 'deconstruct';
+    const isSmooth = designationMode === 'smooth';
+    const isEngrave = designationMode === 'engrave';
     const taskType = designationMode as TaskType;
     const baseBuildWork = BUILD_WORK[designationMode] ?? WORK_BUILD_WALL;
     const priority = taskPriorities[taskType] ?? 5;
@@ -116,6 +132,10 @@ export function useDesignation(opts: {
           if (!mineable.includes(tile.tileType)) continue;
         } else if (isDeconstruct) {
           if (!DECONSTRUCTIBLE.has(tile.tileType)) continue;
+        } else if (isSmooth) {
+          if (!SMOOTHABLE.has(tile.tileType)) continue;
+        } else if (isEngrave) {
+          if (!ENGRAVABLE.has(tile.tileType)) continue;
         } else {
           if (!buildable.includes(tile.tileType)) continue;
         }
@@ -210,6 +230,18 @@ export function useDesignation(opts: {
     setDesignationMode((m) => (m === "deconstruct" ? "none" : "deconstruct"));
   }, []);
 
+  const toggleSmooth = useCallback(() => {
+    setBuildMenuOpen(false);
+    setPrioritiesOpen(false);
+    setDesignationMode((m) => (m === "smooth" ? "none" : "smooth"));
+  }, []);
+
+  const toggleEngrave = useCallback(() => {
+    setBuildMenuOpen(false);
+    setPrioritiesOpen(false);
+    setDesignationMode((m) => (m === "engrave" ? "none" : "engrave"));
+  }, []);
+
   const toggleBuildMenu = useCallback(() => {
     setDesignationMode("none");
     setPrioritiesOpen(false);
@@ -243,6 +275,8 @@ export function useDesignation(opts: {
     toggleMine,
     toggleStockpile,
     toggleDeconstruct,
+    toggleSmooth,
+    toggleEngrave,
     toggleBuildMenu,
     togglePriorities,
     cancelDesignation,

--- a/app/src/hooks/useKeyboard.ts
+++ b/app/src/hooks/useKeyboard.ts
@@ -12,7 +12,9 @@ export type KeyAction =
   | { type: "open_priorities" }
   | { type: "cancel_designation" }
   | { type: "designate_stockpile" }
-  | { type: "designate_deconstruct" };
+  | { type: "designate_deconstruct" }
+  | { type: "designate_smooth" }
+  | { type: "designate_engrave" };
 
 export function useKeyboard(onAction: (action: KeyAction) => void) {
   useEffect(() => {
@@ -76,6 +78,12 @@ export function useKeyboard(onAction: (action: KeyAction) => void) {
           break;
         case "D":
           onAction({ type: "designate_deconstruct" });
+          break;
+        case "O":
+          onAction({ type: "designate_smooth" });
+          break;
+        case "E":
+          onAction({ type: "designate_engrave" });
           break;
         case "Escape":
           onAction({ type: "cancel_designation" });


### PR DESCRIPTION
Closes #416

## Summary
- Adds **O** keyboard shortcut for smooth designation (targets stone, cavern_wall, rock tiles)
- Adds **E** keyboard shortcut for engrave designation (targets smooth_stone tiles only)
- Both create tasks that the sim already handles: smooth → smooth_stone, engrave → engraved_stone with a generated scene
- Adds keyboard hints to the BottomBar
- No sim changes — completion logic already existed in task-completion.ts

## Tile eligibility
| Mode | Valid tile types |
|---|---|
| Smooth | stone, cavern_wall, rock |
| Engrave | smooth_stone |

## Playtest
UI change. New designation modes work the same way as mine/deconstruct: drag to designate, Escape to cancel.

## Tests
All 58 app tests pass. No new pure functions introduced — this is wiring existing designate mechanics to new task types.

## Claude Cost
**Claude cost:** $0.36 (984k tokens)