### PR TITLE
feat: pause/resume button in toolbar

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -57,7 +57,7 @@ export default function App() {
   });
 
   // Sim runner — provides live in-memory state
-  const { snapshot } = useSimRunner(world.civId, world.worldId);
+  const { snapshot, isPaused, togglePause } = useSimRunner(world.civId, world.worldId);
 
   const { getTile: getFortressTile } = useFortressTiles({
     civId: world.civId,
@@ -403,6 +403,8 @@ export default function App() {
         mode={world.mode}
         onSignOut={signOut}
         onRestart={world.handleRestart}
+        onTogglePause={world.civId ? togglePause : undefined}
+        isPaused={isPaused}
         population={liveDwarves.length}
         year={snapshot?.year ?? 1}
         civName={world.mode === "fortress" ? "Stonegear" : undefined}

--- a/app/src/components/Toolbar.tsx
+++ b/app/src/components/Toolbar.tsx
@@ -5,13 +5,15 @@ interface ToolbarProps {
   mode: "fortress" | "world";
   onSignOut?: () => void;
   onRestart?: () => void;
+  onTogglePause?: () => void;
+  isPaused?: boolean;
   population?: number;
   year?: number;
   civName?: string;
   items?: Item[];
 }
 
-export default function Toolbar({ mode, onSignOut, onRestart, population = 0, year = 1, civName, items = [] }: ToolbarProps) {
+export default function Toolbar({ mode, onSignOut, onRestart, onTogglePause, isPaused = false, population = 0, year = 1, civName, items = [] }: ToolbarProps) {
   return (
     <header className="flex items-center justify-between px-3 py-1 border-b border-[var(--border)] bg-[var(--bg-panel)] text-xs select-none shrink-0">
       <div className="flex gap-4 items-center">
@@ -28,6 +30,18 @@ export default function Toolbar({ mode, onSignOut, onRestart, population = 0, ye
         <span>Pop: {population}</span>
         {mode === "fortress" && items.length > 0 && <ResourceCounter items={items} />}
         <span className="text-[var(--amber)]">No alerts</span>
+        {mode === "fortress" && onTogglePause && (
+          <button
+            onClick={onTogglePause}
+            className={`px-2 py-0.5 border cursor-pointer ${
+              isPaused
+                ? "border-[var(--amber)] text-[var(--amber)] hover:text-[var(--green)] hover:border-[var(--green)]"
+                : "border-[var(--border)] text-[var(--text)] hover:text-[var(--amber)] hover:border-[var(--amber)]"
+            }`}
+          >
+            {isPaused ? "Resume" : "Pause"}
+          </button>
+        )}
         {onRestart && (
           <button
             onClick={onRestart}

--- a/app/src/hooks/useSimRunner.ts
+++ b/app/src/hooks/useSimRunner.ts
@@ -8,6 +8,7 @@ export type { SimSnapshot };
 export function useSimRunner(civId: string | null, worldId: string | null) {
   const runnerRef = useRef<SimRunner | null>(null);
   const [snapshot, setSnapshot] = useState<SimSnapshot | null>(null);
+  const [isPaused, setIsPaused] = useState(false);
 
   // Throttle UI updates — emit at most every 100ms (10 fps) to avoid
   // re-rendering on every single sim tick (which runs at 10/s anyway).
@@ -28,9 +29,22 @@ export function useSimRunner(civId: string | null, worldId: string | null) {
     }
   }, []);
 
+  const togglePause = useCallback(() => {
+    const runner = runnerRef.current;
+    if (!runner) return;
+    if (runner.isPaused) {
+      runner.resume();
+      setIsPaused(false);
+    } else {
+      runner.pause();
+      setIsPaused(true);
+    }
+  }, []);
+
   useEffect(() => {
     if (!civId || !worldId) {
       setSnapshot(null);
+      setIsPaused(false);
       return;
     }
 
@@ -52,8 +66,9 @@ export function useSimRunner(civId: string | null, worldId: string | null) {
         console.error('[sim] failed to stop:', err);
       });
       runnerRef.current = null;
+      setIsPaused(false);
     };
   }, [civId, worldId, handleTick]);
 
-  return { runnerRef, snapshot };
+  return { runnerRef, snapshot, isPaused, togglePause };
 }

--- a/sim/src/sim-runner.ts
+++ b/sim/src/sim-runner.ts
@@ -57,6 +57,7 @@ export class SimRunner {
   stepCount = 0;
   currentYear = 1;
   currentDay = 1;
+  isPaused = false;
 
   constructor(adapter: StateAdapter) {
     this.adapter = adapter;
@@ -114,7 +115,25 @@ export class SimRunner {
     }, SIM_FLUSH_INTERVAL_MS);
   }
 
-  /** Pause the loop and persist state. */
+  /** Freeze the tick loop without flushing or unloading state. */
+  pause(): void {
+    if (this.isPaused || !this.timer) return;
+    clearInterval(this.timer);
+    this.timer = null;
+    this.isPaused = true;
+  }
+
+  /** Resume a paused tick loop. */
+  resume(): void {
+    if (!this.isPaused || !this.ctx) return;
+    this.isPaused = false;
+    const intervalMs = 1000 / STEPS_PER_SECOND;
+    this.timer = setInterval(() => {
+      void this.tick();
+    }, intervalMs);
+  }
+
+  /** Fully stop the sim, flush state, and unload. */
   async stop(): Promise<void> {
     if (this.timer) {
       clearInterval(this.timer);


### PR DESCRIPTION
Closes #417

## Summary
- Added `pause()` and `resume()` to `SimRunner` — pauses the tick interval without stopping the flush interval (state keeps persisting to Supabase while paused)
- `useSimRunner` now exposes `isPaused: boolean` and `togglePause: () => void`
- Toolbar shows a Pause/Resume button in fortress mode; highlights amber when paused

## Playtest
UI change in fortress mode. Verified build passes and all 579 sim tests pass. The pause/resume flow is straightforward — `pause()` clears `this.timer` and `resume()` restarts it at the same interval.

## Claude Cost
TBD

## Claude Cost
**Claude cost:** $74.52 (211.7M tokens)