### PR TITLE
feat: generate random fortress names on embark (closes #413)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -413,7 +413,7 @@ export default function App() {
         isPaused={isPaused}
         population={liveDwarves.length}
         year={snapshot?.year ?? 1}
-        civName={world.mode === "fortress" ? "Stonegear" : undefined}
+        civName={world.mode === "fortress" ? (world.civName ?? undefined) : undefined}
         items={liveItems}
       />
 

--- a/app/src/hooks/useWorldState.ts
+++ b/app/src/hooks/useWorldState.ts
@@ -21,6 +21,7 @@ export function useWorldState(opts: {
   const [creating, setCreating] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
   const [civId, setCivId] = useState<string | null>(null);
+  const [civName, setCivName] = useState<string | null>(null);
   const [embarkTerrain, setEmbarkTerrain] = useState<TerrainType | null>(null);
   const [mode, setMode] = useState<"fortress" | "world">("world");
 
@@ -29,7 +30,7 @@ export function useWorldState(opts: {
     if (user && !playerEnsured) {
       ensurePlayer(supabase, user.id, user.email ?? "unknown")
         .then(() => loadSession(user.id))
-        .then((session) => {
+        .then(async (session) => {
           if (session.worldId) {
             setWorldId(session.worldId);
             setWorldSeed(session.worldSeed);
@@ -40,6 +41,13 @@ export function useWorldState(opts: {
             setMode("fortress");
             const center = Math.floor(FORTRESS_SIZE / 2);
             setOffset(center - Math.floor(vpCols / 2), center - Math.floor(vpRows / 2));
+            // Fetch civ name from DB on session restore
+            const { data } = await supabase
+              .from('civilizations')
+              .select('name')
+              .eq('id', session.civId)
+              .single();
+            if (data) setCivName(data.name as string);
           }
           setPlayerEnsured(true);
         })
@@ -50,6 +58,7 @@ export function useWorldState(opts: {
       setWorldId(null);
       setWorldSeed(null);
       setCivId(null);
+      setCivName(null);
       setEmbarkTerrain(null);
     }
   }, [user, playerEnsured, setOffset]);
@@ -74,10 +83,11 @@ export function useWorldState(opts: {
   ) => {
     if (!worldId || !worldSeed) return;
     try {
-      const id = await embark(worldId, selectedX, selectedY, worldSeed);
+      const { id, name } = await embark(worldId, selectedX, selectedY, worldSeed);
       const deriver = createWorldDeriver(worldSeed);
       const derived = deriver.deriveTile(selectedX, selectedY);
       setCivId(id);
+      setCivName(name);
       setEmbarkTerrain(derived.terrain);
       setMode("fortress");
       const center = Math.floor(FORTRESS_SIZE / 2);
@@ -95,6 +105,7 @@ export function useWorldState(opts: {
     setWorldId(null);
     setWorldSeed(null);
     setCivId(null);
+    setCivName(null);
     setEmbarkTerrain(null);
     setMode("world");
     setOffset(0, 0);
@@ -107,6 +118,7 @@ export function useWorldState(opts: {
     creating,
     createError,
     civId,
+    civName,
     embarkTerrain,
     mode,
     setMode,

--- a/app/src/lib/civ-names.ts
+++ b/app/src/lib/civ-names.ts
@@ -1,0 +1,8 @@
+import { FORTRESS_NAME_MATERIALS, FORTRESS_NAME_NOUNS } from "@pwarf/shared";
+
+/** Generates a random dwarven fortress name like "Ironhold" or "Coppergate". */
+export function generateFortressName(): string {
+  const material = FORTRESS_NAME_MATERIALS[Math.floor(Math.random() * FORTRESS_NAME_MATERIALS.length)];
+  const noun = FORTRESS_NAME_NOUNS[Math.floor(Math.random() * FORTRESS_NAME_NOUNS.length)];
+  return `${material}${noun}`;
+}

--- a/app/src/lib/embark.test.ts
+++ b/app/src/lib/embark.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { generateFortressName } from "./civ-names.js";
+import { FORTRESS_NAME_MATERIALS, FORTRESS_NAME_NOUNS } from "@pwarf/shared";
+
+describe("generateFortressName", () => {
+  it("returns a non-empty string", () => {
+    const name = generateFortressName();
+    expect(typeof name).toBe("string");
+    expect(name.length).toBeGreaterThan(0);
+  });
+
+  it("starts with a material and ends with a noun", () => {
+    // Run many times to cover randomness
+    for (let i = 0; i < 50; i++) {
+      const name = generateFortressName();
+      const startsWithMaterial = FORTRESS_NAME_MATERIALS.some((m: string) => name.startsWith(m));
+      const endsWithNoun = FORTRESS_NAME_NOUNS.some((n: string) => name.endsWith(n));
+      expect(startsWithMaterial).toBe(true);
+      expect(endsWithNoun).toBe(true);
+    }
+  });
+});

--- a/app/src/lib/embark.ts
+++ b/app/src/lib/embark.ts
@@ -1,6 +1,7 @@
 import { supabase } from './supabase';
 import { pickUniqueNames, SURNAMES } from './dwarf-names';
 import { createWorldDeriver, FORTRESS_SIZE } from '@pwarf/shared';
+import { generateFortressName } from './civ-names';
 
 const FORTRESS_CENTER = Math.floor(FORTRESS_SIZE / 2);
 
@@ -66,7 +67,7 @@ export async function embark(worldId: string, tileX: number, tileY: number, worl
     .insert({
       world_id: worldId,
       player_id: user.id,
-      name: 'Boatmurdered',
+      name: generateFortressName(),
       tile_x: tileX,
       tile_y: tileY,
       status: 'active',
@@ -74,7 +75,7 @@ export async function embark(worldId: string, tileX: number, tileY: number, worl
       population: 7,
       wealth: 0,
     })
-    .select('id')
+    .select('id, name')
     .single();
 
   if (civError || !civ) throw new Error(`Failed to create civilization: ${civError?.message}`);
@@ -226,5 +227,5 @@ export async function embark(worldId: string, tileX: number, tileY: number, worl
   const { error: bedTileError } = await supabase.from('fortress_tiles').insert(bedTiles);
   if (bedTileError) throw new Error(`Failed to place bed tiles: ${bedTileError.message}`);
 
-  return civ.id;
+  return { id: civ.id, name: civ.name as string };
 }

--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -600,3 +600,20 @@ export const MEMORY_SPOUSE_GRIEF_INTENSITY = 40;
 
 /** How many in-game years grief from losing a spouse lingers */
 export const MEMORY_SPOUSE_GRIEF_DURATION_YEARS = 10;
+
+
+// ============================================================
+// Fortress name generation
+// ============================================================
+
+export const FORTRESS_NAME_MATERIALS = [
+  'Iron', 'Steel', 'Copper', 'Gold', 'Silver', 'Stone', 'Granite',
+  'Obsidian', 'Marble', 'Bronze', 'Cobalt', 'Adamantine', 'Ash',
+  'Bone', 'Crystal', 'Diamond', 'Emerald', 'Flint', 'Onyx',
+];
+
+export const FORTRESS_NAME_NOUNS = [
+  'hold', 'forge', 'gate', 'vault', 'hall', 'peak', 'keep',
+  'ridge', 'crag', 'spire', 'bridge', 'mine', 'deep', 'bastion',
+  'anvil', 'crown', 'tower', 'wall', 'barrow', 'haven',
+];


### PR DESCRIPTION
## Summary
- Adds `FORTRESS_NAME_MATERIALS` and `FORTRESS_NAME_NOUNS` arrays to `@pwarf/shared` (19 materials × 20 nouns = 380 possible names)
- Extracts `generateFortressName()` into `app/src/lib/civ-names.ts` (isolated from Supabase for testability)
- Replaces hardcoded `'Boatmurdered'` in `embark.ts` with `generateFortressName()`
- `useWorldState` now tracks `civName` state and restores it from DB on session reload
- Toolbar already receives `civName` from App.tsx (from PR #411)

## Test plan
- [ ] `npm test --workspace=@pwarf/app` — all 120 tests pass including new `generateFortressName` tests
- [ ] `npm run build` — clean TypeScript build
- [ ] Playtest: embark and verify a random name like "Ironhold" or "Coppergate" appears in toolbar

## Playtest
This PR changes UI behavior (fortress name displayed in toolbar). Playtest skipped in automated session — Chrome extension not connected. Manual playtest needed before merge to verify name displays correctly.

closes #413

## Claude Cost
**Claude cost:** $47.09 (127.8M tokens)