### PR TITLE
feat: keyboard shortcuts for pause (Space) and speed (1/2/5)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -270,9 +270,15 @@ export default function App() {
           designation.cancelDesignation();
           setFollowedDwarfId(null);
           break;
+        case "toggle_pause":
+          if (world.mode === "fortress" && world.civId) togglePause();
+          break;
+        case "set_speed":
+          if (world.mode === "fortress" && world.civId) setSpeed(action.multiplier);
+          break;
       }
     },
-    [viewport.pan, world.civId, world.mode, designation],
+    [viewport.pan, world.civId, world.mode, designation, togglePause, setSpeed],
   );
 
   useKeyboard(handleKeyAction);

--- a/app/src/hooks/useKeyboard.ts
+++ b/app/src/hooks/useKeyboard.ts
@@ -14,7 +14,9 @@ export type KeyAction =
   | { type: "designate_stockpile" }
   | { type: "designate_deconstruct" }
   | { type: "designate_smooth" }
-  | { type: "designate_engrave" };
+  | { type: "designate_engrave" }
+  | { type: "toggle_pause" }
+  | { type: "set_speed"; multiplier: 1 | 2 | 5 };
 
 export function useKeyboard(onAction: (action: KeyAction) => void) {
   useEffect(() => {
@@ -87,6 +89,19 @@ export function useKeyboard(onAction: (action: KeyAction) => void) {
           break;
         case "Escape":
           onAction({ type: "cancel_designation" });
+          break;
+        case " ":
+          e.preventDefault();
+          onAction({ type: "toggle_pause" });
+          break;
+        case "1":
+          onAction({ type: "set_speed", multiplier: 1 });
+          break;
+        case "2":
+          onAction({ type: "set_speed", multiplier: 2 });
+          break;
+        case "5":
+          onAction({ type: "set_speed", multiplier: 5 });
           break;
       }
     }


### PR DESCRIPTION
Adds keyboard shortcuts for pause and speed controls.

- `Space` — toggle pause/resume (fortress mode only)
- `1` — set speed to 1×
- `2` — set speed to 2×
- `5` — set speed to 5×

These map to the new `toggle_pause` and `set_speed` `KeyAction` types added to `useKeyboard.ts`.

closes #425

## Playtest

UI-only change (no sim logic, no DB). Tested via build + existing tests.

- `npm run build` ✓
- `npm test` ✓ (579 tests passed)

## Claude Cost
**Claude cost:** $78.00 (221.5M tokens)