### PR TITLE
feat: stress bar and sort-by-stress in dwarf roster (closes #429)

### DIFF
--- a/app/src/components/LeftPanel.test.ts
+++ b/app/src/components/LeftPanel.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { stressColor } from "./LeftPanel";
+import { stressColor, stressBarColor } from "./LeftPanel";
 
 describe("stressColor", () => {
   it("returns green for low stress (0)", () => {
@@ -24,5 +24,39 @@ describe("stressColor", () => {
 
   it("returns red for max stress (100)", () => {
     expect(stressColor(100)).toBe("var(--red)");
+  });
+});
+
+describe("stressBarColor", () => {
+  it("returns green for low stress (0)", () => {
+    expect(stressBarColor(0)).toBe("var(--green)");
+  });
+
+  it("returns green at boundary (30)", () => {
+    expect(stressBarColor(30)).toBe("var(--green)");
+  });
+
+  it("returns amber for moderate stress (31)", () => {
+    expect(stressBarColor(31)).toBe("var(--amber)");
+  });
+
+  it("returns amber at boundary (60)", () => {
+    expect(stressBarColor(60)).toBe("var(--amber)");
+  });
+
+  it("returns orange for elevated stress (61)", () => {
+    expect(stressBarColor(61)).toBe("#f97316");
+  });
+
+  it("returns orange at boundary (80)", () => {
+    expect(stressBarColor(80)).toBe("#f97316");
+  });
+
+  it("returns red for high stress (81)", () => {
+    expect(stressBarColor(81)).toBe("var(--red)");
+  });
+
+  it("returns red for max stress (100)", () => {
+    expect(stressBarColor(100)).toBe("var(--red)");
   });
 });

--- a/app/src/components/LeftPanel.tsx
+++ b/app/src/components/LeftPanel.tsx
@@ -1,13 +1,25 @@
+import { useState } from "react";
 import type { WorldTile, Item } from "@pwarf/shared";
 import type { LiveDwarf } from "../hooks/useDwarves";
 import type { ActiveTask } from "../hooks/useTasks";
 
 const AUTONOMOUS_TASK_TYPES: ReadonlySet<string> = new Set(['eat', 'drink', 'sleep', 'wander']);
 
+type DwarfSortMode = "stress" | "name" | "activity";
+const SORT_CYCLE: DwarfSortMode[] = ["stress", "name", "activity"];
+
 /** Returns a CSS color for a dwarf's name based on their stress level (0–100). */
 export function stressColor(stressLevel: number): string {
   if (stressLevel >= 67) return "var(--red)";
   if (stressLevel >= 34) return "var(--amber)";
+  return "var(--green)";
+}
+
+/** Returns a CSS color for the stress bar fill (0–100). */
+export function stressBarColor(stressLevel: number): string {
+  if (stressLevel > 80) return "var(--red)";
+  if (stressLevel > 60) return "#f97316"; // orange
+  if (stressLevel > 30) return "var(--amber)";
   return "var(--green)";
 }
 
@@ -38,6 +50,18 @@ function dwarfJobLabel(d: LiveDwarf, tasks?: ActiveTask[]): string {
 
 export default function LeftPanel({ mode, collapsed, onToggle, cursorTile, onEmbark, dwarves = [], onDwarfClick, items = [], tasks, selectedFortressTile, stockpileTiles, zLevel = 0 }: LeftPanelProps) {
   const isOcean = cursorTile?.terrain === "ocean";
+  const [sortMode, setSortMode] = useState<DwarfSortMode>("stress");
+
+  function cycleSortMode() {
+    const idx = SORT_CYCLE.indexOf(sortMode);
+    setSortMode(SORT_CYCLE[(idx + 1) % SORT_CYCLE.length]);
+  }
+
+  const sortedDwarves = [...dwarves].sort((a, b) => {
+    if (sortMode === "stress") return b.stress_level - a.stress_level;
+    if (sortMode === "name") return a.name.localeCompare(b.name);
+    return dwarfJobLabel(a, tasks).localeCompare(dwarfJobLabel(b, tasks));
+  });
 
   return (
     <aside
@@ -91,19 +115,36 @@ export default function LeftPanel({ mode, collapsed, onToggle, cursorTile, onEmb
               </div>
             ) : (
               <>
-                <h2 className="text-[var(--amber)] mb-1 font-bold">Dwarves</h2>
-                <ul className="space-y-0.5">
-                  {dwarves.map((d) => (
+                <button
+                  className="text-[var(--amber)] mb-1 font-bold w-full text-left cursor-pointer hover:text-[var(--green)]"
+                  onClick={cycleSortMode}
+                  title={`Sort: ${sortMode} (click to cycle)`}
+                >
+                  Dwarves <span className="text-[var(--border)] font-normal">[{sortMode}]</span>
+                </button>
+                <ul className="space-y-1">
+                  {sortedDwarves.map((d) => (
                     <li
                       key={d.id}
-                      className="flex justify-between hover:bg-[var(--bg-hover)] px-1 cursor-pointer"
+                      className="hover:bg-[var(--bg-hover)] px-1 cursor-pointer"
                       onClick={() => onDwarfClick?.(d.id)}
                     >
-                      <span style={{ color: stressColor(d.stress_level) }}>{d.name}</span>
-                      <span className="text-[var(--text)]">
-                        <span className="text-[var(--border)] mr-1">z{d.position_z}</span>
-                        {dwarfJobLabel(d, tasks)}
-                      </span>
+                      <div className="flex justify-between">
+                        <span style={{ color: stressColor(d.stress_level) }}>{d.name}</span>
+                        <span className="text-[var(--text)]">
+                          <span className="text-[var(--border)] mr-1">z{d.position_z}</span>
+                          {dwarfJobLabel(d, tasks)}
+                        </span>
+                      </div>
+                      <div className="h-1 w-full bg-[var(--border)] rounded-sm mt-0.5">
+                        <div
+                          className="h-full rounded-sm"
+                          style={{
+                            width: `${d.stress_level}%`,
+                            backgroundColor: stressBarColor(d.stress_level),
+                          }}
+                        />
+                      </div>
                     </li>
                   ))}
                   {dwarves.length === 0 && (


### PR DESCRIPTION
## Summary
- Each dwarf in the roster now shows a color-coded stress bar below their name (green 0–30, amber 31–60, orange 61–80, red 81–100)
- Roster defaults to sort by stress (highest first)
- Clicking the \"Dwarves\" header cycles sort mode: stress → name → activity
- Sort mode label shown in brackets next to header

## Test plan
- [x] `npm run build` — passes
- [x] `npm test --workspace=@pwarf/app` — 68 tests pass (8 new for `stressBarColor`)
- [ ] UI change — requires `/playtest` to verify bars render and sort works

## Playtest
UI change. Automated session — browser not available. Manual verification needed before merge.

closes #429

## Claude Cost
**Claude cost:** $0.28 (749k tokens)