### PR TITLE
feat: live alerts in toolbar (tantrum, starvation, critical health, stress)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -435,6 +435,7 @@ export default function App() {
         civName={world.mode === "fortress" ? (world.civName ?? undefined) : undefined}
         items={liveItems}
         wealth={civWealth}
+        dwarves={liveDwarves}
       />
 
       <div className="flex flex-1 min-h-0 relative">

--- a/app/src/components/Toolbar.tsx
+++ b/app/src/components/Toolbar.tsx
@@ -1,5 +1,7 @@
 import type { Item } from "@pwarf/shared";
 import ResourceCounter from "./ResourceCounter";
+import { deriveAlert } from "../utils/alerts";
+import type { LiveDwarf } from "../hooks/useDwarves";
 
 const SPEEDS = [1, 2, 5] as const;
 
@@ -16,9 +18,12 @@ interface ToolbarProps {
   civName?: string;
   items?: Item[];
   wealth?: number;
+  dwarves?: LiveDwarf[];
 }
 
-export default function Toolbar({ mode, onSignOut, onRestart, onTogglePause, isPaused = false, speed = 1, onSetSpeed, population = 0, year = 1, civName, items = [], wealth = 0 }: ToolbarProps) {
+export default function Toolbar({ mode, onSignOut, onRestart, onTogglePause, isPaused = false, speed = 1, onSetSpeed, population = 0, year = 1, civName, items = [], wealth = 0, dwarves = [] }: ToolbarProps) {
+  const alert = mode === "fortress" ? deriveAlert(dwarves) : null;
+
   return (
     <header className="flex items-center justify-between px-3 py-1 border-b border-[var(--border)] bg-[var(--bg-panel)] text-xs select-none shrink-0">
       <div className="flex gap-4 items-center">
@@ -35,7 +40,17 @@ export default function Toolbar({ mode, onSignOut, onRestart, onTogglePause, isP
         <span>Pop: {population}</span>
         {mode === "fortress" && <span className="text-[var(--amber)]">§ {wealth.toLocaleString()}</span>}
         {mode === "fortress" && items.length > 0 && <ResourceCounter items={items} />}
-        <span className="text-[var(--amber)]">No alerts</span>
+        {mode === "fortress" && (
+          alert ? (
+            <span
+              className={alert.severity === "critical" ? "text-[var(--red,#f87171)] font-bold" : "text-[var(--amber)]"}
+            >
+              ⚠ {alert.message}
+            </span>
+          ) : (
+            <span className="text-[var(--border)]">No alerts</span>
+          )
+        )}
         {mode === "fortress" && onTogglePause && (
           <div className="flex items-center gap-1">
             <button

--- a/app/src/utils/alerts.test.ts
+++ b/app/src/utils/alerts.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { deriveAlert } from "./alerts";
+
+function makeDwarf(overrides: Partial<{
+  name: string;
+  is_in_tantrum: boolean;
+  need_food: number;
+  need_drink: number;
+  health: number;
+  stress_level: number;
+}> = {}) {
+  return {
+    name: "Urist",
+    is_in_tantrum: false,
+    need_food: 80,
+    need_drink: 80,
+    health: 100,
+    stress_level: 20,
+    ...overrides,
+  };
+}
+
+describe("deriveAlert", () => {
+  it("returns null when all dwarves are healthy", () => {
+    expect(deriveAlert([makeDwarf(), makeDwarf({ name: "Kadol" })])).toBeNull();
+  });
+
+  it("returns null for empty dwarves list", () => {
+    expect(deriveAlert([])).toBeNull();
+  });
+
+  it("detects single dwarf tantrum", () => {
+    const alert = deriveAlert([makeDwarf({ name: "Mafol", is_in_tantrum: true })]);
+    expect(alert?.message).toBe("Mafol in tantrum");
+    expect(alert?.severity).toBe("critical");
+  });
+
+  it("detects multiple dwarves in tantrum", () => {
+    const alert = deriveAlert([
+      makeDwarf({ is_in_tantrum: true }),
+      makeDwarf({ is_in_tantrum: true }),
+    ]);
+    expect(alert?.message).toBe("2 dwarves in tantrum");
+    expect(alert?.severity).toBe("critical");
+  });
+
+  it("detects starvation (need_food below threshold)", () => {
+    const alert = deriveAlert([makeDwarf({ name: "Doren", need_food: 10 })]);
+    expect(alert?.message).toBe("Doren starving");
+    expect(alert?.severity).toBe("critical");
+  });
+
+  it("detects dehydration (need_drink below threshold)", () => {
+    const alert = deriveAlert([makeDwarf({ name: "Litast", need_drink: 5 })]);
+    expect(alert?.message).toBe("Litast starving");
+    expect(alert?.severity).toBe("critical");
+  });
+
+  it("detects multiple dwarves starving", () => {
+    const alert = deriveAlert([
+      makeDwarf({ need_food: 5 }),
+      makeDwarf({ need_food: 10 }),
+    ]);
+    expect(alert?.message).toBe("2 dwarves starving");
+  });
+
+  it("detects critical health", () => {
+    const alert = deriveAlert([makeDwarf({ name: "Urist", health: 15 })]);
+    expect(alert?.message).toBe("Urist critically wounded");
+    expect(alert?.severity).toBe("critical");
+  });
+
+  it("detects high stress as warning", () => {
+    const alert = deriveAlert([makeDwarf({ name: "Urist", stress_level: 92 })]);
+    expect(alert?.message).toBe("Urist at breaking point");
+    expect(alert?.severity).toBe("warning");
+  });
+
+  it("detects multiple stressed dwarves", () => {
+    const alert = deriveAlert([
+      makeDwarf({ stress_level: 95 }),
+      makeDwarf({ stress_level: 91 }),
+    ]);
+    expect(alert?.message).toBe("2 dwarves near breaking point");
+  });
+
+  it("prioritizes tantrum over starvation", () => {
+    const alert = deriveAlert([
+      makeDwarf({ name: "Urist", need_food: 5 }),
+      makeDwarf({ name: "Kadol", is_in_tantrum: true }),
+    ]);
+    expect(alert?.message).toContain("tantrum");
+  });
+
+  it("prioritizes starvation over high stress", () => {
+    const alert = deriveAlert([
+      makeDwarf({ name: "Urist", stress_level: 95 }),
+      makeDwarf({ name: "Kadol", need_food: 5 }),
+    ]);
+    expect(alert?.message).toContain("starving");
+  });
+});

--- a/app/src/utils/alerts.ts
+++ b/app/src/utils/alerts.ts
@@ -1,0 +1,63 @@
+export interface AlertInfo {
+  message: string;
+  severity: "critical" | "warning";
+}
+
+interface DwarfAlertData {
+  name: string;
+  is_in_tantrum: boolean;
+  need_food: number;
+  need_drink: number;
+  health: number;
+  stress_level: number;
+}
+
+const CRITICAL_NEED_THRESHOLD = 15;
+const CRITICAL_HEALTH_THRESHOLD = 20;
+const HIGH_STRESS_THRESHOLD = 90;
+
+/**
+ * Derives the highest-priority alert from the current dwarf list.
+ * Returns null if everything is fine.
+ */
+export function deriveAlert(dwarves: DwarfAlertData[]): AlertInfo | null {
+  const aliveDwarves = dwarves.filter(d => d.need_food > 0 || d.need_drink > 0 || d.health > 0);
+
+  // Priority 1: tantrum
+  const tantrumDwarves = aliveDwarves.filter(d => d.is_in_tantrum);
+  if (tantrumDwarves.length === 1) {
+    return { message: `${tantrumDwarves[0].name} in tantrum`, severity: "critical" };
+  }
+  if (tantrumDwarves.length > 1) {
+    return { message: `${tantrumDwarves.length} dwarves in tantrum`, severity: "critical" };
+  }
+
+  // Priority 2: starvation / dehydration
+  const starvingDwarves = aliveDwarves.filter(d => d.need_food < CRITICAL_NEED_THRESHOLD || d.need_drink < CRITICAL_NEED_THRESHOLD);
+  if (starvingDwarves.length === 1) {
+    return { message: `${starvingDwarves[0].name} starving`, severity: "critical" };
+  }
+  if (starvingDwarves.length > 1) {
+    return { message: `${starvingDwarves.length} dwarves starving`, severity: "critical" };
+  }
+
+  // Priority 3: critical health
+  const criticalHealth = aliveDwarves.filter(d => d.health < CRITICAL_HEALTH_THRESHOLD);
+  if (criticalHealth.length === 1) {
+    return { message: `${criticalHealth[0].name} critically wounded`, severity: "critical" };
+  }
+  if (criticalHealth.length > 1) {
+    return { message: `${criticalHealth.length} dwarves critically wounded`, severity: "critical" };
+  }
+
+  // Priority 4: high stress
+  const stressedDwarves = aliveDwarves.filter(d => d.stress_level >= HIGH_STRESS_THRESHOLD);
+  if (stressedDwarves.length === 1) {
+    return { message: `${stressedDwarves[0].name} at breaking point`, severity: "warning" };
+  }
+  if (stressedDwarves.length > 1) {
+    return { message: `${stressedDwarves.length} dwarves near breaking point`, severity: "warning" };
+  }
+
+  return null;
+}


### PR DESCRIPTION
Replaces the hardcoded "No alerts" in the toolbar with live, derived alerts from the sim snapshot.

**Alert priority (highest first):**
1. 🔴 Tantrum — any dwarf with `is_in_tantrum = true`
2. 🔴 Starvation/dehydration — any dwarf with `need_food < 15` or `need_drink < 15`
3. 🔴 Critical health — any dwarf with `health < 20`
4. 🟡 High stress — any dwarf with `stress_level >= 90`

Critical alerts are red/bold; stress warnings are amber; "No alerts" is now dim gray.

**Example messages:** `⚠ Urist in tantrum`, `⚠ 3 dwarves starving`, `⚠ Kadol at breaking point`

**Implementation:** Pure `deriveAlert(dwarves)` function in `app/src/utils/alerts.ts`. `liveDwarves` passed from App.tsx to Toolbar as `dwarves` prop.

closes #433

## Playtest

UI-only change (no sim logic, no DB). Verified with build + tests.

- `npm run build` ✓
- `npm test --workspace=app` ✓ (12 new tests for `deriveAlert`)
- `npm test --workspace=sim` ✓ (579 tests)

## Claude Cost
**Claude cost:** $28.69 (77.8M tokens)