### PR TITLE
feat: skill star ratings in DwarfModal and activity icons in roster (closes #437)

### DIFF
--- a/app/src/components/DwarfModal.test.ts
+++ b/app/src/components/DwarfModal.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { levelToStars } from "../lib/dwarf-skills.js";
+
+describe("levelToStars", () => {
+  it("returns 0 stars for level 0", () => {
+    expect(levelToStars(0)).toBe(0);
+  });
+
+  it("returns 1 star for levels 1–4", () => {
+    expect(levelToStars(1)).toBe(1);
+    expect(levelToStars(4)).toBe(1);
+  });
+
+  it("returns 2 stars for levels 5–8", () => {
+    expect(levelToStars(5)).toBe(2);
+    expect(levelToStars(8)).toBe(2);
+  });
+
+  it("returns 3 stars for levels 9–12", () => {
+    expect(levelToStars(9)).toBe(3);
+    expect(levelToStars(12)).toBe(3);
+  });
+
+  it("returns 4 stars for levels 13–15", () => {
+    expect(levelToStars(13)).toBe(4);
+    expect(levelToStars(15)).toBe(4);
+  });
+
+  it("returns 5 stars for levels 16–20", () => {
+    expect(levelToStars(16)).toBe(5);
+    expect(levelToStars(20)).toBe(5);
+  });
+});

--- a/app/src/components/DwarfModal.tsx
+++ b/app/src/components/DwarfModal.tsx
@@ -13,6 +13,8 @@ interface DwarfModalProps {
   tasks?: ActiveTask[];
 }
 
+import { skillStars } from "../lib/dwarf-skills";
+
 const AUTONOMOUS_TASK_TYPES: ReadonlySet<string> = new Set(['eat', 'drink', 'sleep', 'wander']);
 
 function dwarfJobLabel(d: LiveDwarf, tasks?: ActiveTask[]): string {
@@ -147,7 +149,7 @@ export function DwarfModal({ dwarf, onClose, onGoTo, items = [], tasks }: DwarfM
               {skills.slice(0, 5).map((s) => (
                 <li key={s.id} className="flex justify-between">
                   <span className="text-[var(--text)] capitalize">{s.skill_name.replace(/_/g, ' ')}</span>
-                  <span className="text-[var(--green)]">Lv {s.level}</span>
+                  <span className="text-[var(--amber)]" title={`Lv ${s.level}`}>{skillStars(s.level)}</span>
                 </li>
               ))}
             </ul>

--- a/app/src/components/LeftPanel.test.ts
+++ b/app/src/components/LeftPanel.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { stressColor, stressBarColor, sortDwarves } from "./LeftPanel";
+import { stressColor, stressBarColor, sortDwarves, activityIcon } from "./LeftPanel";
 import type { LiveDwarf } from "../hooks/useDwarves";
+import type { ActiveTask } from "../hooks/useTasks";
 
 describe("stressColor", () => {
   it("returns green for low stress (0)", () => {
@@ -97,5 +98,49 @@ describe("sortDwarves", () => {
     const original = [...dwarves];
     sortDwarves(dwarves, "stress");
     expect(dwarves).toEqual(original);
+  });
+});
+
+describe("activityIcon", () => {
+  function makeD(overrides: Partial<LiveDwarf>): LiveDwarf {
+    return {
+      id: "1", name: "Urist", surname: null, status: "alive", age: null, gender: null,
+      is_in_tantrum: false, position_x: 0, position_y: 0, position_z: 0,
+      current_task_id: null, stress_level: 0,
+      need_food: 100, need_drink: 100, need_sleep: 100, need_social: 100, need_purpose: 100, need_beauty: 100,
+      health: 100, memories: [], ...overrides,
+    };
+  }
+
+  function makeTask(overrides: Partial<ActiveTask>): ActiveTask {
+    return { id: "t1", task_type: "mine", status: "active", target_x: null, target_y: null, target_z: null, work_required: 10, work_progress: 0, ...overrides };
+  }
+
+  it("returns · for idle dwarf", () => {
+    expect(activityIcon(makeD({}))).toBe("·");
+  });
+
+  it("returns 😤 for tantrum", () => {
+    expect(activityIcon(makeD({ is_in_tantrum: true, current_task_id: "t1" }))).toBe("😤");
+  });
+
+  it("returns 💤 for sleeping", () => {
+    const task = makeTask({ id: "t1", task_type: "sleep" });
+    expect(activityIcon(makeD({ current_task_id: "t1" }), [task])).toBe("💤");
+  });
+
+  it("returns 🍖 for eating", () => {
+    const task = makeTask({ id: "t1", task_type: "eat" });
+    expect(activityIcon(makeD({ current_task_id: "t1" }), [task])).toBe("🍖");
+  });
+
+  it("returns 🍖 for drinking", () => {
+    const task = makeTask({ id: "t1", task_type: "drink" });
+    expect(activityIcon(makeD({ current_task_id: "t1" }), [task])).toBe("🍖");
+  });
+
+  it("returns ⛏ for any active work task", () => {
+    const task = makeTask({ id: "t1", task_type: "mine" });
+    expect(activityIcon(makeD({ current_task_id: "t1" }), [task])).toBe("⛏");
   });
 });

--- a/app/src/components/LeftPanel.tsx
+++ b/app/src/components/LeftPanel.tsx
@@ -47,6 +47,18 @@ function dwarfJobLabel(d: LiveDwarf, tasks?: ActiveTask[]): string {
   return `${label} (${pct}%)`;
 }
 
+/** Returns a contextual activity icon for a dwarf. */
+export function activityIcon(d: LiveDwarf, tasks?: ActiveTask[]): string {
+  if (d.is_in_tantrum) return "😤";
+  if (!d.current_task_id) return "·";
+  const task = tasks?.find(t => t.id === d.current_task_id);
+  if (!task) return "⛏";
+  const type = task.task_type;
+  if (type === "sleep") return "💤";
+  if (type === "eat" || type === "drink") return "🍖";
+  return "⛏";
+}
+
 const SORT_CYCLE: Record<SortMode, SortMode> = {
   stress: "name",
   name: "activity",
@@ -144,6 +156,7 @@ export default function LeftPanel({ mode, collapsed, onToggle, cursorTile, onEmb
                       <div className="flex justify-between">
                         <span style={{ color: stressColor(d.stress_level) }}>{d.name}</span>
                         <span className="text-[var(--text)]">
+                          <span className="mr-1">{activityIcon(d, tasks)}</span>
                           <span className="text-[var(--border)] mr-1">z{d.position_z}</span>
                           {dwarfJobLabel(d, tasks)}
                         </span>

--- a/app/src/lib/dwarf-skills.ts
+++ b/app/src/lib/dwarf-skills.ts
@@ -1,0 +1,14 @@
+/** Maps a skill level (0–20) to a 0–5 star count. */
+export function levelToStars(level: number): number {
+  if (level === 0) return 0;
+  if (level >= 16) return 5;
+  if (level >= 13) return 4;
+  if (level >= 9) return 3;
+  if (level >= 5) return 2;
+  return 1;
+}
+
+export function skillStars(level: number): string {
+  const stars = levelToStars(level);
+  return '★'.repeat(stars) + '☆'.repeat(5 - stars);
+}


### PR DESCRIPTION
## Summary
- **DwarfModal**: Replaces `Lv N` text with ★☆☆☆☆ star ratings (5 stars = level 16-20, title tooltip still shows level number)
- **Dwarf roster**: Prefixes each job with a contextual icon: 😤 tantrum, 💤 sleeping, 🍖 eating/drinking, ⛏ working, · idle
- `levelToStars` and `skillStars` extracted to `app/src/lib/dwarf-skills.ts` for testability

## Test plan
- [x] `npm run build` — passes
- [x] `npm test --workspace=@pwarf/app` — 91 tests pass (12 new)
- [ ] UI change — requires `/playtest` with before/after screenshots

closes #437

## Claude Cost
**Claude cost:** $29.11 (79.2M tokens)