### PR TITLE
feat: auto-brew phase — dwarves brew drinks when stocks are low

### DIFF
--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -448,6 +448,9 @@ export const WORK_ENGRAVE = 60;
 /** Work required to brew a batch of ale */
 export const WORK_BREW = 50;
 
+/** Minimum drink item count before auto-brew creates a new brew task */
+export const MIN_DRINK_STOCK = 10;
+
 /** Work required to cook a meal */
 export const WORK_COOK = 40;
 

--- a/sim/src/phases/auto-brew.test.ts
+++ b/sim/src/phases/auto-brew.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { autoBrew } from "./auto-brew.js";
+import { makeItem, makeContext } from "../__tests__/test-helpers.js";
+import { MIN_DRINK_STOCK } from "@pwarf/shared";
+
+describe("autoBrew", () => {
+  it("does not create a brew task when drink count is at threshold", async () => {
+    const drinks = Array.from({ length: MIN_DRINK_STOCK }, () =>
+      makeItem({ category: "drink", position_x: 5, position_y: 5, position_z: 0 }),
+    );
+    const plant = makeItem({ category: "raw_material", position_x: 3, position_y: 3, position_z: 0 });
+    const ctx = makeContext({ items: [...drinks, plant] });
+
+    await autoBrew(ctx);
+
+    expect(ctx.state.tasks.filter(t => t.task_type === "brew")).toHaveLength(0);
+  });
+
+  it("does not create a brew task when drink count exceeds threshold", async () => {
+    const drinks = Array.from({ length: MIN_DRINK_STOCK + 5 }, () =>
+      makeItem({ category: "drink", position_x: 5, position_y: 5, position_z: 0 }),
+    );
+    const plant = makeItem({ category: "raw_material", position_x: 3, position_y: 3, position_z: 0 });
+    const ctx = makeContext({ items: [...drinks, plant] });
+
+    await autoBrew(ctx);
+
+    expect(ctx.state.tasks.filter(t => t.task_type === "brew")).toHaveLength(0);
+  });
+
+  it("creates a brew task when drink count is below threshold and plant exists", async () => {
+    const drinks = Array.from({ length: MIN_DRINK_STOCK - 1 }, () =>
+      makeItem({ category: "drink", position_x: 5, position_y: 5, position_z: 0 }),
+    );
+    const plant = makeItem({ category: "raw_material", position_x: 3, position_y: 3, position_z: 0 });
+    const ctx = makeContext({ items: [...drinks, plant] });
+
+    await autoBrew(ctx);
+
+    const brewTasks = ctx.state.tasks.filter(t => t.task_type === "brew");
+    expect(brewTasks).toHaveLength(1);
+    expect(brewTasks[0].target_x).toBe(3);
+    expect(brewTasks[0].target_y).toBe(3);
+    expect(brewTasks[0].target_z).toBe(0);
+    expect(brewTasks[0].status).toBe("pending");
+  });
+
+  it("does not create a brew task when no plant items exist", async () => {
+    const ctx = makeContext({ items: [] });
+
+    await autoBrew(ctx);
+
+    expect(ctx.state.tasks.filter(t => t.task_type === "brew")).toHaveLength(0);
+  });
+
+  it("does not create a brew task when plant is held by a dwarf", async () => {
+    const plant = makeItem({
+      category: "raw_material",
+      held_by_dwarf_id: "some-dwarf-id",
+      position_x: 3,
+      position_y: 3,
+      position_z: 0,
+    });
+    const ctx = makeContext({ items: [plant] });
+
+    await autoBrew(ctx);
+
+    expect(ctx.state.tasks.filter(t => t.task_type === "brew")).toHaveLength(0);
+  });
+
+  it("does not create a duplicate brew task when one already pending", async () => {
+    const plant = makeItem({ category: "raw_material", position_x: 3, position_y: 3, position_z: 0 });
+    const ctx = makeContext({ items: [plant] });
+
+    // First call — creates a task
+    await autoBrew(ctx);
+    expect(ctx.state.tasks.filter(t => t.task_type === "brew")).toHaveLength(1);
+
+    // Second call — should not create another
+    await autoBrew(ctx);
+    expect(ctx.state.tasks.filter(t => t.task_type === "brew")).toHaveLength(1);
+  });
+
+  it("creates a new brew task after the previous one completes", async () => {
+    const plant = makeItem({ category: "raw_material", position_x: 3, position_y: 3, position_z: 0 });
+    const ctx = makeContext({ items: [plant] });
+
+    await autoBrew(ctx);
+    expect(ctx.state.tasks.filter(t => t.task_type === "brew")).toHaveLength(1);
+
+    // Mark the task as completed
+    ctx.state.tasks.find(t => t.task_type === "brew")!.status = "completed";
+
+    // Should create a new one
+    await autoBrew(ctx);
+    const brewTasks = ctx.state.tasks.filter(t => t.task_type === "brew");
+    expect(brewTasks.filter(t => t.status === "pending")).toHaveLength(1);
+  });
+});

--- a/sim/src/phases/auto-brew.ts
+++ b/sim/src/phases/auto-brew.ts
@@ -1,0 +1,46 @@
+import { MIN_DRINK_STOCK, WORK_BREW } from "@pwarf/shared";
+import type { SimContext } from "../sim-context.js";
+import { createTask } from "../task-helpers.js";
+
+/**
+ * Auto-Brew Phase
+ *
+ * When drink stocks fall below MIN_DRINK_STOCK and raw plant materials are
+ * available, automatically creates a brew task so a brewer will produce ale.
+ * This prevents dwarves dying of thirst once starting supplies run out.
+ *
+ * Only one pending brew task is created at a time to avoid flooding the queue.
+ */
+export async function autoBrew(ctx: SimContext): Promise<void> {
+  const { state } = ctx;
+
+  // Count available drinks (not held by any dwarf)
+  const drinkCount = state.items.filter(
+    i => i.category === 'drink' && i.held_by_dwarf_id === null,
+  ).length;
+
+  if (drinkCount >= MIN_DRINK_STOCK) return;
+
+  // Check if a brew task already exists (pending or in-progress)
+  const brewPending = state.tasks.some(
+    t => t.task_type === 'brew' &&
+      (t.status === 'pending' || t.status === 'claimed' || t.status === 'in_progress'),
+  );
+  if (brewPending) return;
+
+  // Find a plant (raw_material) item not held by any dwarf
+  const plant = state.items.find(
+    i => i.category === 'raw_material' && i.held_by_dwarf_id === null &&
+      i.position_x !== null && i.position_y !== null && i.position_z !== null,
+  );
+  if (!plant) return;
+
+  createTask(ctx, {
+    task_type: 'brew',
+    priority: 6,
+    target_x: plant.position_x!,
+    target_y: plant.position_y!,
+    target_z: plant.position_z!,
+    work_required: WORK_BREW,
+  });
+}

--- a/sim/src/phases/index.ts
+++ b/sim/src/phases/index.ts
@@ -23,3 +23,4 @@ export { beautyRestoration } from "./beauty-restoration.js";
 export { diseasePhase, hasWell } from "./disease.js";
 export { haunting, putGhostToRest } from "./haunting.js";
 export { autoCookPhase } from "./auto-cook.js";
+export { autoBrew } from "./auto-brew.js";

--- a/sim/src/sim-runner.ts
+++ b/sim/src/sim-runner.ts
@@ -24,6 +24,7 @@ import {
   beautyRestoration,
   haunting,
   autoCookPhase,
+  autoBrew,
 } from "./phases/index.js";
 
 /** Snapshot of sim state emitted after every tick for live UI rendering. */
@@ -223,6 +224,7 @@ export class SimRunner {
     await idleWandering(this.ctx);
     await haulAssignment(this.ctx);
     await autoCookPhase(this.ctx);
+    await autoBrew(this.ctx);
     await jobClaiming(this.ctx);
     await eventFiring(this.ctx);
     await thoughtGeneration(this.ctx);


### PR DESCRIPTION
## Summary
- Adds `MIN_DRINK_STOCK = 10` constant to `shared/src/constants.ts`
- New `autoBrew` phase in `sim/src/phases/auto-brew.ts`: when drink stock < threshold and a raw_material plant exists unowned, creates one `brew` task (deduped — no task if one already pending/in-progress)
- Wired into `SimRunner` tick loop before `jobClaiming`
- 7 unit tests covering threshold guard, no plant, held plant, deduplication, and post-completion re-trigger

Closes #445

## Test plan
- [x] `npm test` passes (1360 tests, 112 files)
- [x] `npm run build` passes
- [x] Headless mode unaffected (no new browser dependencies)

## Playtest
Sim logic only — no UI changes. Verified with unit tests and `npm test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Claude Cost
**Claude cost:** $17.63 (49.2M tokens) — Ralph overnight session delta