### PR TITLE
feat: auto-cook phase — dwarves cook meals when food stocks are low

### DIFF
--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -451,6 +451,9 @@ export const WORK_BREW = 50;
 /** Work required to cook a meal */
 export const WORK_COOK = 40;
 
+/** Minimum cooked food stock before auto-cook triggers */
+export const MIN_COOK_STOCK = 15;
+
 /** Work required to smith an item */
 export const WORK_SMITH = 70;
 

--- a/sim/src/phases/auto-cook.test.ts
+++ b/sim/src/phases/auto-cook.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import { autoCookPhase } from "./auto-cook.js";
+import { makeItem, makeTask, makeContext } from "../__tests__/test-helpers.js";
+import { MIN_COOK_STOCK } from "@pwarf/shared";
+
+/** Make a raw food item on the ground at a given position */
+function rawFoodAt(x: number, y: number, z: number) {
+  return makeItem({
+    category: "food",
+    material: "plant",
+    held_by_dwarf_id: null,
+    position_x: x,
+    position_y: y,
+    position_z: z,
+  });
+}
+
+/** Make a cooked meal item on the ground */
+function cookedFoodAt(x: number, y: number, z: number) {
+  return makeItem({
+    category: "food",
+    material: "cooked",
+    held_by_dwarf_id: null,
+    position_x: x,
+    position_y: y,
+    position_z: z,
+  });
+}
+
+describe("autoCookPhase", () => {
+  it("does not create a task when food stock meets threshold", async () => {
+    const items = Array.from({ length: MIN_COOK_STOCK }, () => rawFoodAt(5, 5, 0));
+    const ctx = makeContext({ items });
+
+    await autoCookPhase(ctx);
+
+    expect(ctx.state.tasks.filter(t => t.task_type === "cook")).toHaveLength(0);
+  });
+
+  it("does not create a task when food count exceeds threshold", async () => {
+    const items = Array.from({ length: MIN_COOK_STOCK + 5 }, () => rawFoodAt(5, 5, 0));
+    const ctx = makeContext({ items });
+
+    await autoCookPhase(ctx);
+
+    expect(ctx.state.tasks.filter(t => t.task_type === "cook")).toHaveLength(0);
+  });
+
+  it("creates a cook task when food count is below threshold and raw food exists", async () => {
+    const items = [rawFoodAt(3, 4, 0)];
+    const ctx = makeContext({ items });
+
+    await autoCookPhase(ctx);
+
+    const cookTasks = ctx.state.tasks.filter(t => t.task_type === "cook");
+    expect(cookTasks).toHaveLength(1);
+    expect(cookTasks[0].target_x).toBe(3);
+    expect(cookTasks[0].target_y).toBe(4);
+    expect(cookTasks[0].target_z).toBe(0);
+  });
+
+  it("does not create a duplicate task when a pending cook task exists", async () => {
+    const items = [rawFoodAt(3, 4, 0)];
+    const existingTask = makeTask("cook", { status: "pending" });
+    const ctx = makeContext({ items, tasks: [existingTask] });
+
+    await autoCookPhase(ctx);
+
+    expect(ctx.state.tasks.filter(t => t.task_type === "cook")).toHaveLength(1);
+  });
+
+  it("does not create a duplicate task when an in-progress cook task exists", async () => {
+    const items = [rawFoodAt(3, 4, 0)];
+    const existingTask = makeTask("cook", { status: "in_progress" });
+    const ctx = makeContext({ items, tasks: [existingTask] });
+
+    await autoCookPhase(ctx);
+
+    expect(ctx.state.tasks.filter(t => t.task_type === "cook")).toHaveLength(1);
+  });
+
+  it("does not create a task when no raw food is available (only cooked meals)", async () => {
+    const items = [cookedFoodAt(3, 4, 0)];
+    const ctx = makeContext({ items });
+
+    await autoCookPhase(ctx);
+
+    expect(ctx.state.tasks.filter(t => t.task_type === "cook")).toHaveLength(0);
+  });
+
+  it("does not create a task when no food is on the ground at all", async () => {
+    const ctx = makeContext({});
+
+    await autoCookPhase(ctx);
+
+    expect(ctx.state.tasks.filter(t => t.task_type === "cook")).toHaveLength(0);
+  });
+
+  it("creates a new task after a completed cook task (completed tasks are ignored)", async () => {
+    const items = [rawFoodAt(3, 4, 0)];
+    const completedTask = makeTask("cook", { status: "completed" });
+    const ctx = makeContext({ items, tasks: [completedTask] });
+
+    await autoCookPhase(ctx);
+
+    const cookTasks = ctx.state.tasks.filter(t => t.task_type === "cook");
+    expect(cookTasks).toHaveLength(2); // existing completed + new pending
+    expect(cookTasks.some(t => t.status === "pending")).toBe(true);
+  });
+});

--- a/sim/src/phases/auto-cook.ts
+++ b/sim/src/phases/auto-cook.ts
@@ -1,0 +1,43 @@
+import { MIN_COOK_STOCK, WORK_COOK } from "@pwarf/shared";
+import type { SimContext } from "../sim-context.js";
+import { createTask } from "../task-helpers.js";
+
+/**
+ * Auto-Cook Phase
+ *
+ * When cooked food stock falls below MIN_COOK_STOCK and raw food (category=food,
+ * material≠cooked) is available, create a single cook task at the raw food's
+ * location if no pending/in-progress cook task already exists.
+ */
+export async function autoCookPhase(ctx: SimContext): Promise<void> {
+  const { state } = ctx;
+
+  // Count food items not held by dwarves
+  const groundFood = state.items.filter(
+    i => i.category === 'food' && i.held_by_dwarf_id === null,
+  );
+
+  if (groundFood.length >= MIN_COOK_STOCK) return;
+
+  // Check for existing pending/in-progress cook task
+  const hasCookTask = state.tasks.some(
+    t =>
+      t.task_type === 'cook' &&
+      (t.status === 'pending' || t.status === 'in_progress'),
+  );
+  if (hasCookTask) return;
+
+  // Find a raw food item (material is not 'cooked')
+  const rawFood = groundFood.find(i => i.material !== 'cooked');
+  if (!rawFood) return;
+  if (rawFood.position_x === null || rawFood.position_y === null || rawFood.position_z === null) return;
+
+  createTask(ctx, {
+    task_type: 'cook',
+    priority: 6,
+    target_x: rawFood.position_x,
+    target_y: rawFood.position_y,
+    target_z: rawFood.position_z,
+    work_required: WORK_COOK,
+  });
+}

--- a/sim/src/phases/index.ts
+++ b/sim/src/phases/index.ts
@@ -22,3 +22,4 @@ export { haulAssignment } from "./haul-assignment.js";
 export { beautyRestoration } from "./beauty-restoration.js";
 export { diseasePhase, hasWell } from "./disease.js";
 export { haunting, putGhostToRest } from "./haunting.js";
+export { autoCookPhase } from "./auto-cook.js";

--- a/sim/src/sim-runner.ts
+++ b/sim/src/sim-runner.ts
@@ -23,6 +23,7 @@ import {
   haulAssignment,
   beautyRestoration,
   haunting,
+  autoCookPhase,
 } from "./phases/index.js";
 
 /** Snapshot of sim state emitted after every tick for live UI rendering. */
@@ -221,6 +222,7 @@ export class SimRunner {
     await constructionProgress(this.ctx);
     await idleWandering(this.ctx);
     await haulAssignment(this.ctx);
+    await autoCookPhase(this.ctx);
     await jobClaiming(this.ctx);
     await eventFiring(this.ctx);
     await thoughtGeneration(this.ctx);


### PR DESCRIPTION
## Summary

- Adds `autoCookPhase` in `sim/src/phases/auto-cook.ts`
- When ground food count < `MIN_COOK_STOCK` (15) and raw food exists, creates a single `cook` task at the raw food's location
- Prevents duplicate tasks (skips if a pending or in-progress cook task already exists)
- Wires the phase into the SimRunner tick loop after `haulAssignment`
- Adds `MIN_COOK_STOCK = 15` constant to `@pwarf/shared`

Closes #446

## Test plan

- [x] No task created when food count ≥ threshold
- [x] Task created when food count < threshold and raw food available
- [x] No duplicate task when pending cook task exists
- [x] No duplicate task when in-progress cook task exists
- [x] No task when only cooked meals are available (no raw food)
- [x] No task when no food on ground at all
- [x] New task created after a completed cook task
- [x] `npm test` — all 587 tests pass
- [x] `npm run build` — no type errors

This is a sim-only change with no UI impact, so no playtest required per CLAUDE.md policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Claude Cost
**Claude cost:** $140.07 (381.6M tokens)