### PR TITLE
feat: fire monster_siege world event when monster first attacks the fortress (closes #452)

### DIFF
--- a/sim/src/__tests__/monster-combat.test.ts
+++ b/sim/src/__tests__/monster-combat.test.ts
@@ -353,6 +353,30 @@ describe("combatResolution", () => {
     expect(battleEvents.length).toBe(1);
   });
 
+  it("fires monster_siege on first contact with any dwarf", async () => {
+    const ctx = createTestContext();
+    const dwarf = makeDwarf({ position_x: 5, position_y: 5, health: 100 });
+    ctx.state.dwarves = [dwarf];
+    ctx.state.monsters = [makeMonster({ current_tile_x: 5, current_tile_y: 5, health: 100 })];
+    await combatResolution(ctx);
+    const evt = ctx.state.pendingEvents.find(e => e.category === "monster_siege");
+    expect(evt).toBeDefined();
+    expect(evt?.monster_id).toBe("monster-1");
+  });
+
+  it("fires monster_siege only once even across multiple dwarves", async () => {
+    const ctx = createTestContext();
+    const dwarf1 = makeDwarf({ id: "d1", position_x: 5, position_y: 5, health: 100 });
+    const dwarf2 = makeDwarf({ id: "d2", position_x: 5, position_y: 5, health: 100 });
+    ctx.state.dwarves = [dwarf1, dwarf2];
+    ctx.state.monsters = [makeMonster({ current_tile_x: 5, current_tile_y: 5, health: 100 })];
+    // Pre-seed one combat pair so the monster is already in combat
+    ctx.state.activeCombatPairs.add(`monster-1:d1`);
+    await combatResolution(ctx);
+    const siegeEvents = ctx.state.pendingEvents.filter(e => e.category === "monster_siege");
+    expect(siegeEvents.length).toBe(0);
+  });
+
   it("clears combat pair when monster is slain", async () => {
     const ctx = createTestContext();
     const dwarf = makeDwarf({ position_x: 5, position_y: 5, health: 100 });

--- a/sim/src/phases/combat-resolution.ts
+++ b/sim/src/phases/combat-resolution.ts
@@ -44,6 +44,31 @@ export async function combatResolution(ctx: SimContext): Promise<void> {
     // Fire a battle event the first time this monster/dwarf pair engage
     const combatPairKey = `${monster.id}:${target.id}`;
     if (!state.activeCombatPairs.has(combatPairKey)) {
+      // Fire monster_siege on first engagement of this monster with any dwarf
+      const isFirstEngagement = !Array.from(state.activeCombatPairs).some(k => k.startsWith(`${monster.id}:`));
+      if (isFirstEngagement) {
+        state.pendingEvents.push({
+          id: rng.uuid(),
+          world_id: ctx.worldId,
+          year: ctx.year,
+          category: 'monster_siege',
+          civilization_id: ctx.civilizationId,
+          ruin_id: null,
+          dwarf_id: null,
+          item_id: null,
+          faction_id: null,
+          monster_id: monster.id,
+          description: `The ${monster.name} begins attacking the fortress!`,
+          event_data: {
+            monster_type: monster.type,
+            threat_level: monster.threat_level,
+            tile_x: monster.current_tile_x,
+            tile_y: monster.current_tile_y,
+          },
+          created_at: new Date().toISOString(),
+        });
+      }
+
       state.activeCombatPairs.add(combatPairKey);
       state.pendingEvents.push({
         id: rng.uuid(),


### PR DESCRIPTION
## Summary
- When a monster engages any dwarf for the first time, fire a `monster_siege` world event
- Uses the existing `activeCombatPairs` set from #448 to detect first engagement
- Fires before the per-pair `battle` event, so the sequence in the Legends tab is: sighting → siege begins → battle → slain
- 2 new tests: first-contact siege event, siege fires only once per monster

## Playtest
Sim-only change — no UI. Tested via `npm test` (1334 tests pass).

closes #452

## Claude Cost
**Claude cost:** $0.00 (0k tokens)