### PR TITLE
fix: truncate hourly digest prompt to stay within gpt-4o-mini 8k token limit

### DIFF
--- a/.github/scripts/hourly-digest.mjs
+++ b/.github/scripts/hourly-digest.mjs
@@ -96,14 +96,15 @@ async function summarize(prData) {
         images.length > 0 ? `\nScreenshots in this PR: ${images.length}` : '';
       return [
         `### PR #${pr.number}: ${pr.title}`,
-        pr.body ? `Description:\n${pr.body.slice(0, 600)}` : '(no description)',
-        `Commits:\n${commits.map((c) => `- ${c}`).join('\n')}`,
+        pr.body ? `Description:\n${pr.body.slice(0, 300)}` : '(no description)',
+        `Commits:\n${commits.slice(0, 5).map((c) => `- ${c}`).join('\n')}`,
         imageNote,
       ]
         .filter(Boolean)
         .join('\n');
     })
-    .join('\n\n---\n\n');
+    .join('\n\n---\n\n')
+    .slice(0, 20000); // hard cap to stay within ~8k token limit
 
   const systemPrompt =
     'You are writing a devlog for pwarf, a dwarf-fortress-style colony sim game. ' +


### PR DESCRIPTION
## Summary

- Reduce PR body snippet from 600 → 300 chars per PR
- Cap commits per PR at 5
- Hard-cap total `prBlocks` string at 20,000 chars (~5k tokens), leaving headroom for system prompt and response

Fixes the 413 error: \`tokens_limit_reached\` when many PRs are included in a digest run (especially full-history runs).

## Claude Cost

**Claude cost:** $5.79 (14.7M tokens)