### PR TITLE
feat: show battle, siege, caravan, and marriage events in Legends tab

### DIFF
--- a/app/src/components/RightPanel.test.ts
+++ b/app/src/components/RightPanel.test.ts
@@ -96,6 +96,30 @@ describe("groupEventsByYear", () => {
     expect(groups).toHaveLength(1);
     expect(groups[0].year).toBe(7);
   });
+
+  it("includes battle, monster_slain, monster_siege categories", () => {
+    const e1 = makeEvent("1", "Combat erupted", "battle", 3);
+    const e2 = makeEvent("2", "Goblin slain", "monster_slain", 3);
+    const e3 = makeEvent("3", "Siege began", "monster_siege", 3);
+    const groups = groupEventsByYear([e1, e2, e3]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].events).toHaveLength(3);
+  });
+
+  it("includes trade_caravan_arrival and marriage categories", () => {
+    const e1 = makeEvent("1", "Caravan arrived", "trade_caravan_arrival", 5);
+    const e2 = makeEvent("2", "Dwarves married", "marriage", 5);
+    const groups = groupEventsByYear([e1, e2]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].events).toHaveLength(2);
+  });
+
+  it("includes artifact_lost category", () => {
+    const e = makeEvent("1", "Artifact lost", "artifact_lost", 4);
+    const groups = groupEventsByYear([e]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].year).toBe(4);
+  });
 });
 
 describe("causeLabel", () => {

--- a/app/src/components/RightPanel.tsx
+++ b/app/src/components/RightPanel.tsx
@@ -15,7 +15,12 @@ type WorldTab = "Log" | "Legends" | "Graveyard";
 type Tab = FortressTab | WorldTab;
 
 /** Categories that appear in the Legends tab (significant history). */
-const LEGEND_CATEGORIES = new Set(['death', 'fortress_fallen', 'migration', 'discovery', 'artifact_created']);
+const LEGEND_CATEGORIES = new Set([
+  'death', 'fortress_fallen', 'migration', 'discovery',
+  'artifact_created', 'artifact_lost',
+  'battle', 'monster_slain', 'monster_siege',
+  'trade_caravan_arrival', 'marriage',
+]);
 
 /** Group significant events by year, newest year first. */
 export function groupEventsByYear(events: LiveEvent[]): Array<{ year: number; events: LiveEvent[] }> {
@@ -56,6 +61,15 @@ function categoryColor(category: string): string {
       return 'var(--green)';
     case 'migration':
       return 'var(--cyan)';
+    case 'battle':
+    case 'monster_siege':
+      return '#f97316'; // orange — combat
+    case 'monster_slain':
+      return 'var(--green)';
+    case 'trade_caravan_arrival':
+      return 'var(--cyan)';
+    case 'marriage':
+      return '#cc44aa'; // pink
     default:
       return 'var(--amber)';
   }


### PR DESCRIPTION
Adds the new event categories introduced by recent features to the Legends tab.

## Changes

- Expand `LEGEND_CATEGORIES` to include: `artifact_lost`, `battle`, `monster_slain`, `monster_siege`, `trade_caravan_arrival`, `marriage`
- Add matching colors to `categoryColor()`: orange for combat events, pink for marriage, cyan for caravan
- New tests for all 6 added categories in `RightPanel.test.ts`

## Playtest

UI-only change affecting the Legends tab filter. Build passes, all 99 app tests pass. Categories are now visible in Legends when those events occur.

## Claude Cost

**Claude cost:** $5.82 (15.2M tokens)