### PR TITLE
feat: failed task recovery — reset design tasks to pending when dwarf dies

### DIFF
--- a/sim/src/phases/index.ts
+++ b/sim/src/phases/index.ts
@@ -24,3 +24,4 @@ export { diseasePhase, hasWell } from "./disease.js";
 export { haunting, putGhostToRest } from "./haunting.js";
 export { autoCookPhase } from "./auto-cook.js";
 export { autoBrew } from "./auto-brew.js";
+export { taskRecovery } from "./task-recovery.js";

--- a/sim/src/phases/task-recovery.test.ts
+++ b/sim/src/phases/task-recovery.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from "vitest";
+import { taskRecovery } from "./task-recovery.js";
+import { makeTask, makeContext, makeMapTile } from "../__tests__/test-helpers.js";
+
+describe("taskRecovery", () => {
+  it("resets a failed mine task to pending when no tile override exists", () => {
+    const task = makeTask("mine", {
+      status: "failed",
+      assigned_dwarf_id: null,
+      target_x: 5,
+      target_y: 5,
+      target_z: 0,
+    });
+    const ctx = makeContext({ tasks: [task] });
+
+    taskRecovery(ctx);
+
+    expect(task.status).toBe("pending");
+  });
+
+  it("cancels a failed mine task when the target tile is already open_air", () => {
+    const task = makeTask("mine", {
+      status: "failed",
+      assigned_dwarf_id: null,
+      target_x: 3,
+      target_y: 3,
+      target_z: 0,
+    });
+    const ctx = makeContext({ tasks: [task] });
+    ctx.state.fortressTileOverrides.set("3,3,0", makeMapTile(3, 3, 0, "open_air"));
+
+    taskRecovery(ctx);
+
+    expect(task.status).toBe("cancelled");
+  });
+
+  it("resets a failed mine task to pending when tile override is still minable rock", () => {
+    const task = makeTask("mine", {
+      status: "failed",
+      assigned_dwarf_id: null,
+      target_x: 2,
+      target_y: 2,
+      target_z: 0,
+    });
+    const ctx = makeContext({ tasks: [task] });
+    ctx.state.fortressTileOverrides.set("2,2,0", makeMapTile(2, 2, 0, "rock"));
+
+    taskRecovery(ctx);
+
+    expect(task.status).toBe("pending");
+  });
+
+  it("resets a failed build task to pending", () => {
+    const task = makeTask("build_wall", {
+      status: "failed",
+      assigned_dwarf_id: null,
+    });
+    const ctx = makeContext({ tasks: [task] });
+
+    taskRecovery(ctx);
+
+    expect(task.status).toBe("pending");
+  });
+
+  it("resets a failed brew task to pending", () => {
+    const task = makeTask("brew", { status: "failed", assigned_dwarf_id: null });
+    const ctx = makeContext({ tasks: [task] });
+
+    taskRecovery(ctx);
+
+    expect(task.status).toBe("pending");
+  });
+
+  it("cancels a failed eat task — autonomous tasks do not retry", () => {
+    const task = makeTask("eat", { status: "failed", assigned_dwarf_id: null });
+    const ctx = makeContext({ tasks: [task] });
+
+    taskRecovery(ctx);
+
+    expect(task.status).toBe("cancelled");
+  });
+
+  it("cancels a failed drink task", () => {
+    const task = makeTask("drink", { status: "failed", assigned_dwarf_id: null });
+    const ctx = makeContext({ tasks: [task] });
+
+    taskRecovery(ctx);
+
+    expect(task.status).toBe("cancelled");
+  });
+
+  it("cancels a failed sleep task", () => {
+    const task = makeTask("sleep", { status: "failed", assigned_dwarf_id: null });
+    const ctx = makeContext({ tasks: [task] });
+
+    taskRecovery(ctx);
+
+    expect(task.status).toBe("cancelled");
+  });
+
+  it("cancels a failed wander task", () => {
+    const task = makeTask("wander", { status: "failed", assigned_dwarf_id: null });
+    const ctx = makeContext({ tasks: [task] });
+
+    taskRecovery(ctx);
+
+    expect(task.status).toBe("cancelled");
+  });
+
+  it("ignores tasks that are not failed", () => {
+    const pending = makeTask("mine", { status: "pending" });
+    const inProgress = makeTask("brew", { status: "in_progress" });
+    const completed = makeTask("cook", { status: "completed" });
+    const ctx = makeContext({ tasks: [pending, inProgress, completed] });
+
+    taskRecovery(ctx);
+
+    expect(pending.status).toBe("pending");
+    expect(inProgress.status).toBe("in_progress");
+    expect(completed.status).toBe("completed");
+  });
+
+  it("ignores failed tasks that still have an assigned dwarf", () => {
+    const task = makeTask("mine", {
+      status: "failed",
+      assigned_dwarf_id: "some-dwarf",
+    });
+    const ctx = makeContext({ tasks: [task] });
+
+    taskRecovery(ctx);
+
+    // Still failed — something else is responsible for clearing the dwarf
+    expect(task.status).toBe("failed");
+  });
+
+  it("marks recovered tasks dirty", () => {
+    const task = makeTask("brew", { status: "failed", assigned_dwarf_id: null });
+    const ctx = makeContext({ tasks: [task] });
+
+    taskRecovery(ctx);
+
+    expect(ctx.state.dirtyTaskIds.has(task.id)).toBe(true);
+  });
+
+  it("marks cancelled tasks dirty", () => {
+    const task = makeTask("eat", { status: "failed", assigned_dwarf_id: null });
+    const ctx = makeContext({ tasks: [task] });
+
+    taskRecovery(ctx);
+
+    expect(ctx.state.dirtyTaskIds.has(task.id)).toBe(true);
+  });
+});

--- a/sim/src/phases/task-recovery.ts
+++ b/sim/src/phases/task-recovery.ts
@@ -1,0 +1,62 @@
+import type { SimContext } from "../sim-context.js";
+
+/**
+ * Autonomous task types that should NOT be retried after failure.
+ * These are self-generated per-dwarf needs; when they fail the dwarf
+ * will simply re-generate them on the next need-satisfaction pass.
+ */
+const NO_RETRY_TYPES: ReadonlySet<string> = new Set([
+  'eat',
+  'drink',
+  'sleep',
+  'wander',
+  'haul',
+]);
+
+/**
+ * Task Recovery Phase
+ *
+ * When a dwarf dies or abandons a task, deprivation.ts sets it to
+ * `failed` and clears `assigned_dwarf_id`. Without recovery, that
+ * work is permanently lost — no other dwarf can pick it up.
+ *
+ * This phase scans for unassigned failed tasks each tick and either:
+ * - Resets design tasks back to `pending` so another dwarf can claim them.
+ * - Cancels tasks that are no longer valid (autonomous types that
+ *   self-generate, or tasks whose target tile no longer exists).
+ */
+export function taskRecovery(ctx: SimContext): void {
+  const { state } = ctx;
+
+  for (const task of state.tasks) {
+    if (task.status !== 'failed') continue;
+    if (task.assigned_dwarf_id !== null) continue;
+
+    // Autonomous tasks self-regenerate — don't retry them
+    if (NO_RETRY_TYPES.has(task.task_type)) {
+      task.status = 'cancelled';
+      state.dirtyTaskIds.add(task.id);
+      continue;
+    }
+
+    // Mine tasks: cancel if the tile has already been mined (override shows
+    // a non-minable type like open_air). If no override exists the tile is
+    // still in its generated state and is safe to retry.
+    if (task.task_type === 'mine' &&
+        task.target_x !== null && task.target_y !== null && task.target_z !== null) {
+      const key = `${task.target_x},${task.target_y},${task.target_z}`;
+      const override = state.fortressTileOverrides.get(key);
+      const minable = new Set(['rock', 'soil', 'stone', 'ore', 'gem', 'ignite']);
+      if (override && !minable.has(override.tile_type)) {
+        task.status = 'cancelled';
+        state.dirtyTaskIds.add(task.id);
+        continue;
+      }
+    }
+
+    // All other design tasks (build, brew, cook, farm, engrave, smith, etc.)
+    // are reset to pending — another dwarf will pick them up
+    task.status = 'pending';
+    state.dirtyTaskIds.add(task.id);
+  }
+}

--- a/sim/src/sim-runner.ts
+++ b/sim/src/sim-runner.ts
@@ -25,6 +25,7 @@ import {
   haunting,
   autoCookPhase,
   autoBrew,
+  taskRecovery,
 } from "./phases/index.js";
 
 /** Snapshot of sim state emitted after every tick for live UI rendering. */
@@ -223,6 +224,7 @@ export class SimRunner {
     await constructionProgress(this.ctx);
     await idleWandering(this.ctx);
     await haulAssignment(this.ctx);
+    taskRecovery(this.ctx);
     await autoCookPhase(this.ctx);
     await autoBrew(this.ctx);
     await jobClaiming(this.ctx);


### PR DESCRIPTION
## Summary

When a dwarf dies mid-task, `deprivation.ts` sets the task to `failed` and clears `assigned_dwarf_id`. Previously nothing ever read failed tasks back — they sat permanently lost. This PR fixes that.

Adds `taskRecovery` phase (runs each tick, before `jobClaiming`):
- **Design tasks** (mine, build, brew, cook, farm, engrave, smith, etc.) reset to `pending` so another dwarf can claim them
- **Autonomous tasks** (eat, drink, sleep, wander, haul) are cancelled — they self-generate from need-satisfaction each tick anyway
- **Mine tasks** additionally check `fortressTileOverrides`: if the target is already `open_air` the task is cancelled rather than retried

Closes #457

## Test plan
- [x] 12 unit tests covering: reset mine/build/brew, cancel eat/drink/sleep/wander, cancel already-mined tile, ignore non-failed tasks, ignore still-assigned tasks, dirty-marking
- [x] `npm test` passes (1498 tests, 126 files)
- [x] `npm run build` passes
- [x] Headless mode unaffected

## Playtest
Sim logic only — no UI changes. Verified with unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Claude Cost
**Claude cost:** $1.91 (estimated delta from session baseline of $8.16)