### PR TITLE
fix: respect explicit lookback_minutes in workflow_dispatch

### DIFF
--- a/.github/scripts/hourly-digest.mjs
+++ b/.github/scripts/hourly-digest.mjs
@@ -253,9 +253,9 @@ async function main() {
   // Use time-since-last-post as the lookback window so we never double-count PRs.
   // Fall back to LOOKBACK_MINUTES (or 10 min) on the very first run.
   const sinceLastPost = minutesSinceLastPost();
-  const lookback = sinceLastPost != null
-    ? sinceLastPost + 2          // +2 min buffer for clock skew
-    : Number(process.env.LOOKBACK_MINUTES ?? 10);
+  // Explicit LOOKBACK_MINUTES (from workflow_dispatch) overrides dynamic lookback.
+  const explicitLookback = process.env.LOOKBACK_MINUTES ? Number(process.env.LOOKBACK_MINUTES) : null;
+  const lookback = explicitLookback ?? (sinceLastPost != null ? sinceLastPost + 2 : 10);
 
   console.log(`Fetching PRs merged in the last ${lookback} min…`);
   const prs = await getMergedPRs(lookback);

--- a/.github/workflows/hourly-digest.yml
+++ b/.github/workflows/hourly-digest.yml
@@ -41,5 +41,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          LOOKBACK_MINUTES: ${{ github.event.inputs.lookback_minutes || '65' }}
+          LOOKBACK_MINUTES: ${{ github.event.inputs.lookback_minutes }}
         run: node .github/scripts/hourly-digest.mjs


### PR DESCRIPTION
## Summary
- `LOOKBACK_MINUTES` from `workflow_dispatch` now overrides the dynamic last-post lookback, so backfill runs work correctly
- Removes `|| '65'` fallback from workflow env so the env var is only set when explicitly provided

## Claude Cost