### PR TITLE
feat: guest mode — play without an account

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -30,7 +30,7 @@ import type { Item } from "@pwarf/shared";
 import type { LiveDwarf } from "./hooks/useDwarves";
 
 export default function App() {
-  const { session, user, loading, signIn, signUp, signOut } = useAuth();
+  const { session, user, loading, signIn, signUp, signInAsGuest, signOut } = useAuth();
 
   const [leftOpen, setLeftOpen] = useState(true);
   const [rightOpen, setRightOpen] = useState(true);
@@ -385,7 +385,7 @@ export default function App() {
 
   // Auth screen
   if (!session) {
-    return <AuthScreen onSignIn={signIn} onSignUp={signUp} />;
+    return <AuthScreen onSignIn={signIn} onSignUp={signUp} onPlayAsGuest={signInAsGuest} />;
   }
 
   // Restoring session

--- a/app/src/components/AuthScreen.test.tsx
+++ b/app/src/components/AuthScreen.test.tsx
@@ -14,7 +14,7 @@ describe("AuthScreen", () => {
   }
 
   it("renders login form with email and password fields", () => {
-    render(<AuthScreen onSignIn={noop} onSignUp={noop} />);
+    render(<AuthScreen onSignIn={noop} onSignUp={noop} onPlayAsGuest={noop} />);
 
     expect(screen.getByPlaceholderText("Email")).toBeDefined();
     expect(screen.getByPlaceholderText("Password")).toBeDefined();
@@ -22,7 +22,7 @@ describe("AuthScreen", () => {
   });
 
   it("switches to signup mode when Sign Up tab is clicked", () => {
-    render(<AuthScreen onSignIn={noop} onSignUp={noop} />);
+    render(<AuthScreen onSignIn={noop} onSignUp={noop} onPlayAsGuest={noop} />);
 
     // Click the tab (type="button") Sign Up button
     const tabs = screen.getAllByRole("button", { name: "Sign Up" });
@@ -36,7 +36,7 @@ describe("AuthScreen", () => {
   it("displays error messages", async () => {
     const failSignIn = vi.fn().mockRejectedValue(new Error("Invalid credentials"));
 
-    render(<AuthScreen onSignIn={failSignIn} onSignUp={noop} />);
+    render(<AuthScreen onSignIn={failSignIn} onSignUp={noop} onPlayAsGuest={noop} />);
 
     fireEvent.change(screen.getByPlaceholderText("Email"), {
       target: { value: "test@example.com" },

--- a/app/src/components/AuthScreen.tsx
+++ b/app/src/components/AuthScreen.tsx
@@ -5,9 +5,10 @@ type AuthMode = "login" | "signup";
 interface AuthScreenProps {
   onSignIn: (email: string, password: string) => Promise<void>;
   onSignUp: (email: string, password: string) => Promise<void>;
+  onPlayAsGuest: () => Promise<void>;
 }
 
-export default function AuthScreen({ onSignIn, onSignUp }: AuthScreenProps) {
+export default function AuthScreen({ onSignIn, onSignUp, onPlayAsGuest }: AuthScreenProps) {
   const [mode, setMode] = useState<AuthMode>("login");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -110,6 +111,29 @@ export default function AuthScreen({ onSignIn, onSignUp }: AuthScreenProps) {
               : "Sign Up"}
         </button>
       </form>
+
+      <div className="flex flex-col items-center gap-2 mt-2">
+        <div className="text-[var(--text)] opacity-40 text-xs">or</div>
+        <button
+          type="button"
+          disabled={submitting}
+          onClick={async () => {
+            setError(null);
+            setSubmitting(true);
+            try {
+              await onPlayAsGuest();
+            } catch (err) {
+              setError(err instanceof Error ? err.message : String(err));
+            } finally {
+              setSubmitting(false);
+            }
+          }}
+          className="text-[var(--text)] text-xs hover:text-[var(--amber)] cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Play as Guest
+        </button>
+        <p className="text-[var(--text)] opacity-30 text-xs">Progress won't be saved.</p>
+      </div>
     </div>
   );
 }

--- a/app/src/hooks/useAuth.ts
+++ b/app/src/hooks/useAuth.ts
@@ -42,12 +42,18 @@ export function useAuth() {
     if (error) throw error;
   }, []);
 
+  const signInAsGuest = useCallback(async () => {
+    const { error } = await supabase.auth.signInAnonymously();
+    if (error) throw error;
+  }, []);
+
   const signOut = useCallback(async () => {
     const { error } = await supabase.auth.signOut();
     if (error) throw error;
   }, []);
 
   const user: User | null = session?.user ?? null;
+  const isGuest = user?.is_anonymous ?? false;
 
-  return { session, user, loading, signIn, signUp, signOut };
+  return { session, user, loading, signIn, signUp, signInAsGuest, signOut, isGuest };
 }


### PR DESCRIPTION
## Summary
- Adds a **Play as Guest** button to the auth screen
- Uses Supabase anonymous auth — anonymous users get a real user ID so all existing DB/sim code works unchanged
- Shows "Progress won't be saved." note so guests know the deal

## ⚠️ Manual step required before merging
Enable anonymous sign-ins in the Supabase dashboard:
**Authentication → Configuration → Enable anonymous sign-ins**

## Test plan
- [ ] Enable anonymous auth in Supabase dashboard
- [ ] Click "Play as Guest" — should land in the game without entering credentials
- [ ] Verify fortress works normally (embark, dwarves, tasks)
- [ ] Verify signing out works

Closes #490

## Claude Cost