### PR TITLE
fix: anonymous auth stuck on restoring session

### DIFF
--- a/app/src/components/AuthScreen.tsx
+++ b/app/src/components/AuthScreen.tsx
@@ -133,6 +133,7 @@ export default function AuthScreen({ onSignIn, onSignUp, onPlayAsGuest }: AuthSc
           Play as Guest
         </button>
         <p className="text-[var(--text)] opacity-30 text-xs">Progress won't be saved.</p>
+        <p className="text-[var(--text)] opacity-20 text-xs italic">← Regan &amp; Nathaly use this</p>
       </div>
     </div>
   );

--- a/app/src/hooks/useWorldState.ts
+++ b/app/src/hooks/useWorldState.ts
@@ -28,7 +28,7 @@ export function useWorldState(opts: {
   // Ensure player profile exists after auth, then restore any existing session
   useEffect(() => {
     if (user && !playerEnsured) {
-      ensurePlayer(supabase, user.id, user.email ?? "unknown")
+      ensurePlayer(supabase, user.id, user.email ?? undefined)
         .then(() => loadSession(user.id))
         .then(async (session) => {
           if (session.worldId) {

--- a/app/src/lib/ensure-player.ts
+++ b/app/src/lib/ensure-player.ts
@@ -3,16 +3,16 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 export async function ensurePlayer(
   client: SupabaseClient,
   userId: string,
-  email: string,
+  email: string | undefined,
 ): Promise<void> {
   const { data } = await client
     .from("players")
     .select("id")
     .eq("id", userId)
-    .single();
+    .maybeSingle();
 
   if (!data) {
-    const username = email.split("@")[0];
+    const username = email ? email.split("@")[0] : `anon-${userId.slice(0, 8)}`;
     const { error } = await client
       .from("players")
       .insert({ id: userId, username });


### PR DESCRIPTION
## Summary

- Use `.maybeSingle()` instead of `.single()` on the player existence check — `.single()` returns a 406 when no row is found, causing the insert to never run on first login
- Derive username as `anon-<first 8 chars of user ID>` for anonymous users (no email) — previously all anon users got username `"unknown"`, causing a duplicate key constraint that looped forever
- Added a fun little label on the auth screen pointing Regan & Nathaly to the guest flow

## Test plan

- [x] `npm test` passes (1418 tests)
- [x] `npm run build` passes (no type errors)
- Manual: anonymous auth previously stuck on "restoring session" — now should create a player record and proceed

## Claude Cost

**Claude cost:** $0.93 (1.9M tokens)