### PR TITLE
fix: replace placeholder embark items, add well/mushroom_garden structures

### DIFF
--- a/app/src/lib/embark.ts
+++ b/app/src/lib/embark.ts
@@ -136,41 +136,29 @@ export async function embark(worldId: string, tileX: number, tileY: number, worl
     if (skillError) throw new Error(`Failed to create dwarf skills: ${skillError.message}`);
   }
 
-  // Create starting items
-  const startingItems = [
-    // Food and drink are provided by infinite sources (meat roast / beer fountain)
-    ...Array.from({ length: 10 }, () => ({
-      name: 'Plump helmet seed',
-      category: 'raw_material',
-      quality: 'standard',
-      material: 'plant',
-      weight: 1,
-      value: 1,
-      is_artifact: false,
-      located_in_civ_id: civ.id,
-      created_in_civ_id: civ.id,
-      created_year: 1,
-      properties: {},
-    })),
-    ...Array.from({ length: 2 }, () => ({
-      name: 'Stone pickaxe',
-      category: 'tool',
-      quality: 'standard',
-      material: 'stone',
-      weight: 5,
-      value: 10,
-      is_artifact: false,
-      located_in_civ_id: civ.id,
-      created_in_civ_id: civ.id,
-      created_year: 1,
-      properties: {},
-    })),
-  ];
+  // Create starting food items — enough to survive while foraging ramps up.
+  // Dwarves drink from the starting well, so no drink items needed.
+  const startingItems = Array.from({ length: 15 }, () => ({
+    name: 'Dried meat',
+    category: 'food',
+    quality: 'standard',
+    material: 'meat',
+    weight: 1,
+    value: 2,
+    is_artifact: false,
+    located_in_civ_id: civ.id,
+    created_in_civ_id: civ.id,
+    created_year: 1,
+    position_x: FORTRESS_CENTER,
+    position_y: FORTRESS_CENTER - 4,
+    position_z: 0,
+    properties: {},
+  }));
 
   const { error: itemError } = await supabase.from('items').insert(startingItems);
   if (itemError) throw new Error(`Failed to create starting items: ${itemError.message}`);
 
-  // Place a well and mushroom garden near fortress center
+  // Place a well and mushroom garden near fortress center (tiles for rendering)
   const fortressTiles = [
     {
       civilization_id: civ.id,
@@ -196,6 +184,36 @@ export async function embark(worldId: string, tileX: number, tileY: number, worl
 
   const { error: tileOverrideError } = await supabase.from('fortress_tiles').insert(fortressTiles);
   if (tileOverrideError) throw new Error(`Failed to place starting structures: ${tileOverrideError.message}`);
+
+  // Place structure records for well and mushroom garden so the sim engine can use them.
+  // The sim reads from the `structures` table, not `fortress_tiles`, so both are needed.
+  const startingStructures = [
+    {
+      civilization_id: civ.id,
+      type: 'well',
+      name: null,
+      completion_pct: 100,
+      built_year: 1,
+      quality: 'standard',
+      position_x: FORTRESS_CENTER + 3,
+      position_y: FORTRESS_CENTER,
+      position_z: 0,
+    },
+    {
+      civilization_id: civ.id,
+      type: 'mushroom_garden',
+      name: null,
+      completion_pct: 100,
+      built_year: 1,
+      quality: 'standard',
+      position_x: FORTRESS_CENTER - 3,
+      position_y: FORTRESS_CENTER,
+      position_z: 0,
+    },
+  ];
+
+  const { error: structureError } = await supabase.from('structures').insert(startingStructures);
+  if (structureError) throw new Error(`Failed to create starting structures: ${structureError.message}`);
 
   // Place starting beds near fortress center (one per dwarf)
   const startingBeds = STARTING_OFFSETS.map((offset) => ({


### PR DESCRIPTION
## Summary

Fixes two related issues that were causing dwarves to die immediately after embarking:

1. **Placeholder items removed** — `Plump helmet seed` (raw_material) and `Stone pickaxe` were leftover from early development and provided no survival value
2. **Well now works as a drink source** — the well was placed as a `fortress_tile` for rendering but never had a corresponding `structures` row, so `findNearestWaterSource` in the sim could never find it and dwarves died of thirst
3. **Mushroom garden structure added** — same issue; now creates a structure record so beauty restoration picks it up
4. **Starting food** — 15 "Dried meat" food items placed at embark to bridge survival until foraging ramps up

Closes #488

## Test plan

- [x] `npm run build` — passes
- [x] `npm test --workspace=sim` — 634/634 pass
- [ ] Playtest: embark → dwarves survive first minutes, drink from well, eat dried meat

This is an app-side change (no new DB schema) — the `structures` table already exists. No migration needed.

## Claude Cost

## Claude Cost
**Claude cost:** $5.46 (12.4M tokens)

**Claude cost:** $0.73 (844k tokens)