### PR TITLE
fix: group carried items by name in inventory modal

### DIFF
--- a/app/src/components/InventoryModal.tsx
+++ b/app/src/components/InventoryModal.tsx
@@ -128,10 +128,10 @@ export function InventoryModal({ items, dwarves, onClose }: InventoryModalProps)
                   <div key={dwarfId} className="mb-2">
                     <div className="text-[var(--green)] font-bold mb-0.5">{name}</div>
                     <ul className="space-y-0.5 pl-2">
-                      {dwarfItems.map(item => (
-                        <li key={item.id} className="flex justify-between">
-                          <span className="text-[var(--text)]">{item.name}</span>
-                          <span className="text-[var(--text)] opacity-60 capitalize">{item.category.replace(/_/g, ' ')}</span>
+                      {countByName(dwarfItems).map(([name, count]) => (
+                        <li key={name} className="flex justify-between">
+                          <span className="text-[var(--text)]">{name}</span>
+                          <span className="text-[var(--text)]">{count}</span>
                         </li>
                       ))}
                     </ul>


### PR DESCRIPTION
## Summary

- Carried items section now uses `countByName()` to group duplicate items, matching the stockpile section's behavior
- e.g. "Stone block  5" instead of 5 separate "Stone block" rows

Closes #487

## Test plan

- [x] `npm run build` — passes
- UI change — the inventory modal rendering is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Claude Cost
**Claude cost:** $0.00 (0k tokens)