### PR TITLE
feat: sound engine foundation

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -14,7 +14,8 @@
     "@supabase/supabase-js": "^2.49.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "simplex-noise": "^4.0.3"
+    "simplex-noise": "^4.0.3",
+    "tone": "^15.1.22"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.3",

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -25,6 +25,8 @@ import { InventoryModal } from "./components/InventoryModal";
 import { EpitaphScreen } from "./components/EpitaphScreen";
 import { TutorialOverlay } from "./components/TutorialOverlay";
 import { useTutorial } from "./hooks/useTutorial";
+import { useSettings } from "./hooks/useSettings";
+import { useSoundEngine } from "./sounds/use-sound-engine";
 import { SURFACE_Z, CAVE_Z } from "@pwarf/shared";
 import type { Item } from "@pwarf/shared";
 import type { LiveDwarf } from "./hooks/useDwarves";
@@ -319,6 +321,8 @@ export default function App() {
   }, [selectedWorldTile, selectedTileData, world, designation]);
 
   const tutorial = useTutorial();
+  const { settings, toggleSound } = useSettings();
+  useSoundEngine(snapshot, !settings.soundEnabled);
 
   // Follow mode — camera tracks a selected dwarf every tick
   const [followedDwarfId, setFollowedDwarfId] = useState<string | null>(null);
@@ -453,6 +457,8 @@ export default function App() {
         dwarves={liveDwarves}
         onTutorial={tutorial.start}
         onInventory={world.civId ? () => setInventoryOpen(true) : undefined}
+        soundEnabled={settings.soundEnabled}
+        onToggleSound={toggleSound}
       />
 
       {tutorial.active && (

--- a/app/src/components/Toolbar.tsx
+++ b/app/src/components/Toolbar.tsx
@@ -20,9 +20,11 @@ interface ToolbarProps {
   dwarves?: LiveDwarf[];
   onTutorial?: () => void;
   onInventory?: () => void;
+  soundEnabled?: boolean;
+  onToggleSound?: () => void;
 }
 
-export default function Toolbar({ mode, onSignOut, onRestart, onTogglePause, isPaused = false, speed = 1, onSetSpeed, population = 0, year = 1, civName, items = [], wealth = 0, dwarves = [], onTutorial, onInventory }: ToolbarProps) {
+export default function Toolbar({ mode, onSignOut, onRestart, onTogglePause, isPaused = false, speed = 1, onSetSpeed, population = 0, year = 1, civName, items = [], wealth = 0, dwarves = [], onTutorial, onInventory, soundEnabled = true, onToggleSound }: ToolbarProps) {
   const alert = mode === "fortress" ? deriveAlert(dwarves) : null;
 
   return (
@@ -86,6 +88,19 @@ export default function Toolbar({ mode, onSignOut, onRestart, onTogglePause, isP
               </button>
             ))}
           </div>
+        )}
+        {onToggleSound && (
+          <button
+            onClick={onToggleSound}
+            title={soundEnabled ? "Mute sounds" : "Unmute sounds"}
+            className={`px-2 py-0.5 border cursor-pointer ${
+              soundEnabled
+                ? "border-[var(--border)] text-[var(--text)] hover:text-[var(--amber)] hover:border-[var(--amber)]"
+                : "border-[var(--border)] text-[var(--border)] hover:text-[var(--text)] hover:border-[var(--border)]"
+            }`}
+          >
+            {soundEnabled ? "♪" : "♪̶"}
+          </button>
         )}
         {onRestart && (
           <button

--- a/app/src/hooks/useSettings.test.ts
+++ b/app/src/hooks/useSettings.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useSettings } from "./useSettings.js";
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    clear: () => { store = {}; },
+  };
+})();
+
+beforeEach(() => {
+  localStorageMock.clear();
+  vi.stubGlobal("localStorage", localStorageMock);
+});
+
+describe("useSettings", () => {
+  it("returns default settings on first load", () => {
+    const { result } = renderHook(() => useSettings());
+    expect(result.current.settings.soundEnabled).toBe(true);
+    expect(result.current.settings.soundVolume).toBe(70);
+    expect(result.current.settings.animationsEnabled).toBe(true);
+  });
+
+  it("toggleSound flips soundEnabled", () => {
+    const { result } = renderHook(() => useSettings());
+    act(() => result.current.toggleSound());
+    expect(result.current.settings.soundEnabled).toBe(false);
+    act(() => result.current.toggleSound());
+    expect(result.current.settings.soundEnabled).toBe(true);
+  });
+
+  it("setSoundVolume clamps to 0–100", () => {
+    const { result } = renderHook(() => useSettings());
+    act(() => result.current.setSoundVolume(150));
+    expect(result.current.settings.soundVolume).toBe(100);
+    act(() => result.current.setSoundVolume(-10));
+    expect(result.current.settings.soundVolume).toBe(0);
+  });
+
+  it("toggleAnimations flips animationsEnabled", () => {
+    const { result } = renderHook(() => useSettings());
+    act(() => result.current.toggleAnimations());
+    expect(result.current.settings.animationsEnabled).toBe(false);
+  });
+
+  it("persists settings to localStorage", () => {
+    const { result } = renderHook(() => useSettings());
+    act(() => result.current.toggleSound());
+    const stored = JSON.parse(localStorageMock.getItem("pwarf_settings")!);
+    expect(stored.soundEnabled).toBe(false);
+  });
+
+  it("loads persisted settings on mount", () => {
+    localStorageMock.setItem("pwarf_settings", JSON.stringify({ soundEnabled: false, soundVolume: 30, animationsEnabled: false }));
+    const { result } = renderHook(() => useSettings());
+    expect(result.current.settings.soundEnabled).toBe(false);
+    expect(result.current.settings.soundVolume).toBe(30);
+    expect(result.current.settings.animationsEnabled).toBe(false);
+  });
+});

--- a/app/src/hooks/useSettings.ts
+++ b/app/src/hooks/useSettings.ts
@@ -1,0 +1,55 @@
+import { useState, useEffect } from "react";
+
+const STORAGE_KEY = "pwarf_settings";
+
+export interface Settings {
+  soundEnabled: boolean;
+  soundVolume: number;      // 0–100
+  animationsEnabled: boolean;
+}
+
+const DEFAULTS: Settings = {
+  soundEnabled: true,
+  soundVolume: 70,
+  animationsEnabled: true,
+};
+
+function load(): Settings {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { ...DEFAULTS };
+    return { ...DEFAULTS, ...JSON.parse(raw) };
+  } catch {
+    return { ...DEFAULTS };
+  }
+}
+
+function save(s: Settings): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(s));
+  } catch {
+    // ignore storage errors
+  }
+}
+
+export function useSettings() {
+  const [settings, setSettings] = useState<Settings>(load);
+
+  useEffect(() => {
+    save(settings);
+  }, [settings]);
+
+  function toggleSound() {
+    setSettings((s) => ({ ...s, soundEnabled: !s.soundEnabled }));
+  }
+
+  function setSoundVolume(volume: number) {
+    setSettings((s) => ({ ...s, soundVolume: Math.max(0, Math.min(100, volume)) }));
+  }
+
+  function toggleAnimations() {
+    setSettings((s) => ({ ...s, animationsEnabled: !s.animationsEnabled }));
+  }
+
+  return { settings, toggleSound, setSoundVolume, toggleAnimations };
+}

--- a/app/src/sounds/sound-catalog.test.ts
+++ b/app/src/sounds/sound-catalog.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { CATEGORY_SOUNDS, monsterRoarPitch } from "./sound-catalog.js";
+
+describe("CATEGORY_SOUNDS", () => {
+  it("maps battle to sword_clash", () => {
+    expect(CATEGORY_SOUNDS["battle"]).toBe("sword_clash");
+  });
+
+  it("maps death to death_thud", () => {
+    expect(CATEGORY_SOUNDS["death"]).toBe("death_thud");
+  });
+
+  it("maps artifact_created to artifact_fanfare", () => {
+    expect(CATEGORY_SOUNDS["artifact_created"]).toBe("artifact_fanfare");
+  });
+
+  it("maps fortress_fallen to fortress_fallen", () => {
+    expect(CATEGORY_SOUNDS["fortress_fallen"]).toBe("fortress_fallen");
+  });
+
+  it("maps trade_caravan_arrival to caravan_bells", () => {
+    expect(CATEGORY_SOUNDS["trade_caravan_arrival"]).toBe("caravan_bells");
+  });
+
+  it("maps monster_sighting to monster_roar", () => {
+    expect(CATEGORY_SOUNDS["monster_sighting"]).toBe("monster_roar");
+  });
+
+  it("maps monster_slain to monster_die", () => {
+    expect(CATEGORY_SOUNDS["monster_slain"]).toBe("monster_die");
+  });
+
+  it("maps migration to migration_crowd", () => {
+    expect(CATEGORY_SOUNDS["migration"]).toBe("migration_crowd");
+  });
+
+  it("has no mapping for categories that shouldn't play sounds", () => {
+    expect(CATEGORY_SOUNDS["birth"]).toBeUndefined();
+    expect(CATEGORY_SOUNDS["fortress_founded"]).toBeUndefined();
+    expect(CATEGORY_SOUNDS["discovery"]).toBeUndefined();
+  });
+});
+
+describe("monsterRoarPitch", () => {
+  it("returns negative pitch for high-threat monsters (dragon tier)", () => {
+    expect(monsterRoarPitch(8)).toBeLessThan(0);
+    expect(monsterRoarPitch(10)).toBeLessThan(0);
+  });
+
+  it("returns zero pitch for mid-tier threats", () => {
+    expect(monsterRoarPitch(5)).toBe(0);
+    expect(monsterRoarPitch(7)).toBe(0);
+  });
+
+  it("returns positive pitch for low-tier threats", () => {
+    expect(monsterRoarPitch(1)).toBeGreaterThan(0);
+    expect(monsterRoarPitch(4)).toBeGreaterThan(0);
+  });
+});

--- a/app/src/sounds/sound-catalog.ts
+++ b/app/src/sounds/sound-catalog.ts
@@ -1,0 +1,22 @@
+import type { EventCategory } from "@pwarf/shared";
+import type { SynthPresetName } from "./synth-presets.js";
+
+/** Maps WorldEvent category to a sound preset. */
+export const CATEGORY_SOUNDS: Partial<Record<EventCategory, SynthPresetName>> = {
+  battle: "sword_clash",
+  death: "death_thud",
+  artifact_created: "artifact_fanfare",
+  fortress_fallen: "fortress_fallen",
+  trade_caravan_arrival: "caravan_bells",
+  monster_sighting: "monster_roar",
+  monster_slain: "monster_die",
+  monster_siege: "monster_roar",
+  migration: "migration_crowd",
+};
+
+/** Pitch offsets (semitones) for monster roar by rough threat tier. */
+export function monsterRoarPitch(threatLevel: number): number {
+  if (threatLevel >= 8) return -6;  // dragon / titan: deep
+  if (threatLevel >= 5) return 0;
+  return 6;                          // small monsters: higher
+}

--- a/app/src/sounds/synth-presets.ts
+++ b/app/src/sounds/synth-presets.ts
@@ -1,0 +1,245 @@
+import * as Tone from "tone";
+
+export type SynthPresetName =
+  | "pick_hit"
+  | "rock_crumble"
+  | "wall_placed"
+  | "sword_clash"
+  | "death_thud"
+  | "tantrum_scream"
+  | "item_smash"
+  | "monster_roar"
+  | "monster_die"
+  | "stomach_growl"
+  | "gulp"
+  | "snore"
+  | "stress_sting"
+  | "artifact_fanfare"
+  | "fortress_fallen"
+  | "caravan_bells"
+  | "disease_cough"
+  | "year_chime"
+  | "migration_crowd";
+
+export type PlayFn = (options?: { pitch?: number }) => void;
+
+export const PRESETS: Record<SynthPresetName, PlayFn> = {
+  pick_hit({ pitch = 0 } = {}) {
+    const synth = new Tone.MetalSynth({
+      envelope: { attack: 0.001, decay: 0.1, release: 0.1 },
+      harmonicity: 5.1,
+      modulationIndex: 32,
+      resonance: 4000,
+      octaves: 1.5,
+      volume: -18,
+    }).toDestination();
+    const freq = 400 * Math.pow(2, pitch / 12);
+    synth.frequency.value = freq;
+    synth.triggerAttackRelease(freq, "8n");
+    setTimeout(() => synth.dispose(), 500);
+  },
+
+  rock_crumble() {
+    const synth = new Tone.NoiseSynth({
+      noise: { type: "brown" },
+      envelope: { attack: 0.05, decay: 0.4, sustain: 0, release: 0.2 },
+      volume: -22,
+    }).toDestination();
+    synth.triggerAttackRelease("16n");
+    setTimeout(() => synth.dispose(), 1000);
+  },
+
+  wall_placed() {
+    const synth = new Tone.MembraneSynth({
+      pitchDecay: 0.08,
+      octaves: 4,
+      envelope: { attack: 0.001, decay: 0.3, sustain: 0, release: 0.2 },
+      volume: -16,
+    }).toDestination();
+    synth.triggerAttackRelease("C1", "8n");
+    setTimeout(() => synth.dispose(), 800);
+  },
+
+  sword_clash() {
+    const synth = new Tone.MetalSynth({
+      envelope: { attack: 0.001, decay: 0.15, release: 0.1 },
+      harmonicity: 8.5,
+      modulationIndex: 40,
+      resonance: 3000,
+      octaves: 2,
+      volume: -14,
+    }).toDestination();
+    synth.frequency.value = 200;
+    synth.triggerAttackRelease(200, "16n");
+    setTimeout(() => synth.dispose(), 600);
+  },
+
+  death_thud() {
+    const synth = new Tone.MembraneSynth({
+      pitchDecay: 0.15,
+      octaves: 6,
+      envelope: { attack: 0.001, decay: 0.6, sustain: 0, release: 0.4 },
+      volume: -12,
+    }).toDestination();
+    synth.triggerAttackRelease("A0", "4n");
+    setTimeout(() => synth.dispose(), 1500);
+  },
+
+  tantrum_scream() {
+    const synth = new Tone.Synth({
+      oscillator: { type: "sawtooth" },
+      envelope: { attack: 0.01, decay: 0.3, sustain: 0.1, release: 0.3 },
+      volume: -16,
+    }).toDestination();
+    synth.triggerAttackRelease("G#3", "8n");
+    setTimeout(() => synth.dispose(), 800);
+  },
+
+  item_smash() {
+    const synth = new Tone.NoiseSynth({
+      noise: { type: "white" },
+      envelope: { attack: 0.001, decay: 0.25, sustain: 0, release: 0.1 },
+      volume: -18,
+    }).toDestination();
+    synth.triggerAttackRelease("16n");
+    setTimeout(() => synth.dispose(), 600);
+  },
+
+  monster_roar({ pitch = 0 } = {}) {
+    const synth = new Tone.Synth({
+      oscillator: { type: "sawtooth" },
+      envelope: { attack: 0.1, decay: 0.8, sustain: 0.2, release: 0.5 },
+      volume: -12,
+    }).toDestination();
+    synth.triggerAttackRelease(80 * Math.pow(2, pitch / 12), "4n");
+    setTimeout(() => synth.dispose(), 2000);
+  },
+
+  monster_die() {
+    const synth = new Tone.Synth({
+      oscillator: { type: "sawtooth" },
+      envelope: { attack: 0.01, decay: 1.0, sustain: 0, release: 0.5 },
+      volume: -16,
+    }).toDestination();
+    synth.triggerAttackRelease("D2", "4n");
+    setTimeout(() => synth.dispose(), 2000);
+  },
+
+  stomach_growl() {
+    const synth = new Tone.Synth({
+      oscillator: { type: "sine" },
+      envelope: { attack: 0.05, decay: 0.4, sustain: 0, release: 0.2 },
+      volume: -24,
+    }).toDestination();
+    synth.triggerAttackRelease("G2", "4n");
+    setTimeout(() => synth.dispose(), 1000);
+  },
+
+  gulp() {
+    const synth = new Tone.Synth({
+      oscillator: { type: "sine" },
+      envelope: { attack: 0.01, decay: 0.1, sustain: 0, release: 0.05 },
+      volume: -28,
+    }).toDestination();
+    synth.triggerAttackRelease("C5", "32n");
+    setTimeout(() => synth.dispose(), 300);
+  },
+
+  snore() {
+    const synth = new Tone.NoiseSynth({
+      noise: { type: "pink" },
+      envelope: { attack: 0.1, decay: 0.5, sustain: 0, release: 0.3 },
+      volume: -30,
+    }).toDestination();
+    synth.triggerAttackRelease("4n");
+    setTimeout(() => synth.dispose(), 1200);
+  },
+
+  stress_sting() {
+    const synth = new Tone.Synth({
+      oscillator: { type: "triangle" },
+      envelope: { attack: 0.01, decay: 0.2, sustain: 0.1, release: 0.3 },
+      volume: -20,
+    }).toDestination();
+    synth.triggerAttackRelease("Bb4", "8n");
+    setTimeout(() => synth.dispose(), 800);
+  },
+
+  artifact_fanfare() {
+    const synth = new Tone.PolySynth(Tone.Synth, {
+      oscillator: { type: "triangle" },
+      envelope: { attack: 0.02, decay: 0.3, sustain: 0.4, release: 0.8 },
+      volume: -14,
+    }).toDestination();
+    const now = Tone.now();
+    synth.triggerAttackRelease("C4", "8n", now);
+    synth.triggerAttackRelease("E4", "8n", now + 0.12);
+    synth.triggerAttackRelease("G4", "8n", now + 0.24);
+    synth.triggerAttackRelease(["C5", "E5"], "4n", now + 0.36);
+    setTimeout(() => synth.dispose(), 3000);
+  },
+
+  fortress_fallen() {
+    const synth = new Tone.PolySynth(Tone.Synth, {
+      oscillator: { type: "sine" },
+      envelope: { attack: 0.5, decay: 2.0, sustain: 0.5, release: 2.0 },
+      volume: -10,
+    }).toDestination();
+    synth.triggerAttackRelease(["C3", "Eb3", "Gb3"], "2n");
+    setTimeout(() => synth.dispose(), 6000);
+  },
+
+  caravan_bells() {
+    const synth = new Tone.MetalSynth({
+      envelope: { attack: 0.001, decay: 0.5, release: 0.3 },
+      harmonicity: 5.1,
+      modulationIndex: 16,
+      resonance: 4000,
+      octaves: 0.5,
+      volume: -20,
+    }).toDestination();
+    synth.frequency.value = 800;
+    const now = Tone.now();
+    [0, 0.15, 0.35].forEach((t) => synth.triggerAttackRelease(800, "8n", now + t));
+    setTimeout(() => synth.dispose(), 2000);
+  },
+
+  disease_cough() {
+    const synth = new Tone.NoiseSynth({
+      noise: { type: "white" },
+      envelope: { attack: 0.01, decay: 0.2, sustain: 0.1, release: 0.2 },
+      volume: -22,
+    }).toDestination();
+    const now = Tone.now();
+    [0, 0.25].forEach((t) => synth.triggerAttackRelease("8n", now + t));
+    setTimeout(() => synth.dispose(), 1200);
+  },
+
+  year_chime() {
+    const synth = new Tone.MetalSynth({
+      envelope: { attack: 0.001, decay: 1.0, release: 0.5 },
+      harmonicity: 2.0,
+      modulationIndex: 8,
+      resonance: 3000,
+      octaves: 1.0,
+      volume: -18,
+    }).toDestination();
+    synth.frequency.value = 500;
+    synth.triggerAttackRelease(500, "8n", Tone.now());
+    setTimeout(() => synth.dispose(), 3000);
+  },
+
+  migration_crowd() {
+    const synth = new Tone.NoiseSynth({
+      noise: { type: "pink" },
+      envelope: { attack: 0.3, decay: 1.0, sustain: 0.2, release: 0.8 },
+      volume: -26,
+    }).toDestination();
+    synth.triggerAttackRelease("2n");
+    setTimeout(() => synth.dispose(), 3000);
+  },
+};
+
+export function playPreset(name: SynthPresetName, options?: { pitch?: number }): void {
+  PRESETS[name](options);
+}

--- a/app/src/sounds/use-sound-engine.ts
+++ b/app/src/sounds/use-sound-engine.ts
@@ -1,0 +1,62 @@
+import { useEffect, useRef } from "react";
+import * as Tone from "tone";
+import type { SimSnapshot } from "@pwarf/sim";
+import { playPreset } from "./synth-presets.js";
+import { CATEGORY_SOUNDS, monsterRoarPitch } from "./sound-catalog.js";
+
+/**
+ * Subscribes to the sim snapshot and plays sounds for new events.
+ *
+ * - Deduplicates: at most one sound per event category per tick.
+ * - Skips all sounds when muted or when the AudioContext hasn't been
+ *   unlocked yet (browsers require a user gesture).
+ */
+export function useSoundEngine(
+  snapshot: SimSnapshot | null,
+  muted: boolean,
+): void {
+  const prevEventIds = useRef(new Set<string>());
+  const audioUnlocked = useRef(false);
+
+  // Unlock AudioContext on first user interaction
+  useEffect(() => {
+    const unlock = () => {
+      if (!audioUnlocked.current) {
+        Tone.start().then(() => {
+          audioUnlocked.current = true;
+        });
+      }
+    };
+    window.addEventListener("click", unlock, { once: false });
+    window.addEventListener("keydown", unlock, { once: false });
+    return () => {
+      window.removeEventListener("click", unlock);
+      window.removeEventListener("keydown", unlock);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!snapshot || muted || !audioUnlocked.current) return;
+
+    const fired = new Set<string>(); // deduplicate by category within this tick
+
+    for (const event of snapshot.events) {
+      if (prevEventIds.current.has(event.id)) continue;
+      if (fired.has(event.category)) continue;
+
+      const preset = CATEGORY_SOUNDS[event.category];
+      if (preset) {
+        const options =
+          (event.category === "monster_sighting" || event.category === "monster_siege")
+            ? { pitch: monsterRoarPitch((event.event_data?.threat_level as number) ?? 5) }
+            : undefined;
+        playPreset(preset, options);
+        fired.add(event.category);
+      }
+    }
+
+    // Update seen-event tracking: keep last 200 IDs to bound memory
+    const allIds = snapshot.events.map((e) => e.id);
+    prevEventIds.current = new Set(allIds.slice(-200));
+  }, [snapshot, muted]);
+}

--- a/docs/brainstorm-sounds-animations.md
+++ b/docs/brainstorm-sounds-animations.md
@@ -1,0 +1,197 @@
+# Brainstorm: Sounds & Animations for pWarf
+
+## Current State
+
+- Zero audio infrastructure
+- Zero animation infrastructure
+- ASCII canvas is fully stateless — each tick redraws everything from scratch
+- 10 ticks/sec event-driven render cycle
+- Rich event stream already flowing: combat, death, tantrum, mining, disease, monster spawns, artifacts, etc.
+
+---
+
+## Guiding Principles
+
+- **Stay ASCII.** pWarf's identity is its terminal aesthetic. Animations should enhance that, not break it.
+- **Event-driven first.** Sound and visual effects should be reactions to `WorldEvent` and `SimSnapshot` state — not timers.
+- **Headless sim stays clean.** No audio or animation code in `sim/`. Everything lives in `app/`.
+- **Performance.** Canvas redraws at 10Hz. Effects must not tank framerate or cause janky re-renders.
+- **Mutable by default.** All sounds and animations should be toggleable via settings.
+
+---
+
+## Sounds
+
+### Tech Options
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Web Audio API (native)** | No dependency, precise timing | Verbose to use |
+| **Howler.js** | Simple API, sprite sheets, volume/fade | External dep |
+| **Tone.js** | Synthesized sound (no audio files needed!) | Complex API, larger bundle |
+
+**Recommendation: Tone.js for synthesized/procedural sounds** — no asset files needed, fits the ASCII aesthetic, fully seeded/deterministic if we want. Fallback: Howler.js + `.ogg` audio sprites.
+
+### Sound Categories & Triggers
+
+#### Mining & Construction
+- `pick_hit` — every tick a mining task makes progress (`DwarfActionEvent { action: 'mine' }`)
+- `wall_placed` — construction task completes
+- `rock_crumble` — mine tile becomes exposed floor
+
+#### Combat & Violence
+- `sword_clash` — `CombatEvent` (damage > 0)
+- `death_thud` — `DeathEvent`
+- `tantrum_scream` — `DwarfTantrumEvent` fires
+- `item_smash` — `DwarfTantrumEvent.items_destroyed > 0`
+- `monster_roar` — `MonsterSpawnEvent` (tone varies by monster type)
+- `monster_die` — `MonsterSlainEvent`
+
+#### Needs & Status
+- `stomach_growl` — `DwarfNeedCriticalEvent { need: 'food' }`
+- `gulp` — dwarf eats or drinks (`DwarfActionEvent { action: 'eat' | 'drink' }`)
+- `snore` — dwarf sleeps
+- `stress_sting` — dwarf stress crosses 60 (warning tone)
+
+#### Milestones & Drama
+- `artifact_fanfare` — `ArtifactCreatedEvent`
+- `fortress_fallen` — `FortressFallenEvent` (somber chord or doom sting)
+- `caravan_bells` — `TradeCaravanArrivalEvent`
+- `disease_cough` — `DiseaseOutbreakEvent`
+- `year_chime` — `YearRollupEvent`
+- `migration_crowd` — `MigrationEvent`
+
+### Sound Architecture
+
+```
+app/src/sounds/
+  use-sound-engine.ts     ← React hook, subscribes to snapshot events
+  sound-catalog.ts        ← maps event types to synthesizer params or file paths
+  synth-presets.ts        ← Tone.js instrument configs (pick, thud, roar, etc.)
+```
+
+- `useSoundEngine(snapshot)` — called in `App.tsx`, compares previous vs current events
+- Deduplicates sounds per tick (don't play 5 "pick hits" at once — sample one)
+- Volume normalization: ambient sounds quieter, drama louder
+- Global mute toggle in Toolbar
+
+---
+
+## Animations
+
+### Approach: Canvas Overlay + CSS Transitions
+
+Two layers:
+1. **Canvas effects** — drawn on top of the existing ASCII canvas (or a second canvas layer)
+2. **CSS/React transitions** — for UI panels, modals, and text elements
+
+No tweening of dwarf positions (they teleport tile to tile — matches the sim model).
+
+### Visual Effects
+
+#### Tile Flash / Glyph Color Pulse
+- **Mining flash** — tile briefly lights up amber when a mine tick hits
+- **Death flash** — tile flashes red for ~500ms when a dwarf dies there
+- **Tantrum flash** — dwarf's tile pulses red while `is_in_tantrum`
+- **Combat flash** — brief white flash on defender's tile per `CombatEvent`
+- **Artifact glow** — newly created artifact glows yellow for 2s
+- **Critical need warning** — dwarf glyph blinks when any need < 10
+
+Implementation: maintain an `effects: Map<string, Effect>` keyed by `"x,y"`, render during canvas draw pass with decay.
+
+#### Screen Effects
+- **Fortress fallen** — slow red vignette fade + screen darkens
+- **Monster siege** — subtle red tint at screen edges during active siege
+
+#### UI Transitions
+- **Event log entries** — slide in from right + fade (replace abrupt append)
+- **Modal open/close** — fade in/out (DwarfModal, InventoryModal)
+- **Toolbar speed indicator** — animate when paused/unpaused
+- **Need bars** — smooth CSS transitions on progress bars in DwarfModal (they already exist as divs)
+
+#### Particles (ASCII-style)
+If we want to stay fully in-character, particles can be ASCII glyphs that drift upward and fade out:
+- `*` sparks for mining/smithing
+- `~` splash for drinking
+- `.` debris for item smashing
+- `!` impact markers for combat
+
+These would be lightweight: a canvas overlay, an array of `{x, y, char, alpha, vy}` objects, updated on `requestAnimationFrame`.
+
+### Animation Architecture
+
+```
+app/src/animations/
+  use-canvas-effects.ts    ← React hook, returns effects map + update function
+  canvas-effects-layer.ts  ← canvas draw helper, renders effects over main canvas
+  css-transitions.ts       ← shared animation constants (durations, easings)
+  particle-system.ts       ← ASCII particle emitter/renderer
+```
+
+- `useCanvasEffects(snapshot)` — watches snapshot diffs, emits new effects
+- Effects have a `ttl` (time-to-live in ms), decay on `requestAnimationFrame`
+- Particle system runs its own `rAF` loop (independent of sim tick)
+- All effects are purely cosmetic — no sim state affected
+
+---
+
+## Integration Points
+
+### Where to hook in
+
+| Effect type | Integration point |
+|-------------|-------------------|
+| Sound effects | `App.tsx` → `useSoundEngine(snapshot)` |
+| Canvas flash/glow | `MainViewport.tsx` → second canvas layer or overlay in `render()` |
+| Particles | `MainViewport.tsx` → overlay canvas with own `rAF` loop |
+| UI transitions | CSS in component files + `app.css` |
+| Screen effects | CSS overlay `<div>` in `App.tsx` triggered by snapshot state |
+
+### Snapshot data available
+
+Every tick provides:
+- `events[]` — all fired events (combat, death, etc.) — primary trigger source
+- `dwarves[]` — includes `is_in_tantrum`, `stress_level`, all needs — for continuous effects
+- `monsters[]` — positions and behavior — for siege mode detection
+- `fortressTileOverrides[]` — newly mined/built tiles — for tile flash
+
+---
+
+## Proposed GitHub Issues
+
+### Phase 1 — Foundation
+1. **`feat: sound engine foundation`** — `useSoundEngine` hook + Tone.js install + global mute toggle
+2. **`feat: canvas effects layer`** — `useCanvasEffects` hook + overlay canvas + tile flash system
+3. **`feat: ASCII particle system`** — lightweight ASCII particle emitter on canvas overlay
+
+### Phase 2 — Core Sounds
+4. **`feat: mining and construction sounds`** — pick, crumble, wall place
+5. **`feat: combat and death sounds`** — clash, thud, monster roar/die, tantrum scream
+6. **`feat: needs and daily life sounds`** — gulp, snore, growl, stress sting
+
+### Phase 3 — Drama
+7. **`feat: milestone and event sounds`** — artifact fanfare, fortress fallen, caravan, disease, year chime
+8. **`feat: fortress fallen screen effect`** — red vignette + slow darkening
+9. **`feat: siege mode screen tint`** — edge glow during active monster siege
+
+### Phase 4 — Polish
+10. **`feat: UI transitions and animations`** — event log slide-in, modal fade, need bar transitions
+11. **`feat: dwarf need blink warning`** — dwarf glyph blinks when any need is critical
+12. **`feat: sound and animation settings`** — toggles for sound/animations in a settings panel
+
+---
+
+## Out of Scope
+
+- Music / ambient soundtrack (separate initiative)
+- Sprite-based animations (breaks ASCII identity)
+- Tweened dwarf movement (doesn't match sim model, would be misleading)
+- Sound in headless/sim mode
+
+---
+
+## Open Questions
+
+- Tone.js vs Howler.js + asset files? Synthesized is dependency-light and fits the aesthetic, but harder to make sound "good". Could do both: synth for ambient/repeated, assets for drama.
+- Second canvas vs single canvas for effects? Two canvases (`position: absolute` layered) is cleanest architecture. One canvas requires careful draw order.
+- Should effects be seeded/deterministic? Probably not — they're cosmetic. But if we want replay fidelity, pass the sim RNG down.

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
         "@supabase/supabase-js": "^2.49.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "simplex-noise": "^4.0.3"
+        "simplex-noise": "^4.0.3",
+        "tone": "^15.1.22"
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.1.3",
@@ -346,10 +347,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "dev": true,
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2197,6 +2197,19 @@
         "node": ">=12"
       }
     },
+    "node_modules/automation-events": {
+      "version": "7.1.16",
+      "resolved": "https://registry.npmjs.org/automation-events/-/automation-events-7.1.16.tgz",
+      "integrity": "sha512-vAAHG8WO+Cx2PfwmWIAxSD51ZYg+zRam52pzOGVAJOqsqQO6oaPM2k4/cdEF7QQ786FYB8Wzbw//qTWCdyGvzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.2.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.8",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.8.tgz",
@@ -3379,6 +3392,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardized-audio-context": {
+      "version": "25.3.77",
+      "resolved": "https://registry.npmjs.org/standardized-audio-context/-/standardized-audio-context-25.3.77.tgz",
+      "integrity": "sha512-Ki9zNz6pKcC5Pi+QPjPyVsD9GwJIJWgryji0XL9cAJXMGyn+dPOf6Qik1AHei0+UNVcc4BOCa0hWLBzlwqsW/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.6",
+        "automation-events": "^7.0.9",
+        "tslib": "^2.7.0"
+      }
+    },
     "node_modules/std-env": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
@@ -3530,6 +3554,16 @@
       "integrity": "sha512-5WJ2SqFsv4G2Dwi7ZFVRnz6b2H1od39QME1lc2y5Ew3eWiZMAeqOAfWpRP9jHvhUl881406QtZTODvjttJs+ew==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tone": {
+      "version": "15.1.22",
+      "resolved": "https://registry.npmjs.org/tone/-/tone-15.1.22.tgz",
+      "integrity": "sha512-TCScAGD4sLsama5DjvTUXlLDXSqPealhL64nsdV1hhr6frPWve0DeSo63AKnSJwgfg55fhvxj0iPPRwPN5o0ag==",
+      "license": "MIT",
+      "dependencies": {
+        "standardized-audio-context": "^25.3.70",
+        "tslib": "^2.3.1"
+      }
     },
     "node_modules/tough-cookie": {
       "version": "6.0.1",


### PR DESCRIPTION
## Summary

- Adds Tone.js and a synthesized sound system with 19 preset sounds (no audio files needed)
- `useSoundEngine` hook fires sounds on new `WorldEvent` types, deduplicates per tick, and respects browser AudioContext unlock requirement (user gesture)
- `useSettings` hook persists `soundEnabled`, `soundVolume`, and `animationsEnabled` to localStorage
- Mute toggle button `♪` added to Toolbar
- Brainstorm doc at `docs/brainstorm-sounds-animations.md` with full plan for 11 follow-on issues (#498–#508)

## Sound mappings

| Event | Sound |
|-------|-------|
| battle | sword clash |
| death | bass thud |
| artifact_created | ascending fanfare |
| fortress_fallen | somber chord |
| trade_caravan_arrival | bells |
| monster_sighting / siege | roar (pitch varies by threat level) |
| monster_slain | die sound |
| migration | crowd noise |

## Test plan

- [x] `npm test` — 18 new tests pass (sound-catalog: 9, useSettings: 6, plus existing 96)
- [x] `npm run build` — TypeScript build passes
- No sim code touched; headless mode unaffected

## Claude Cost

**Claude cost:** $0.03 (57k tokens)