### PR TITLE
fix: deconstruct pending builds instantly, fix z-level bleed (closes #512, closes #513)

### DIFF
--- a/app/src/hooks/__tests__/useDesignation.test.ts
+++ b/app/src/hooks/__tests__/useDesignation.test.ts
@@ -10,7 +10,7 @@ let deleteResult = { error: null as { message: string } | null };
 
 function makeChain(): Record<string, (...args: unknown[]) => unknown> {
   const chain: Record<string, (...args: unknown[]) => unknown> = {};
-  for (const method of ["delete", "eq", "gte", "lte"]) {
+  for (const method of ["delete", "eq", "gte", "lte", "in", "like"]) {
     chain[method] = (...args: unknown[]) => {
       calls.push({ method, args });
       return { ...chain, then: (resolve: (v: unknown) => void) => resolve(deleteResult) };
@@ -192,6 +192,40 @@ describe("useDesignation", () => {
     });
   });
 
+  describe("deconstruct cancels pending builds (fix #512)", () => {
+    it("cancels a pending build task when deconstructing that tile", async () => {
+      setupDeleteChain();
+      const designatedTiles = new Map([["5,5", "build_bed"]]);
+      const { result } = makeHook({ designatedTiles });
+
+      act(() => { result.current.toggleDeconstruct(); });
+      await act(async () => {
+        await result.current.handleDesignateArea(5, 5, 5, 5);
+      });
+
+      // Should have called delete on tasks table
+      expect(mockFrom).toHaveBeenCalledWith("tasks");
+      expect(calls.some((c) => c.method === "delete")).toBe(true);
+      expect(findCall("eq", "target_x")?.args[1]).toBe(5);
+      expect(findCall("eq", "target_y")?.args[1]).toBe(5);
+      expect(findCall("like", "task_type")?.args[1]).toBe("build_%");
+    });
+
+    it("does not cancel non-build tasks when deconstructing", async () => {
+      setupDeleteChain();
+      const designatedTiles = new Map([["5,5", "mine"]]);
+      const { result } = makeHook({ designatedTiles });
+
+      act(() => { result.current.toggleDeconstruct(); });
+      await act(async () => {
+        await result.current.handleDesignateArea(5, 5, 5, 5);
+      });
+
+      // Should not have called any DB operation (mine task is not build_*)
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+  });
+
   describe("optimistic tile clearing (fix #348)", () => {
     it("shows optimistic tile immediately after designation", async () => {
       setupInsertChain();
@@ -249,6 +283,57 @@ describe("useDesignation", () => {
       });
 
       expect(result.current.optimisticTiles.has("2,3")).toBe(false);
+    });
+  });
+
+  describe("optimistic tiles z-level filtering (fix #513)", () => {
+    it("does not show surface optimistic tiles when viewing caves", async () => {
+      setupInsertChain();
+      const getFortressTile = () => ({ tileType: "stone" as const, material: null, x: 2, y: 3, z: 0, isRevealed: false, isMined: false });
+      const { result, rerender } = renderHook(
+        (props: Parameters<typeof useDesignation>[0]) => useDesignation(props),
+        { initialProps: { civId: "civ-1", zLevel: 0, getFortressTile, designatedTiles: new Map<string, string>(), addOptimistic: () => {} } },
+      );
+
+      // Designate on surface (z=0)
+      act(() => { result.current.toggleMine(); });
+      await act(async () => {
+        await result.current.handleDesignateArea(2, 3, 2, 3);
+      });
+
+      expect(result.current.optimisticTiles.has("2,3")).toBe(true);
+
+      // Switch to cave view (z=-1) — optimistic tile should NOT appear
+      await act(async () => {
+        rerender({ civId: "civ-1", zLevel: -1, getFortressTile, designatedTiles: new Map<string, string>(), addOptimistic: () => {} });
+      });
+
+      expect(result.current.optimisticTiles.has("2,3")).toBe(false);
+    });
+
+    it("shows optimistic tile again when switching back to original z-level", async () => {
+      setupInsertChain();
+      const getFortressTile = () => ({ tileType: "stone" as const, material: null, x: 2, y: 3, z: 0, isRevealed: false, isMined: false });
+      const { result, rerender } = renderHook(
+        (props: Parameters<typeof useDesignation>[0]) => useDesignation(props),
+        { initialProps: { civId: "civ-1", zLevel: 0, getFortressTile, designatedTiles: new Map<string, string>(), addOptimistic: () => {} } },
+      );
+
+      // Designate on surface (z=0)
+      act(() => { result.current.toggleMine(); });
+      await act(async () => {
+        await result.current.handleDesignateArea(2, 3, 2, 3);
+      });
+
+      // Switch to caves then back to surface
+      await act(async () => {
+        rerender({ civId: "civ-1", zLevel: -1, getFortressTile, designatedTiles: new Map<string, string>(), addOptimistic: () => {} });
+      });
+      await act(async () => {
+        rerender({ civId: "civ-1", zLevel: 0, getFortressTile, designatedTiles: new Map<string, string>(), addOptimistic: () => {} });
+      });
+
+      expect(result.current.optimisticTiles.has("2,3")).toBe(true);
     });
   });
 });

--- a/app/src/hooks/useDesignation.ts
+++ b/app/src/hooks/useDesignation.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import type { TaskType } from "@pwarf/shared";
 import {
   WORK_MINE_BASE,
@@ -66,24 +66,39 @@ export function useDesignation(opts: {
   const [prioritiesOpen, setPrioritiesOpen] = useState(false);
   const [taskPriorities, setTaskPriorities] = useState<Record<string, number>>({});
 
-  // Optimistic designations — shown immediately before poll picks them up
-  const [optimisticTiles, setOptimisticTiles] = useState<Map<string, string>>(new Map());
+  // Optimistic designations — keyed by "x,y,z" to avoid cross-z-level bleed (#513)
+  const [optimisticTilesRaw, setOptimisticTilesRaw] = useState<Map<string, string>>(new Map());
+
+  // Expose only entries matching the current zLevel, keyed by "x,y" for rendering
+  const optimisticTiles = useMemo(() => {
+    const filtered = new Map<string, string>();
+    const suffix = `,${zLevel}`;
+    for (const [key, val] of optimisticTilesRaw) {
+      if (key.endsWith(suffix)) {
+        // Strip the z component: "x,y,z" → "x,y"
+        filtered.set(key.slice(0, key.lastIndexOf(',')), val);
+      }
+    }
+    return filtered;
+  }, [optimisticTilesRaw, zLevel]);
 
   // Clear optimistic tiles one-by-one as each key appears in the real designatedTiles.
   // Content-based so a new array reference on every sim tick doesn't wipe all optimistic
   // state before the sim has picked up the newly inserted task.
   useEffect(() => {
-    if (optimisticTiles.size === 0) return;
+    if (optimisticTilesRaw.size === 0) return;
     let changed = false;
-    const next = new Map(optimisticTiles);
-    for (const key of optimisticTiles.keys()) {
-      if (designatedTiles.has(key)) {
+    const next = new Map(optimisticTilesRaw);
+    for (const key of optimisticTilesRaw.keys()) {
+      if (!key.endsWith(`,${zLevel}`)) continue;
+      const xyKey = key.slice(0, key.lastIndexOf(','));
+      if (designatedTiles.has(xyKey)) {
         next.delete(key);
         changed = true;
       }
     }
-    if (changed) setOptimisticTiles(next);
-  }, [designatedTiles, optimisticTiles]);
+    if (changed) setOptimisticTilesRaw(next);
+  }, [designatedTiles, optimisticTilesRaw, zLevel]);
 
   const handleDesignateArea = useCallback(async (x1: number, y1: number, x2: number, y2: number) => {
     if (designationMode === 'none' || !civId) return;
@@ -129,9 +144,21 @@ export function useDesignation(opts: {
       work_required: number;
     }> = [];
 
+    // Deconstruct mode: collect pending build tasks to cancel immediately (#512)
+    const cancelBuildCoords: Array<{ x: number; y: number }> = [];
+
     for (let y = y1; y <= y2; y++) {
       for (let x = x1; x <= x2; x++) {
-        if (designatedTiles.has(`${x},${y}`)) continue;
+        if (designatedTiles.has(`${x},${y}`)) {
+          // In deconstruct mode, cancel any existing pending build task at this tile
+          if (isDeconstruct) {
+            const existing = designatedTiles.get(`${x},${y}`)!;
+            if (existing.startsWith('build_')) {
+              cancelBuildCoords.push({ x, y });
+            }
+          }
+          continue;
+        }
 
         const tile = getFortressTile(x, y);
         if (!tile) continue;
@@ -175,7 +202,26 @@ export function useDesignation(opts: {
       }
     }
 
-    if (tasks.length === 0) return;
+    // Cancel pending build tasks that were targeted for deconstruction (#512)
+    if (cancelBuildCoords.length > 0) {
+      for (const coord of cancelBuildCoords) {
+        const { error } = await supabase
+          .from('tasks')
+          .delete()
+          .eq('civilization_id', civId)
+          .eq('target_x', coord.x)
+          .eq('target_y', coord.y)
+          .eq('target_z', zLevel)
+          .in('status', ['pending', 'claimed', 'in_progress'])
+          .like('task_type', 'build_%');
+        if (error) {
+          console.error('[designate] Failed to cancel build task:', error.message);
+        }
+      }
+    }
+
+    if (tasks.length === 0 && cancelBuildCoords.length === 0) return;
+    if (tasks.length === 0) return; // Only cancellations, already handled above
 
     // Show blueprints immediately — the next poll will reconcile with real data
     addOptimistic(tasks.map((t) => ({ x: t.target_x, y: t.target_y, taskType: t.task_type })));
@@ -184,11 +230,11 @@ export function useDesignation(opts: {
     if (error) {
       console.error('[designate] Failed to create tasks:', error.message);
     } else {
-      // Optimistically show the new designations immediately
-      setOptimisticTiles((prev) => {
+      // Optimistically show the new designations immediately (keyed with z)
+      setOptimisticTilesRaw((prev) => {
         const next = new Map(prev);
         for (const t of tasks) {
-          next.set(`${t.target_x},${t.target_y}`, t.task_type);
+          next.set(`${t.target_x},${t.target_y},${t.target_z}`, t.task_type);
         }
         return next;
       });


### PR DESCRIPTION
## Summary
- **#512**: Deconstructing a tile with a pending/in-progress build task now cancels that build task immediately via DB delete, instead of requiring the tile to already be in a DECONSTRUCTIBLE state. Completed buildings still require a dwarf to perform deconstruction work as before.
- **#513**: Optimistic designation tiles now use `"x,y,z"` keys internally and filter by current z-level when exposed for rendering. Previously, optimistic tiles used `"x,y"` keys which caused them to bleed across z-levels (e.g., surface builds showing in caves).

## Test plan
- [x] New tests: deconstruct cancels pending build tasks
- [x] New tests: deconstruct ignores non-build tasks
- [x] New tests: optimistic tiles don't appear on wrong z-level
- [x] New tests: optimistic tiles reappear when switching back to correct z-level
- [x] All existing designation tests still pass (14/14)

## Claude Cost
<!-- Will be filled by /review-pr -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Claude Cost
**Claude cost:** $4.89 (6.6M tokens)