### PR TITLE
test: unit tests for monster-spawning and monster-pathfinding (closes #483)

### DIFF
--- a/sim/src/__tests__/test-helpers.ts
+++ b/sim/src/__tests__/test-helpers.ts
@@ -1,4 +1,4 @@
-import type { Dwarf, DwarfRelationship, DwarfSkill, FortressTile, FortressTileType, RelationshipType, Task, TaskType, Item, Structure } from "@pwarf/shared";
+import type { Dwarf, DwarfRelationship, DwarfSkill, FortressTile, FortressTileType, RelationshipType, Task, TaskType, Item, Structure, Monster } from "@pwarf/shared";
 import type { SimContext } from "../sim-context.js";
 import { createTestContext } from "../sim-context.js";
 import { createRng, DEFAULT_TEST_SEED } from "../rng.js";
@@ -163,6 +163,40 @@ export function makeRelationship(
     strength: 1,
     shared_events: [],
     formed_year: 1,
+    ...overrides,
+  };
+}
+
+export function makeMonster(overrides?: Partial<Monster>): Monster {
+  return {
+    id: _factoryRng.uuid(),
+    world_id: "world-1",
+    name: "Grakzel",
+    epithet: null,
+    type: "night_creature",
+    status: "active",
+    behavior: "aggressive",
+    is_named: false,
+    lair_tile_x: 20,
+    lair_tile_y: 20,
+    current_tile_x: 20,
+    current_tile_y: 20,
+    threat_level: 30,
+    health: 50,
+    size_category: "medium",
+    body_parts: [],
+    attacks: [],
+    abilities: [],
+    weaknesses: [],
+    lore: null,
+    origin_myth: null,
+    properties: {},
+    first_seen_year: 1,
+    slain_year: null,
+    slain_by_dwarf_id: null,
+    slain_in_civ_id: null,
+    slain_in_ruin_id: null,
+    created_at: new Date().toISOString(),
     ...overrides,
   };
 }

--- a/sim/src/phases/monster-pathfinding.test.ts
+++ b/sim/src/phases/monster-pathfinding.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from "vitest";
+import { makeDwarf, makeMonster, makeContext } from "../__tests__/test-helpers.js";
+import { monsterPathfinding, findNearestDwarf, stepToward } from "./monster-pathfinding.js";
+
+describe("stepToward", () => {
+  it("moves toward target on the X axis when dx > dy", () => {
+    const result = stepToward(0, 0, 5, 2);
+    expect(result).toEqual({ newX: 1, newY: 0 });
+  });
+
+  it("moves toward target on the Y axis when dy > dx", () => {
+    const result = stepToward(0, 0, 2, 5);
+    expect(result).toEqual({ newX: 0, newY: 1 });
+  });
+
+  it("does not move when already at target", () => {
+    const result = stepToward(3, 3, 3, 3);
+    expect(result).toEqual({ newX: 3, newY: 3 });
+  });
+
+  it("moves in negative direction when target is behind", () => {
+    const result = stepToward(5, 5, 0, 0);
+    expect(result).toEqual({ newX: 4, newY: 5 });
+  });
+
+  it("flees away from target when fleeing=true", () => {
+    const result = stepToward(3, 3, 5, 3, true);
+    expect(result).toEqual({ newX: 2, newY: 3 }); // Moves away on X
+  });
+
+  it("handles equal axis differences by preferring X", () => {
+    const result = stepToward(0, 0, 3, 3);
+    expect(result).toEqual({ newX: 1, newY: 0 }); // abs(dx) >= abs(dy) → moves X
+  });
+});
+
+describe("findNearestDwarf", () => {
+  it("finds the closest alive dwarf by Manhattan distance", () => {
+    const monster = { current_tile_x: 10, current_tile_y: 10 };
+    const dwarves = [
+      { position_x: 15, position_y: 10, status: "alive" as const },
+      { position_x: 11, position_y: 10, status: "alive" as const },
+    ];
+
+    const nearest = findNearestDwarf(monster, dwarves);
+    expect(nearest?.position_x).toBe(11);
+  });
+
+  it("ignores dead dwarves", () => {
+    const monster = { current_tile_x: 10, current_tile_y: 10 };
+    const dwarves = [
+      { position_x: 11, position_y: 10, status: "dead" as const },
+      { position_x: 20, position_y: 10, status: "alive" as const },
+    ];
+
+    const nearest = findNearestDwarf(monster, dwarves);
+    expect(nearest?.position_x).toBe(20);
+  });
+
+  it("returns null if no alive dwarves", () => {
+    const monster = { current_tile_x: 10, current_tile_y: 10 };
+    const dwarves = [
+      { position_x: 11, position_y: 10, status: "dead" as const },
+    ];
+
+    expect(findNearestDwarf(monster, dwarves)).toBeNull();
+  });
+
+  it("returns null if monster has null position", () => {
+    const monster = { current_tile_x: null, current_tile_y: null };
+    const dwarves = [
+      { position_x: 11, position_y: 10, status: "alive" as const },
+    ];
+
+    expect(findNearestDwarf(monster, dwarves)).toBeNull();
+  });
+});
+
+describe("monsterPathfinding", () => {
+  it("moves aggressive monster toward nearest dwarf", async () => {
+    const dwarf = makeDwarf({ position_x: 10, position_y: 10 });
+    const monster = makeMonster({
+      current_tile_x: 20,
+      current_tile_y: 10,
+      behavior: "aggressive",
+    });
+
+    const ctx = makeContext({ dwarves: [dwarf] });
+    ctx.state.monsters.push(monster);
+
+    await monsterPathfinding(ctx);
+
+    // Should have moved one step toward dwarf (dx=10, dy=0 → moves X)
+    expect(monster.current_tile_x).toBe(19);
+    expect(monster.current_tile_y).toBe(10);
+  });
+
+  it("does not move neutral monsters", async () => {
+    const dwarf = makeDwarf({ position_x: 10, position_y: 10 });
+    const monster = makeMonster({
+      current_tile_x: 20,
+      current_tile_y: 10,
+      behavior: "neutral",
+    });
+
+    const ctx = makeContext({ dwarves: [dwarf] });
+    ctx.state.monsters.push(monster);
+
+    await monsterPathfinding(ctx);
+
+    expect(monster.current_tile_x).toBe(20);
+    expect(monster.current_tile_y).toBe(10);
+  });
+
+  it("does not move hibernating monsters", async () => {
+    const dwarf = makeDwarf({ position_x: 10, position_y: 10 });
+    const monster = makeMonster({
+      current_tile_x: 20,
+      current_tile_y: 10,
+      behavior: "hibernating",
+    });
+
+    const ctx = makeContext({ dwarves: [dwarf] });
+    ctx.state.monsters.push(monster);
+
+    await monsterPathfinding(ctx);
+
+    expect(monster.current_tile_x).toBe(20);
+  });
+
+  it("fleeing monster moves away from nearest dwarf", async () => {
+    const dwarf = makeDwarf({ position_x: 10, position_y: 10 });
+    const monster = makeMonster({
+      current_tile_x: 15,
+      current_tile_y: 10,
+      behavior: "fleeing",
+    });
+
+    const ctx = makeContext({ dwarves: [dwarf] });
+    ctx.state.monsters.push(monster);
+
+    await monsterPathfinding(ctx);
+
+    // Should move AWAY from dwarf
+    expect(monster.current_tile_x).toBe(16);
+    expect(monster.current_tile_y).toBe(10);
+  });
+
+  it("skips non-active monsters", async () => {
+    const dwarf = makeDwarf({ position_x: 10, position_y: 10 });
+    const monster = makeMonster({
+      current_tile_x: 20,
+      current_tile_y: 10,
+      status: "slain",
+    });
+
+    const ctx = makeContext({ dwarves: [dwarf] });
+    ctx.state.monsters.push(monster);
+
+    await monsterPathfinding(ctx);
+
+    expect(monster.current_tile_x).toBe(20);
+  });
+
+  it("does nothing when no alive dwarves exist", async () => {
+    const dwarf = makeDwarf({ status: "dead", position_x: 10, position_y: 10 });
+    const monster = makeMonster({
+      current_tile_x: 20,
+      current_tile_y: 10,
+    });
+
+    const ctx = makeContext({ dwarves: [dwarf] });
+    ctx.state.monsters.push(monster);
+
+    await monsterPathfinding(ctx);
+
+    expect(monster.current_tile_x).toBe(20);
+  });
+
+  it("moves toward the closest of multiple dwarves", async () => {
+    const farDwarf = makeDwarf({ position_x: 0, position_y: 0 });
+    const nearDwarf = makeDwarf({ position_x: 18, position_y: 10 });
+    const monster = makeMonster({
+      current_tile_x: 20,
+      current_tile_y: 10,
+    });
+
+    const ctx = makeContext({ dwarves: [farDwarf, nearDwarf] });
+    ctx.state.monsters.push(monster);
+
+    await monsterPathfinding(ctx);
+
+    // Should move toward nearDwarf (dx=2) not farDwarf (dx=20)
+    expect(monster.current_tile_x).toBe(19);
+  });
+
+  it("skips monsters with null position", async () => {
+    const dwarf = makeDwarf({ position_x: 10, position_y: 10 });
+    const monster = makeMonster({
+      current_tile_x: null,
+      current_tile_y: null,
+    });
+
+    const ctx = makeContext({ dwarves: [dwarf] });
+    ctx.state.monsters.push(monster);
+
+    await monsterPathfinding(ctx);
+
+    expect(monster.current_tile_x).toBeNull();
+  });
+});

--- a/sim/src/phases/monster-spawning.test.ts
+++ b/sim/src/phases/monster-spawning.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import {
+  MONSTER_SPAWN_INTERVAL,
+  MONSTER_MAX_ACTIVE,
+  MONSTER_NIGHT_CREATURE_HEALTH,
+  MONSTER_NIGHT_CREATURE_THREAT,
+} from "@pwarf/shared";
+import { makeDwarf, makeMonster, makeContext } from "../__tests__/test-helpers.js";
+import { monsterSpawning, generateMonsterName } from "./monster-spawning.js";
+
+describe("generateMonsterName", () => {
+  it("returns a capitalized two-syllable name", () => {
+    const rng = { int: (min: number, max: number) => min };
+    const name = generateMonsterName(rng);
+    expect(name.length).toBeGreaterThan(2);
+    expect(name[0]).toBe(name[0].toUpperCase());
+  });
+
+  it("produces different names with different RNG values", () => {
+    const rng1 = { int: () => 0 };
+    const rng2 = { int: () => 3 };
+    expect(generateMonsterName(rng1)).not.toBe(generateMonsterName(rng2));
+  });
+});
+
+describe("monsterSpawning", () => {
+  it("does not spawn on non-interval ticks", async () => {
+    const dwarf = makeDwarf();
+    const ctx = makeContext({ dwarves: [dwarf] });
+    ctx.step = 1; // Not a multiple of MONSTER_SPAWN_INTERVAL
+
+    await monsterSpawning(ctx);
+
+    expect(ctx.state.monsters.length).toBe(0);
+  });
+
+  it("spawns a monster on interval ticks when dwarves are alive", async () => {
+    const dwarf = makeDwarf({ position_x: 50, position_y: 50 });
+    const ctx = makeContext({ dwarves: [dwarf] });
+    ctx.step = MONSTER_SPAWN_INTERVAL;
+
+    await monsterSpawning(ctx);
+
+    expect(ctx.state.monsters.length).toBe(1);
+    const monster = ctx.state.monsters[0];
+    expect(monster.type).toBe("night_creature");
+    expect(monster.status).toBe("active");
+    expect(monster.health).toBe(MONSTER_NIGHT_CREATURE_HEALTH);
+    expect(monster.threat_level).toBe(MONSTER_NIGHT_CREATURE_THREAT);
+  });
+
+  it("does not spawn when no dwarves are alive", async () => {
+    const dwarf = makeDwarf({ status: "dead" });
+    const ctx = makeContext({ dwarves: [dwarf] });
+    ctx.step = MONSTER_SPAWN_INTERVAL;
+
+    await monsterSpawning(ctx);
+
+    expect(ctx.state.monsters.length).toBe(0);
+  });
+
+  it("does not spawn when at max active monster count", async () => {
+    const dwarf = makeDwarf();
+    const ctx = makeContext({ dwarves: [dwarf] });
+    ctx.step = MONSTER_SPAWN_INTERVAL;
+
+    // Fill up to max
+    for (let i = 0; i < MONSTER_MAX_ACTIVE; i++) {
+      ctx.state.monsters.push(makeMonster());
+    }
+
+    const countBefore = ctx.state.monsters.length;
+    await monsterSpawning(ctx);
+
+    expect(ctx.state.monsters.length).toBe(countBefore);
+  });
+
+  it("spawns near the centroid of alive dwarves", async () => {
+    const d1 = makeDwarf({ position_x: 40, position_y: 40 });
+    const d2 = makeDwarf({ position_x: 60, position_y: 60 });
+    const ctx = makeContext({ dwarves: [d1, d2] });
+    ctx.step = MONSTER_SPAWN_INTERVAL;
+
+    await monsterSpawning(ctx);
+
+    const monster = ctx.state.monsters[0];
+    // Centroid is (50, 50), spawn radius is 20
+    // Monster should be within radius of centroid
+    const dx = Math.abs(monster.current_tile_x! - 50);
+    const dy = Math.abs(monster.current_tile_y! - 50);
+    expect(dx).toBeLessThanOrEqual(21); // Rounding tolerance
+    expect(dy).toBeLessThanOrEqual(21);
+  });
+
+  it("emits a monster_sighting event on spawn", async () => {
+    const dwarf = makeDwarf();
+    const ctx = makeContext({ dwarves: [dwarf] });
+    ctx.step = MONSTER_SPAWN_INTERVAL;
+
+    await monsterSpawning(ctx);
+
+    expect(ctx.state.pendingEvents.length).toBe(1);
+    expect(ctx.state.pendingEvents[0].category).toBe("monster_sighting");
+    expect(ctx.state.pendingEvents[0].monster_id).toBe(ctx.state.monsters[0].id);
+  });
+
+  it("ignores dead monsters when counting active monsters", async () => {
+    const dwarf = makeDwarf();
+    const ctx = makeContext({ dwarves: [dwarf] });
+    ctx.step = MONSTER_SPAWN_INTERVAL;
+
+    // Add a dead monster — should not count toward the cap
+    ctx.state.monsters.push(makeMonster({ status: "slain" }));
+
+    await monsterSpawning(ctx);
+
+    // Should still spawn (dead monster doesn't count)
+    const activeCount = ctx.state.monsters.filter(m => m.status === "active").length;
+    expect(activeCount).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- 27 unit tests across two new test files covering monster-spawning.ts and monster-pathfinding.ts:
  - **Spawning**: interval gating, alive dwarf requirement, max active cap, centroid-based position, event emission, dead monster exclusion
  - **Pathfinding**: stepToward (all directions, fleeing, equal axes), findNearestDwarf (closest, dead filter, null position), behavior filtering (aggressive/neutral/hibernating/fleeing), non-active skip
- Adds `makeMonster()` helper to `test-helpers.ts`

## Test plan
- [x] `npm test --workspace=sim` — 702 tests pass (54 files)
- [x] No code changes beyond test files and test helper

## Claude Cost
<!-- Will be filled by /review-pr -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Claude Cost
**Claude cost:** $12.58 (19.4M tokens)