### PR TITLE
test: scenario — skill levels up through repeated work (closes #476)

### DIFF
--- a/sim/src/__tests__/skill-scenario.test.ts
+++ b/sim/src/__tests__/skill-scenario.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from "vitest";
+import { runScenario } from "../run-scenario.js";
+import { makeDwarf, makeTask, makeSkill, makeItem, makeMapTile } from "./test-helpers.js";
+import { WORK_MINE_BASE, WORK_BUILD_FLOOR, XP_MINE, XP_BUILD } from "@pwarf/shared";
+
+describe("skill level-up scenario (issue #476)", () => {
+  it("dwarf mining skill levels up after completing mine tasks end-to-end", async () => {
+    // Start with 85 XP (level 0). After 1 mine completion (+15 XP = 100) → level 1.
+    // This tests the full flow: job claiming → pathfinding → task execution → completion → XP award → level-up event.
+    const dwarf = makeDwarf({
+      position_x: 0,
+      position_y: 5,
+      position_z: 0,
+      need_food: 100,
+      need_drink: 100,
+      need_sleep: 100,
+    });
+
+    const miningSkill = makeSkill(dwarf.id, "mining", 0, 85);
+
+    // Single mine task — dwarf starts adjacent to target
+    const task = makeTask("mine", {
+      target_x: 1,
+      target_y: 5,
+      target_z: 0,
+      work_required: WORK_MINE_BASE,
+      status: "pending",
+    });
+
+    const tile = makeMapTile(1, 5, 0, "stone");
+
+    // Food/drink nearby for survival
+    const foodItems = [];
+    for (let i = 0; i < 5; i++) {
+      foodItems.push(makeItem({ category: "food", name: "Plump helmet", position_x: 0, position_y: 4, position_z: 0 }));
+      foodItems.push(makeItem({ category: "drink", name: "Dwarven ale", position_x: 0, position_y: 4, position_z: 0 }));
+    }
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      dwarfSkills: [miningSkill],
+      tasks: [task],
+      items: foodItems,
+      fortressTileOverrides: [tile],
+      ticks: WORK_MINE_BASE + 50, // Enough for claiming + execution + completion
+    });
+
+    const completedTask = result.tasks.find(t => t.task_type === "mine" && t.status === "completed");
+    expect(completedTask).toBeDefined();
+
+    const levelUpEvents = result.events.filter(
+      e => e.category === "discovery"
+        && e.event_data
+        && (e.event_data as Record<string, unknown>).skill_name === "mining",
+    );
+
+    expect(levelUpEvents.length).toBe(1);
+    const data = levelUpEvents[0].event_data as Record<string, unknown>;
+    expect(data.new_level).toBe(1);
+    expect(data.tier).toBe("Novice");
+  });
+
+  it("dwarf building skill levels up from repeated build tasks", async () => {
+    // Start with 88 XP. After 1 build completion (+12 XP = 100) → level 1.
+    const dwarf = makeDwarf({
+      position_x: 0,
+      position_y: 0,
+      position_z: 0,
+      need_food: 100,
+      need_drink: 100,
+      need_sleep: 100,
+    });
+
+    const buildingSkill = makeSkill(dwarf.id, "building", 0, 88);
+
+    const task = makeTask("build_floor", {
+      target_x: 0,
+      target_y: 0,
+      target_z: 0,
+      work_required: WORK_BUILD_FLOOR,
+      status: "pending",
+    });
+
+    const foodItems = [];
+    for (let i = 0; i < 5; i++) {
+      foodItems.push(makeItem({ category: "food", name: "Plump helmet", position_x: 0, position_y: 1, position_z: 0 }));
+      foodItems.push(makeItem({ category: "drink", name: "Dwarven ale", position_x: 0, position_y: 1, position_z: 0 }));
+    }
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      dwarfSkills: [buildingSkill],
+      tasks: [task],
+      items: foodItems,
+      ticks: WORK_BUILD_FLOOR + 50,
+    });
+
+    const completedTask = result.tasks.find(t => t.task_type === "build_floor" && t.status === "completed");
+    expect(completedTask).toBeDefined();
+
+    const levelUpEvents = result.events.filter(
+      e => e.category === "discovery"
+        && e.event_data
+        && (e.event_data as Record<string, unknown>).skill_name === "building",
+    );
+    expect(levelUpEvents.length).toBe(1);
+    const data = levelUpEvents[0].event_data as Record<string, unknown>;
+    expect(data.new_level).toBe(1);
+    expect(data.tier).toBe("Novice");
+  });
+
+  it("XP accumulates without level-up when below threshold", async () => {
+    // 0 XP + 3 mine completions = 45 XP — not enough for level 1 (needs 100)
+    const dwarf = makeDwarf({
+      position_x: 0,
+      position_y: 5,
+      position_z: 0,
+      need_food: 100,
+      need_drink: 100,
+      need_sleep: 100,
+    });
+
+    const miningSkill = makeSkill(dwarf.id, "mining", 0, 0);
+
+    const tasks = [];
+    const tiles = [];
+    for (let i = 0; i < 3; i++) {
+      const task = makeTask("mine", {
+        target_x: 1,
+        target_y: 5 + i,
+        target_z: 0,
+        work_required: WORK_MINE_BASE,
+        status: "pending",
+      });
+      tasks.push(task);
+      tiles.push(makeMapTile(1, 5 + i, 0, "stone"));
+    }
+
+    // Pre-claim first task
+    tasks[0].status = "claimed";
+    tasks[0].assigned_dwarf_id = dwarf.id;
+    dwarf.current_task_id = tasks[0].id;
+
+    const foodItems = [];
+    for (let i = 0; i < 10; i++) {
+      foodItems.push(makeItem({ category: "food", name: "Plump helmet", position_x: 0, position_y: 4, position_z: 0 }));
+      foodItems.push(makeItem({ category: "drink", name: "Dwarven ale", position_x: 0, position_y: 4, position_z: 0 }));
+    }
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      dwarfSkills: [miningSkill],
+      tasks,
+      items: foodItems,
+      fortressTileOverrides: tiles,
+      ticks: 1500,
+    });
+
+    const completedMineTasks = result.tasks.filter(
+      t => t.task_type === "mine" && t.status === "completed",
+    );
+    expect(completedMineTasks.length).toBe(3);
+
+    // No level-up event (45 XP < 100 threshold)
+    const levelUpEvents = result.events.filter(
+      e => e.category === "discovery"
+        && e.event_data
+        && (e.event_data as Record<string, unknown>).skill_name === "mining",
+    );
+    expect(levelUpEvents.length).toBe(0);
+  });
+});

--- a/sim/src/run-scenario.ts
+++ b/sim/src/run-scenario.ts
@@ -136,7 +136,11 @@ export async function runScenario(config: ScenarioConfig): Promise<ScenarioResul
       await yearlyRollup(ctx);
     }
 
-    // Collect events fired this tick (eventFiring clears pendingEvents)
+    // Flush pendingEvents → worldEvents (mirrors what flush-state does for the DB)
+    if (state.pendingEvents.length > 0) {
+      state.worldEvents.push(...state.pendingEvents);
+      state.pendingEvents = [];
+    }
     allEvents.push(...state.worldEvents.slice(allEvents.length));
   }
 


### PR DESCRIPTION
## Summary
- 3 end-to-end scenario tests using `runScenario()`:
  - Mining skill levels up (85 XP → 100 XP → level 1 "Novice") after completing a mine task
  - Building skill levels up (88 XP → 100 XP → level 1 "Novice") after completing a build task
  - XP accumulates without level-up when below threshold (3 mine completions = 45 XP < 100)
- **Bug fix in `run-scenario.ts`**: `pendingEvents` were never flushed to `worldEvents` during scenario runs, so events created during task completion (skill level-ups, monster sightings, etc.) were invisible in scenario results. Now flushes each tick, matching `flush-state.ts` behavior.

## Test plan
- [x] `npm test --workspace=sim` — 705 tests pass (55 files)
- [x] Existing scenario tests still pass (run-scenario fix is backwards-compatible)

## Claude Cost
<!-- Will be filled by /review-pr -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Claude Cost
**Claude cost:** $21.76 (36.0M tokens)