### PR TITLE
fix: day counter uses STEPS_PER_DAY instead of incrementing 1:1 with ticks (closes #534)

### DIFF
--- a/sim/src/headless-runner.ts
+++ b/sim/src/headless-runner.ts
@@ -1,5 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { STEPS_PER_YEAR } from "@pwarf/shared";
+import { STEPS_PER_YEAR, STEPS_PER_DAY } from "@pwarf/shared";
 import type { SimContext } from "./sim-context.js";
 import { createEmptyCachedState } from "./sim-context.js";
 import { createRng } from "./rng.js";
@@ -98,11 +98,10 @@ export async function runHeadless(opts: HeadlessRunOptions): Promise<HeadlessRun
   let tasksCompleted = 0;
   let stepCount = 0;
   let currentYear = 1;
-  let currentDay = 1;
 
   for (let i = 0; i < ticks; i++) {
     stepCount++;
-    currentDay++;
+    const currentDay = Math.floor((stepCount % STEPS_PER_YEAR) / STEPS_PER_DAY) + 1;
     ctx.step = stepCount;
     ctx.day = currentDay;
     ctx.year = currentYear;
@@ -129,9 +128,8 @@ export async function runHeadless(opts: HeadlessRunOptions): Promise<HeadlessRun
 
     if (stepCount % STEPS_PER_YEAR === 0) {
       currentYear++;
-      currentDay = 1;
       ctx.year = currentYear;
-      ctx.day = currentDay;
+      ctx.day = 1;
       await yearlyRollup(ctx);
     }
 

--- a/sim/src/run-scenario.ts
+++ b/sim/src/run-scenario.ts
@@ -1,5 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { STEPS_PER_YEAR } from "@pwarf/shared";
+import { STEPS_PER_YEAR, STEPS_PER_DAY } from "@pwarf/shared";
 import type { Dwarf, DwarfSkill, FortressTile, Item, Structure, Monster, Task, WorldEvent } from "@pwarf/shared";
 import type { SimContext, CachedState } from "./sim-context.js";
 import { createEmptyCachedState, createRng } from "./sim-context.js";
@@ -108,11 +108,10 @@ export async function runScenario(config: ScenarioConfig): Promise<ScenarioResul
   const allEvents: WorldEvent[] = [];
   let stepCount = 0;
   let currentYear = 1;
-  let currentDay = 1;
 
   for (let i = 0; i < config.ticks; i++) {
     stepCount++;
-    currentDay++;
+    const currentDay = Math.floor((stepCount % STEPS_PER_YEAR) / STEPS_PER_DAY) + 1;
     ctx.step = stepCount;
     ctx.day = currentDay;
     ctx.year = currentYear;
@@ -137,9 +136,8 @@ export async function runScenario(config: ScenarioConfig): Promise<ScenarioResul
 
     if (stepCount % STEPS_PER_YEAR === 0) {
       currentYear++;
-      currentDay = 1;
       ctx.year = currentYear;
-      ctx.day = currentDay;
+      ctx.day = 1;
       await yearlyRollup(ctx);
     }
 

--- a/sim/src/sim-runner.ts
+++ b/sim/src/sim-runner.ts
@@ -1,4 +1,4 @@
-import { STEPS_PER_SECOND, STEPS_PER_YEAR, SIM_FLUSH_INTERVAL_MS, createFortressDeriver } from "@pwarf/shared";
+import { STEPS_PER_SECOND, STEPS_PER_YEAR, STEPS_PER_DAY, SIM_FLUSH_INTERVAL_MS, createFortressDeriver } from "@pwarf/shared";
 import type { Dwarf, Item, Task, WorldEvent, FortressTile, Monster } from "@pwarf/shared";
 import type { SimContext } from "./sim-context.js";
 import { createEmptyCachedState } from "./sim-context.js";
@@ -207,7 +207,7 @@ export class SimRunner {
     if (!this.ctx) return;
 
     this.stepCount++;
-    this.currentDay++;
+    this.currentDay = Math.floor((this.stepCount % STEPS_PER_YEAR) / STEPS_PER_DAY) + 1;
     this.ctx.step = this.stepCount;
     this.ctx.day = this.currentDay;
     this.ctx.year = this.currentYear;

--- a/sim/src/step-mode.ts
+++ b/sim/src/step-mode.ts
@@ -1,5 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { STEPS_PER_YEAR } from "@pwarf/shared";
+import { STEPS_PER_YEAR, STEPS_PER_DAY } from "@pwarf/shared";
 import type { TaskType } from "@pwarf/shared";
 import type { SimContext } from "./sim-context.js";
 import { createEmptyCachedState } from "./sim-context.js";
@@ -104,7 +104,7 @@ function makeTaskId(): string {
 async function runOneTick(session: StepSession): Promise<void> {
   const { ctx } = session;
   session.step++;
-  session.day++;
+  session.day = Math.floor((session.step % STEPS_PER_YEAR) / STEPS_PER_DAY) + 1;
   ctx.step = session.step;
   ctx.day = session.day;
   ctx.year = session.year;
@@ -133,7 +133,7 @@ async function runOneTick(session: StepSession): Promise<void> {
     session.year++;
     session.day = 1;
     ctx.year = session.year;
-    ctx.day = session.day;
+    ctx.day = 1;
     await yearlyRollup(ctx);
   }
 


### PR DESCRIPTION
## Summary
- Day counter was incrementing every tick (day 5001 at tick 5000)
- Now computes from `STEPS_PER_DAY = 49`: tick 5000 → day 103
- Fixed in all 4 tick loops: run-scenario, step-mode, headless-runner, sim-runner

## Test plan
- [x] All 722 sim tests pass
- [x] Build passes
- [x] Verified via playtest: tick 49→day 2, tick 98→day 3, tick 5000→day 103
- [x] No UI changes

## Claude Cost
**Claude cost:** $8.80 (13.4M tokens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)