### PR TITLE
feat: add inspect command, task/tile state output, fix scenario dwarf skills (closes #543)

### DIFF
--- a/sim/src/scenarios.ts
+++ b/sim/src/scenarios.ts
@@ -1,4 +1,4 @@
-import type { Dwarf, Item, Task } from "@pwarf/shared";
+import type { Dwarf, DwarfSkill, Item, Task } from "@pwarf/shared";
 import type { CachedState } from "./sim-context.js";
 import { createEmptyCachedState } from "./sim-context.js";
 import { createRng, type Rng } from "./rng.js";
@@ -160,6 +160,21 @@ function makeDrink(rng: Rng, civId: string, count: number): Item[] {
   return items;
 }
 
+/** Core skills every dwarf needs to function. */
+const BASIC_SKILLS = ['mining', 'building', 'farming', 'engraving', 'brewing', 'cooking'];
+
+/** Create skill records for a dwarf — all basic skills at level 0. */
+function makeSkills(rng: Rng, dwarfId: string): DwarfSkill[] {
+  return BASIC_SKILLS.map(skill => ({
+    id: rng.uuid(),
+    dwarf_id: dwarfId,
+    skill_name: skill,
+    level: 0,
+    xp: 0,
+    last_used_year: null,
+  }));
+}
+
 /** Build initial CachedState from a scenario definition. */
 export function buildScenarioState(scenario: ScenarioDefinition): CachedState {
   const rng = createRng(scenario.seed);
@@ -173,6 +188,11 @@ export function buildScenarioState(scenario: ScenarioDefinition): CachedState {
   state.dwarves = Array.from({ length: scenario.dwarfCount }, (_, i) =>
     makeDwarf(rng, civId, i, needFood, needDrink)
   );
+
+  // Give every dwarf basic skills so they can claim player-designated tasks
+  for (const dwarf of state.dwarves) {
+    state.dwarfSkills.push(...makeSkills(rng, dwarf.id));
+  }
 
   state.items = [
     ...makeFood(rng, civId, scenario.initialFood),

--- a/sim/src/state-serializer.ts
+++ b/sim/src/state-serializer.ts
@@ -39,9 +39,26 @@ export interface Summary {
   events_count: number;
 }
 
+export interface TaskSnapshot {
+  id: string;
+  type: string;
+  status: string;
+  target: { x: number | null; y: number | null; z: number | null };
+  progress: string;
+}
+
+export interface TileSnapshot {
+  x: number;
+  y: number;
+  z: number;
+  tile_type: string;
+}
+
 export interface StateSnapshot {
   summary: Summary;
   dwarves: DwarfSnapshot[];
+  tasks: TaskSnapshot[];
+  tiles: TileSnapshot[];
   recent_events: Array<{ tick: number; text: string }>;
 }
 
@@ -137,6 +154,26 @@ export function serializeState(ctx: SimContext, tasksCompleted = 0): StateSnapsh
     is_in_tantrum: d.is_in_tantrum,
   }));
 
+  const AUTONOMOUS_TASKS = new Set(['eat', 'drink', 'sleep']);
+  const taskSnapshots: TaskSnapshot[] = state.tasks
+    .filter(t => !AUTONOMOUS_TASKS.has(t.task_type) && t.status !== 'completed' && t.status !== 'cancelled')
+    .map(t => ({
+      id: t.id,
+      type: t.task_type,
+      status: t.status,
+      target: { x: t.target_x, y: t.target_y, z: t.target_z },
+      progress: t.work_required > 0
+        ? `${Math.round((t.work_progress / t.work_required) * 100)}%`
+        : "n/a",
+    }));
+
+  const tileSnapshots: TileSnapshot[] = [...state.fortressTileOverrides.values()].map(t => ({
+    x: t.x,
+    y: t.y,
+    z: t.z,
+    tile_type: t.tile_type,
+  }));
+
   return {
     summary: {
       tick: step,
@@ -149,6 +186,8 @@ export function serializeState(ctx: SimContext, tasksCompleted = 0): StateSnapsh
       events_count: state.worldEvents.length,
     },
     dwarves: dwarfSnapshots,
+    tasks: taskSnapshots,
+    tiles: tileSnapshots,
     recent_events: recentEvents,
   };
 }

--- a/sim/src/step-mode.ts
+++ b/sim/src/step-mode.ts
@@ -58,12 +58,18 @@ export interface ScenarioCommand {
   name: string;
 }
 
+export interface InspectCommand {
+  command: "inspect";
+  z: number;
+}
+
 export type StepCommand =
   | TickCommand
   | StateCommand
   | DesignateCommand
   | CancelCommand
-  | ScenarioCommand;
+  | ScenarioCommand
+  | InspectCommand;
 
 // ---------------------------------------------------------------------------
 // Response types
@@ -79,7 +85,13 @@ export interface ErrorResponse {
   error: string;
 }
 
-export type CommandResponse = OkResponse | ErrorResponse | ReturnType<typeof serializeState>;
+export interface InspectResponse {
+  z: number;
+  tiles: Array<{ x: number; y: number; tile_type: string }>;
+  tasks: Array<{ id: string; type: string; status: string; x: number; y: number }>;
+}
+
+export type CommandResponse = OkResponse | ErrorResponse | InspectResponse | ReturnType<typeof serializeState>;
 
 // ---------------------------------------------------------------------------
 // Session state
@@ -223,6 +235,18 @@ export async function dispatchCommand(
       session.ctx.year = 1;
       session.ctx.day = 1;
       return { ok: true };
+    }
+
+    case "inspect": {
+      const z = cmd.z;
+      const tiles = [...session.ctx.state.fortressTileOverrides.values()]
+        .filter(t => t.z === z)
+        .map(t => ({ x: t.x, y: t.y, tile_type: t.tile_type }));
+      const AUTONOMOUS = new Set(['eat', 'drink', 'sleep']);
+      const tasks = session.ctx.state.tasks
+        .filter(t => t.target_z === z && !AUTONOMOUS.has(t.task_type) && t.status !== 'completed' && t.status !== 'cancelled')
+        .map(t => ({ id: t.id, type: t.task_type, status: t.status, x: t.target_x!, y: t.target_y! }));
+      return { z, tiles, tasks };
     }
 
     default: {


### PR DESCRIPTION
## Summary
- **State serializer** now includes `tasks` (active non-autonomous) and `tiles` (fortress overrides) in output
- **New `inspect` command** in step mode returns tiles/tasks filtered by z-level
- **Scenario dwarves get basic skills** (mining, building, farming, engraving, brewing, cooking) — without these, dwarves couldn't claim any player-designated tasks, which was the root cause of "designations have no effect"

## Headless playtest verification

Used the new inspect command to verify #526 and #527:

```
# Build wall → claimed → completed → tile exists
designate build_wall at (101,100,z=0)
tick 50:  inspect z=0 → build_wall(in_progress)
tick 250: inspect z=0 → constructed_wall tile ✅

# Deconstruct → claimed → completed → tile gone
designate deconstruct at (101,100,z=0)
tick 500: inspect z=0 → open_air tile ✅

# Z-level isolation
inspect z=-1 → 0 tasks, 0 tiles ✅ (no bleed from z=0)
```

## Test plan
- [x] All 721 sim tests pass
- [x] Build passes
- [x] Headless playtest confirms build/deconstruct/z-level work correctly
- [x] All 4 scenarios still survive with rebalanced constants

## Claude Cost
**Claude cost:** $8.93 (13.7M tokens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)