### PR TITLE
fix: scenario dwarves get skills/traits + missing phases in pipelines

### DIFF
--- a/sim/src/headless-runner.ts
+++ b/sim/src/headless-runner.ts
@@ -22,6 +22,10 @@ import {
   haulAssignment,
   beautyRestoration,
   haunting,
+  autoCookPhase,
+  autoBrew,
+  autoForage,
+  taskRecovery,
 } from "./phases/index.js";
 import { SCENARIOS, buildScenarioState, buildEatDrinkTasks } from "./scenarios.js";
 import { serializeState } from "./state-serializer.js";
@@ -120,6 +124,10 @@ export async function runHeadless(opts: HeadlessRunOptions): Promise<HeadlessRun
     await constructionProgress(ctx);
     await idleWandering(ctx);
     await haulAssignment(ctx);
+    taskRecovery(ctx);
+    await autoCookPhase(ctx);
+    await autoBrew(ctx);
+    await autoForage(ctx);
     await jobClaiming(ctx);
     await eventFiring(ctx);
     await thoughtGeneration(ctx);

--- a/sim/src/run-scenario.ts
+++ b/sim/src/run-scenario.ts
@@ -22,7 +22,11 @@ import {
   haulAssignment,
   beautyRestoration,
   haunting,
+  autoCookPhase,
+  autoBrew,
   autoForage,
+  taskRecovery,
+  monsterSpawning,
 } from "./phases/index.js";
 
 /** Input configuration for a scenario run. */
@@ -122,17 +126,21 @@ export async function runScenario(config: ScenarioConfig): Promise<ScenarioResul
     await stressUpdate(ctx);
     await tantrumCheck(ctx);
     await tantrumActions(ctx);
+    await monsterSpawning(ctx);
     await monsterPathfinding(ctx);
     await combatResolution(ctx);
     await constructionProgress(ctx);
     await idleWandering(ctx);
     await haulAssignment(ctx);
+    taskRecovery(ctx);
+    await autoCookPhase(ctx);
+    await autoBrew(ctx);
+    await autoForage(ctx);
     await jobClaiming(ctx);
     await eventFiring(ctx);
     await thoughtGeneration(ctx);
     await beautyRestoration(ctx);
     await haunting(ctx);
-    await autoForage(ctx);
 
     if (stepCount % STEPS_PER_YEAR === 0) {
       currentYear++;

--- a/sim/src/scenarios.ts
+++ b/sim/src/scenarios.ts
@@ -3,6 +3,9 @@ import type { CachedState } from "./sim-context.js";
 import { createEmptyCachedState } from "./sim-context.js";
 import { createRng, type Rng } from "./rng.js";
 
+/** All skill names that dwarves can have. */
+const ALL_SKILLS = ['mining', 'farming', 'building', 'engraving', 'brewing', 'cooking', 'smithing'] as const;
+
 export interface ScenarioDefinition {
   name: string;
   description: string;
@@ -84,11 +87,11 @@ function makeDwarf(rng: Rng, civId: string, index: number, needFood: number, nee
     health: 100,
     injuries: [],
     memories: [],
-    trait_openness: null,
-    trait_conscientiousness: null,
-    trait_extraversion: null,
-    trait_agreeableness: null,
-    trait_neuroticism: null,
+    trait_openness: 0.1 + rng.random() * 0.8,
+    trait_conscientiousness: 0.1 + rng.random() * 0.8,
+    trait_extraversion: 0.1 + rng.random() * 0.8,
+    trait_agreeableness: 0.1 + rng.random() * 0.8,
+    trait_neuroticism: 0.1 + rng.random() * 0.8,
     religious_devotion: 0,
     faction_id: null,
     born_year: null,
@@ -160,16 +163,17 @@ function makeDrink(rng: Rng, civId: string, count: number): Item[] {
   return items;
 }
 
-/** Core skills every dwarf needs to function. */
-const BASIC_SKILLS = ['mining', 'building', 'farming', 'engraving', 'brewing', 'cooking'];
-
-/** Create skill records for a dwarf — all basic skills at level 0. */
+/**
+ * Generate skill records for a dwarf. Each dwarf gets all skills at level 0
+ * so they can claim any task. A few random skills get a small level boost
+ * to create specialization and differentiate dwarves.
+ */
 function makeSkills(rng: Rng, dwarfId: string): DwarfSkill[] {
-  return BASIC_SKILLS.map(skill => ({
+  return ALL_SKILLS.map(skillName => ({
     id: rng.uuid(),
     dwarf_id: dwarfId,
-    skill_name: skill,
-    level: 0,
+    skill_name: skillName,
+    level: rng.random() < 0.3 ? rng.int(1, 3) : 0,
     xp: 0,
     last_used_year: null,
   }));
@@ -189,7 +193,7 @@ export function buildScenarioState(scenario: ScenarioDefinition): CachedState {
     makeDwarf(rng, civId, i, needFood, needDrink)
   );
 
-  // Give every dwarf basic skills so they can claim player-designated tasks
+  // Give every dwarf all skills so they can claim any task type
   for (const dwarf of state.dwarves) {
     state.dwarfSkills.push(...makeSkills(rng, dwarf.id));
   }

--- a/sim/src/step-mode.ts
+++ b/sim/src/step-mode.ts
@@ -23,6 +23,10 @@ import {
   haulAssignment,
   beautyRestoration,
   haunting,
+  autoCookPhase,
+  autoBrew,
+  autoForage,
+  taskRecovery,
 } from "./phases/index.js";
 import { SCENARIOS, buildScenarioState, buildEatDrinkTasks } from "./scenarios.js";
 import { serializeState } from "./state-serializer.js";
@@ -135,6 +139,10 @@ async function runOneTick(session: StepSession): Promise<void> {
   await constructionProgress(ctx);
   await idleWandering(ctx);
   await haulAssignment(ctx);
+  taskRecovery(ctx);
+  await autoCookPhase(ctx);
+  await autoBrew(ctx);
+  await autoForage(ctx);
   await jobClaiming(ctx);
   await eventFiring(ctx);
   await thoughtGeneration(ctx);


### PR DESCRIPTION
## Summary

- **Scenario dwarves now get all 7 skill records** (mining, farming, building, engraving, brewing, cooking, smithing) so they can claim skilled tasks like mine, build, farm, brew, cook. ~30% of skills get a random level 1-3 boost for specialization.
- **Scenario dwarves now get randomized personality traits** (0.1-0.9) instead of null, enabling the conscientiousness/neuroticism modifiers.
- **Added missing phases to headless-runner, step-mode, and run-scenario pipelines:** `autoCook`, `autoBrew`, `autoForage`, `taskRecovery`
- **Added `monsterSpawning` to run-scenario pipeline** (was already in headless-runner and step-mode)

Closes #538, closes #539, closes #545, closes #547

## Test plan

- [x] `npm test` — all 1578 tests pass
- [x] Typecheck passes (only pre-existing tantrum-spiral error)
- [x] Quick headless playtest confirms skills are assigned

## Claude Cost

**Claude cost:** $29.71 (44.6M tokens)

<!-- filled by /review-pr -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)