### PR TITLE
fix: forageable tiles in scenarios + clear tantrum on death

### DIFF
--- a/sim/src/__tests__/deprivation.test.ts
+++ b/sim/src/__tests__/deprivation.test.ts
@@ -89,6 +89,15 @@ describe("killDwarf", () => {
     expect(dwarf.current_task_id).toBeNull();
   });
 
+  it("clears tantrum state on death", () => {
+    const dwarf = makeDwarf({ is_in_tantrum: true });
+    const ctx = makeContext({ dwarves: [dwarf] });
+
+    killDwarf(dwarf, "starvation", ctx);
+
+    expect(dwarf.is_in_tantrum).toBe(false);
+  });
+
   it("fires fortress_fallen event when last dwarf dies", () => {
     const dwarf = makeDwarf();
     const ctx = makeContext({ dwarves: [dwarf] });

--- a/sim/src/phases/deprivation.ts
+++ b/sim/src/phases/deprivation.ts
@@ -45,6 +45,7 @@ export function killDwarf(dwarf: Dwarf, cause: string, ctx: SimContext): void {
   dwarf.status = 'dead';
   dwarf.died_year = ctx.year;
   dwarf.cause_of_death = cause;
+  dwarf.is_in_tantrum = false;
   state.dirtyDwarfIds.add(dwarf.id);
   state.warnedNeedIds.delete(dwarf.id);
 

--- a/sim/src/scenarios.ts
+++ b/sim/src/scenarios.ts
@@ -1,4 +1,4 @@
-import type { Dwarf, DwarfSkill, Item, Task } from "@pwarf/shared";
+import type { Dwarf, DwarfSkill, FortressTile, Item, Task } from "@pwarf/shared";
 import type { CachedState } from "./sim-context.js";
 import { createEmptyCachedState } from "./sim-context.js";
 import { createRng, type Rng } from "./rng.js";
@@ -202,6 +202,16 @@ export function buildScenarioState(scenario: ScenarioDefinition): CachedState {
     ...makeFood(rng, civId, scenario.initialFood),
     ...makeDrink(rng, civId, scenario.initialDrink),
   ];
+
+  // Add forageable surface tiles so autoForage can trigger when food runs low
+  const forageableTiles: FortressTile[] = [
+    { id: rng.uuid(), civilization_id: civId, x: 90, y: 100, z: 0, tile_type: 'grass', material: null, is_revealed: true, is_mined: false, created_at: new Date().toISOString() },
+    { id: rng.uuid(), civilization_id: civId, x: 91, y: 100, z: 0, tile_type: 'bush', material: null, is_revealed: true, is_mined: false, created_at: new Date().toISOString() },
+    { id: rng.uuid(), civilization_id: civId, x: 92, y: 100, z: 0, tile_type: 'tree', material: null, is_revealed: true, is_mined: false, created_at: new Date().toISOString() },
+  ];
+  for (const tile of forageableTiles) {
+    state.fortressTileOverrides.set(`${tile.x},${tile.y},${tile.z}`, tile);
+  }
 
   return state;
 }


### PR DESCRIPTION
## Summary

- **Scenarios now include forageable tiles** (grass, bush, tree) near dwarf starting positions so `autoForage` can trigger when food runs low, rather than silently failing because no forageable tiles exist in overrides
- **`killDwarf()` clears `is_in_tantrum`** so dead dwarves don't retain tantrum state

Closes #540, closes #546

## Test plan

- [x] `npm test` — 722 tests pass
- [x] New test: "clears tantrum state on death" in deprivation.test.ts

## Claude Cost

**Claude cost:** $35.40 (55.4M tokens)

<!-- filled by /review-pr -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)