### PR TITLE
fix: dead dwarves from previous sessions no longer auto-register as ghosts

### DIFF
--- a/sim/src/__tests__/ghost-haunting.test.ts
+++ b/sim/src/__tests__/ghost-haunting.test.ts
@@ -22,6 +22,7 @@ describe("ghost haunting scenario (issue #478)", () => {
 
     const result = await runScenario({
       dwarves: [deadDwarf, livingDwarf],
+      ghostDwarfIds: [deadDwarf.id], // pre-register ghost
       ticks: 20,
     });
 
@@ -62,7 +63,8 @@ describe("ghost haunting scenario (issue #478)", () => {
       dwarves: [deadDwarf, engraver],
       dwarfSkills: [engravingSkill],
       tasks: [memorialTask],
-      ticks: WORK_ENGRAVE_MEMORIAL + 100, // Enough for claiming + movement + completion
+      ghostDwarfIds: [deadDwarf.id], // pre-register ghost
+      ticks: WORK_ENGRAVE_MEMORIAL + 100,
     });
 
     // Task should be completed
@@ -97,6 +99,7 @@ describe("ghost haunting scenario (issue #478)", () => {
 
     const result = await runScenario({
       dwarves: [deadDwarf, livingDwarf],
+      ghostDwarfIds: [deadDwarf.id],
       ticks: 20,
     });
 
@@ -123,6 +126,7 @@ describe("ghost haunting scenario (issue #478)", () => {
 
     const result = await runScenario({
       dwarves: [deadDwarf, livingDwarf],
+      ghostDwarfIds: [deadDwarf.id],
       ticks: 20,
     });
 

--- a/sim/src/phases/haunting.test.ts
+++ b/sim/src/phases/haunting.test.ts
@@ -10,10 +10,10 @@ describe("haunting - ghost registration", () => {
     expect(ctx.state.ghostDwarfIds.has('d1')).toBe(false);
   });
 
-  it("adds newly dead dwarves to ghostDwarfIds", () => {
+  it("does NOT auto-register dead dwarves as ghosts (registration happens in killDwarf)", () => {
     const ctx = makeContext({ dwarves: [makeDwarf({ id: 'd1', status: 'dead' })] });
     haunting(ctx);
-    expect(ctx.state.ghostDwarfIds.has('d1')).toBe(true);
+    expect(ctx.state.ghostDwarfIds.has('d1')).toBe(false);
   });
 
   it("does not double-register an already-tracked ghost", () => {

--- a/sim/src/phases/haunting.ts
+++ b/sim/src/phases/haunting.ts
@@ -22,13 +22,8 @@ import { dwarfName } from "../dwarf-utils.js";
 export function haunting(ctx: SimContext): void {
   const { state } = ctx;
 
-  // Register newly dead dwarves as ghosts
-  for (const dwarf of state.dwarves) {
-    if (dwarf.status === 'dead' && !state.ghostDwarfIds.has(dwarf.id)) {
-      state.ghostDwarfIds.add(dwarf.id);
-    }
-  }
-
+  // Ghost registration happens in killDwarf() — not here.
+  // Dead dwarves from previous sessions are NOT ghosts.
   if (state.ghostDwarfIds.size === 0) return;
 
   const aliveDwarves = state.dwarves.filter(d => d.status === 'alive');

--- a/sim/src/run-scenario.ts
+++ b/sim/src/run-scenario.ts
@@ -42,6 +42,8 @@ export interface ScenarioConfig {
   fortressTileOverrides?: FortressTile[];
   /** Pre-infected dwarf IDs — seeds the disease system without relying on the outbreak roll. */
   infectedDwarfIds?: string[];
+  /** Pre-registered ghost dwarf IDs — these dead dwarves haunt living dwarves from tick 0. */
+  ghostDwarfIds?: string[];
   ticks: number;
   seed?: number;
 }
@@ -90,6 +92,11 @@ export async function runScenario(config: ScenarioConfig): Promise<ScenarioResul
   if (config.infectedDwarfIds) {
     for (const id of config.infectedDwarfIds) {
       state.infectedDwarfIds.add(id);
+    }
+  }
+  if (config.ghostDwarfIds) {
+    for (const id of config.ghostDwarfIds) {
+      state.ghostDwarfIds.add(id);
     }
   }
 


### PR DESCRIPTION
## Summary

Found the root cause of dwarves tantrumming within ~1 minute: the haunting phase was registering **all dead dwarves** (including those from previous sessions) as ghosts every tick. Each ghost applies `GHOST_STRESS_PER_TICK = 0.5` stress to nearby living dwarves. With even 1 ghost from a prior session, dwarves hit the tantrum threshold (80) in just 160 ticks (16 seconds).

**Fix:** Removed the auto-registration loop from the haunting phase. Ghost registration now only happens in `killDwarf()` when a dwarf actually dies during the current sim session.

Also added `ghostDwarfIds` to `ScenarioConfig` so ghost-related tests can pre-register ghosts explicitly.

Closes #562

## Test plan

- [x] `npm test --workspace=sim` — 736 tests pass
- [x] Ghost haunting tests updated to use `ghostDwarfIds` config
- [x] Haunting test verifies dead dwarves are NOT auto-registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)