### PR TITLE
fix: dwarves cannot occupy the same tile as each other

### DIFF
--- a/sim/src/__tests__/dwarf-collision.test.ts
+++ b/sim/src/__tests__/dwarf-collision.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { runScenario } from "../run-scenario.js";
+import { makeDwarf, makeTask, makeSkill } from "./test-helpers.js";
+import { WORK_MINE_BASE } from "@pwarf/shared";
+import type { FortressTile } from "@pwarf/shared";
+
+function makeMinableTile(x: number, y: number, z: number): FortressTile {
+  return {
+    id: `tile-${x}-${y}-${z}`,
+    civilization_id: "civ-1",
+    x, y, z,
+    tile_type: "stone",
+    material: "granite",
+    is_revealed: true,
+    is_mined: false,
+    created_at: new Date().toISOString(),
+  };
+}
+
+describe("dwarf collision", () => {
+  it("two dwarves heading to the same area don't stack on one tile", async () => {
+    // Two dwarves start at different positions and move toward nearby mine tasks
+    const dwarf1 = makeDwarf({ position_x: 5, position_y: 5, position_z: 0 });
+    const dwarf2 = makeDwarf({ position_x: 5, position_y: 6, position_z: 0 });
+    const skill1 = makeSkill(dwarf1.id, "mining", 1);
+    const skill2 = makeSkill(dwarf2.id, "mining", 1);
+
+    // Both tasks target the same tile — dwarves stand adjacent for mine tasks
+    const tile = makeMinableTile(8, 5, 0);
+    const task1 = makeTask("mine", {
+      status: "pending",
+      target_x: 8, target_y: 5, target_z: 0,
+      work_required: WORK_MINE_BASE,
+    });
+    const task2 = makeTask("mine", {
+      status: "pending",
+      target_x: 8, target_y: 5, target_z: 0,
+      work_required: WORK_MINE_BASE,
+    });
+
+    const result = await runScenario({
+      dwarves: [dwarf1, dwarf2],
+      dwarfSkills: [skill1, skill2],
+      tasks: [task1, task2],
+      fortressTileOverrides: [tile],
+      ticks: 10, // enough to move a few steps
+    });
+
+    // The two dwarves should NOT be on the same tile
+    const pos1 = `${result.dwarves[0]!.position_x},${result.dwarves[0]!.position_y}`;
+    const pos2 = `${result.dwarves[1]!.position_x},${result.dwarves[1]!.position_y}`;
+    expect(pos1).not.toBe(pos2);
+  });
+
+  it("dwarves on the same starting tile spread out when given tasks", async () => {
+    // Start 3 dwarves on the exact same tile
+    const dwarves = [
+      makeDwarf({ position_x: 10, position_y: 10, position_z: 0 }),
+      makeDwarf({ position_x: 10, position_y: 10, position_z: 0 }),
+      makeDwarf({ position_x: 10, position_y: 10, position_z: 0 }),
+    ];
+    const skills = dwarves.map(d => makeSkill(d.id, "mining", 1));
+
+    // Tasks at different locations
+    const tiles = [
+      makeMinableTile(15, 10, 0),
+      makeMinableTile(10, 15, 0),
+      makeMinableTile(5, 10, 0),
+    ];
+    const tasks = tiles.map(t => makeTask("mine", {
+      status: "pending",
+      target_x: t.x, target_y: t.y, target_z: t.z,
+      work_required: WORK_MINE_BASE,
+    }));
+
+    const result = await runScenario({
+      dwarves,
+      dwarfSkills: skills,
+      tasks,
+      fortressTileOverrides: tiles,
+      ticks: 5, // a few steps to spread out
+    });
+
+    // After a few ticks, not all 3 should still be on the same tile
+    const positions = result.dwarves.map(d => `${d.position_x},${d.position_y}`);
+    const uniquePositions = new Set(positions);
+    expect(uniquePositions.size).toBeGreaterThan(1);
+  });
+});

--- a/sim/src/phases/task-execution.ts
+++ b/sim/src/phases/task-execution.ts
@@ -35,6 +35,14 @@ export async function taskExecution(ctx: SimContext): Promise<void> {
 
   handleDeprivationDeaths(ctx);
 
+  // Build a set of occupied tiles so dwarves don't stack on each other
+  const occupiedTiles = new Set<string>();
+  for (const d of state.dwarves) {
+    if (d.status === 'alive') {
+      occupiedTiles.add(`${d.position_x},${d.position_y},${d.position_z}`);
+    }
+  }
+
   for (const dwarf of state.dwarves) {
     if (dwarf.status !== 'alive') continue;
     if (dwarf.current_task_id === null) continue;
@@ -60,7 +68,7 @@ export async function taskExecution(ctx: SimContext): Promise<void> {
         : (dwarf.position_x === task.target_x && dwarf.position_y === task.target_y && dwarf.position_z === task.target_z);
 
       if (!atSite) {
-        const moved = moveTowardTarget(dwarf, task, ctx);
+        const moved = moveTowardTarget(dwarf, task, ctx, occupiedTiles);
         if (!moved) {
           failTask(dwarf, task, state);
         }
@@ -111,7 +119,7 @@ function isAdjacentToTarget(dwarf: Dwarf, task: Task): boolean {
   return (dx + dy) === 1;
 }
 
-function moveTowardTarget(dwarf: Dwarf, task: Task, ctx: SimContext): boolean {
+function moveTowardTarget(dwarf: Dwarf, task: Task, ctx: SimContext, occupiedTiles: Set<string>): boolean {
   if (task.target_x === null || task.target_y === null || task.target_z === null) return true;
 
   // Already at the task site — no movement needed
@@ -133,6 +141,17 @@ function moveTowardTarget(dwarf: Dwarf, task: Task, ctx: SimContext): boolean {
   if (nextStep === null) {
     return false; // No path found
   }
+
+  // Don't move onto a tile occupied by another dwarf — wait instead
+  const nextKey = `${nextStep.x},${nextStep.y},${nextStep.z}`;
+  if (occupiedTiles.has(nextKey)) {
+    return true; // Path exists but tile is blocked — wait, don't fail the task
+  }
+
+  // Update occupancy tracking
+  const prevKey = `${dwarf.position_x},${dwarf.position_y},${dwarf.position_z}`;
+  occupiedTiles.delete(prevKey);
+  occupiedTiles.add(nextKey);
 
   dwarf.position_x = nextStep.x;
   dwarf.position_y = nextStep.y;


### PR DESCRIPTION
## Summary

Dwarves can no longer stack on the same tile. When a dwarf's BFS pathfinding returns a next step that's already occupied by another alive dwarf, the dwarf waits for the tile to clear instead of moving onto it.

Implementation:
- Built an `occupiedTiles` set at the start of each `taskExecution` tick
- Before moving, check if the target tile is occupied — if so, skip the move (don't fail the task)
- Update the set when a dwarf moves (remove old position, add new)

Closes #576

## Test plan

- [x] New test: two dwarves heading to same area don't stack
- [x] New test: dwarves starting on same tile spread out when given tasks
- [x] All 26 task-execution + collision tests pass
- [x] No new test failures (29 pre-existing failures from stale shared dist unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)