### PR TITLE
fix: allow building on mud and sand tiles (closes #583)

### DIFF
--- a/app/src/hooks/useDesignation.ts
+++ b/app/src/hooks/useDesignation.ts
@@ -123,7 +123,7 @@ export function useDesignation(opts: {
     }
 
     const mineable: string[] = ['stone', 'ore', 'gem', 'soil', 'cavern_wall', 'tree', 'rock', 'bush'];
-    const buildable: string[] = ['open_air', 'grass', 'constructed_floor', 'cavern_floor'];
+    const buildable: string[] = ['open_air', 'grass', 'mud', 'sand', 'constructed_floor', 'cavern_floor'];
     const isMine = designationMode === 'mine';
     const isDeconstruct = designationMode === 'deconstruct';
     const isSmooth = designationMode === 'smooth';


### PR DESCRIPTION
## Summary
- Adds `mud` and `sand` to the `buildable` tile list in `useDesignation.ts`
- Without this, swamp and desert biomes are completely unbuildable

One-line change: `['open_air', 'grass', 'constructed_floor', 'cavern_floor']` → `['open_air', 'grass', 'mud', 'sand', 'constructed_floor', 'cavern_floor']`

## Test plan
- [x] `npm run build` passes
- [ ] Playtest: designate a build on a mud tile in a swamp fortress

🤖 Generated with [Claude Code](https://claude.com/claude-code)