### PR TITLE
feat: ambient background soundtrack using Tone.js

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -14,7 +14,8 @@
     "@supabase/supabase-js": "^2.49.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "simplex-noise": "^4.0.3"
+    "simplex-noise": "^4.0.3",
+    "tone": "^15.1.22"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.3",

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -25,6 +25,7 @@ import { InventoryModal } from "./components/InventoryModal";
 import { EpitaphScreen } from "./components/EpitaphScreen";
 import { TutorialOverlay } from "./components/TutorialOverlay";
 import { useTutorial } from "./hooks/useTutorial";
+import { useSoundtrack } from "./hooks/useSoundtrack";
 import { SURFACE_Z, CAVE_Z, BUILDING_COSTS } from "@pwarf/shared";
 import type { Item } from "@pwarf/shared";
 import type { LiveDwarf } from "./hooks/useDwarves";
@@ -368,6 +369,10 @@ export default function App() {
 
   const tutorial = useTutorial();
 
+  // Ambient soundtrack — starts when fortress is active, pauses with game
+  const gameActive = world.mode === "fortress" && !!world.civId;
+  const { muted: soundMuted, toggleMute } = useSoundtrack(gameActive, isPaused);
+
   // Follow mode — camera tracks a selected dwarf every tick
   const [followedDwarfId, setFollowedDwarfId] = useState<string | null>(null);
 
@@ -501,6 +506,8 @@ export default function App() {
         dwarves={liveDwarves}
         onTutorial={tutorial.start}
         onInventory={world.civId ? () => setInventoryOpen(true) : undefined}
+        soundMuted={soundMuted}
+        onToggleMute={toggleMute}
       />
 
       {tutorial.active && (

--- a/app/src/components/Toolbar.tsx
+++ b/app/src/components/Toolbar.tsx
@@ -20,9 +20,11 @@ interface ToolbarProps {
   dwarves?: LiveDwarf[];
   onTutorial?: () => void;
   onInventory?: () => void;
+  soundMuted?: boolean;
+  onToggleMute?: () => void;
 }
 
-export default function Toolbar({ mode, onSignOut, onRestart, onTogglePause, isPaused = false, speed = 1, onSetSpeed, population = 0, year = 1, civName, items = [], wealth = 0, dwarves = [], onTutorial, onInventory }: ToolbarProps) {
+export default function Toolbar({ mode, onSignOut, onRestart, onTogglePause, isPaused = false, speed = 1, onSetSpeed, population = 0, year = 1, civName, items = [], wealth = 0, dwarves = [], onTutorial, onInventory, soundMuted = false, onToggleMute }: ToolbarProps) {
   const alert = mode === "fortress" ? deriveAlert(dwarves) : null;
 
   return (
@@ -86,6 +88,15 @@ export default function Toolbar({ mode, onSignOut, onRestart, onTogglePause, isP
               </button>
             ))}
           </div>
+        )}
+        {onToggleMute && (
+          <button
+            onClick={onToggleMute}
+            className="px-2 py-0.5 border border-[var(--border)] text-[var(--text)] hover:text-[var(--amber)] hover:border-[var(--amber)] cursor-pointer"
+            title={soundMuted ? "Unmute soundtrack" : "Mute soundtrack"}
+          >
+            {soundMuted ? "Muted" : "Sound"}
+          </button>
         )}
         {onRestart && (
           <button

--- a/app/src/hooks/useSoundtrack.ts
+++ b/app/src/hooks/useSoundtrack.ts
@@ -1,0 +1,93 @@
+import { useEffect, useRef, useState, useCallback } from "react";
+import * as Tone from "tone";
+import {
+  startSoundtrack,
+  stopSoundtrack,
+  pauseSoundtrack,
+  resumeSoundtrack,
+  setSoundtrackMuted,
+  disposeSoundtrack,
+} from "../sounds/soundtrack.js";
+
+const MUTE_KEY = "pwarf-soundtrack-muted";
+
+/**
+ * Manages the ambient soundtrack lifecycle.
+ *
+ * - Unlocks AudioContext on first user interaction (browser autoplay policy)
+ * - Starts the soundtrack when the game is running
+ * - Pauses/resumes in sync with the game
+ * - Persists mute preference in localStorage
+ */
+export function useSoundtrack(gameActive: boolean, isPaused: boolean) {
+  const [muted, setMuted] = useState(() => {
+    try {
+      return localStorage.getItem(MUTE_KEY) === "true";
+    } catch {
+      return false;
+    }
+  });
+
+  const audioUnlocked = useRef(false);
+  const soundtrackStarted = useRef(false);
+
+  // Unlock AudioContext on first user interaction
+  useEffect(() => {
+    const unlock = () => {
+      if (!audioUnlocked.current) {
+        Tone.start().then(() => {
+          audioUnlocked.current = true;
+        });
+      }
+    };
+    window.addEventListener("click", unlock, { once: false });
+    window.addEventListener("keydown", unlock, { once: false });
+    return () => {
+      window.removeEventListener("click", unlock);
+      window.removeEventListener("keydown", unlock);
+    };
+  }, []);
+
+  // Start/stop soundtrack based on game active state
+  useEffect(() => {
+    if (gameActive && audioUnlocked.current && !muted) {
+      startSoundtrack();
+      soundtrackStarted.current = true;
+    }
+    return () => {
+      if (soundtrackStarted.current) {
+        stopSoundtrack();
+        soundtrackStarted.current = false;
+      }
+    };
+  }, [gameActive, muted]);
+
+  // Pause/resume in sync with game
+  useEffect(() => {
+    if (!soundtrackStarted.current || muted) return;
+    if (isPaused) {
+      pauseSoundtrack();
+    } else {
+      resumeSoundtrack();
+    }
+  }, [isPaused, muted]);
+
+  // Mute/unmute
+  useEffect(() => {
+    setSoundtrackMuted(muted);
+    try {
+      localStorage.setItem(MUTE_KEY, String(muted));
+    } catch {
+      // localStorage unavailable
+    }
+  }, [muted]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => disposeSoundtrack();
+  }, []);
+
+  const toggleMute = useCallback(() => setMuted((m) => !m), []);
+
+  return { muted, toggleMute };
+}

--- a/app/src/sounds/soundtrack.test.ts
+++ b/app/src/sounds/soundtrack.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock Tone.js before importing soundtrack
+vi.mock("tone", () => {
+  function MockGain() {
+    return {
+      gain: { rampTo: vi.fn() },
+      toDestination: vi.fn().mockReturnThis(),
+      dispose: vi.fn(),
+      connect: vi.fn().mockReturnThis(),
+    };
+  }
+  function MockPolySynth() {
+    return {
+      triggerAttack: vi.fn(),
+      releaseAll: vi.fn(),
+      dispose: vi.fn(),
+      connect: vi.fn().mockReturnThis(),
+    };
+  }
+  function MockSynth() {
+    return {
+      triggerAttackRelease: vi.fn(),
+      dispose: vi.fn(),
+      connect: vi.fn().mockReturnThis(),
+    };
+  }
+  function MockLoop() {
+    return {
+      start: vi.fn(),
+      stop: vi.fn(),
+      dispose: vi.fn(),
+    };
+  }
+  const mockTransport = {
+    state: "stopped",
+    start: vi.fn(),
+    stop: vi.fn(),
+    pause: vi.fn(),
+  };
+  return {
+    Gain: vi.fn(MockGain),
+    PolySynth: vi.fn(MockPolySynth),
+    Synth: vi.fn(MockSynth),
+    Loop: vi.fn(MockLoop),
+    getTransport: vi.fn(() => mockTransport),
+    dbToGain: vi.fn((db: number) => Math.pow(10, db / 20)),
+    start: vi.fn(() => Promise.resolve()),
+  };
+});
+
+describe("soundtrack", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("startSoundtrack initializes and starts transport", async () => {
+    const Tone = await import("tone");
+    const { startSoundtrack } = await import("./soundtrack.js");
+
+    startSoundtrack();
+
+    expect(Tone.PolySynth).toHaveBeenCalled();
+    expect(Tone.Synth).toHaveBeenCalled();
+    expect(Tone.Loop).toHaveBeenCalled();
+    expect(Tone.getTransport().start).toHaveBeenCalled();
+  });
+
+  it("stopSoundtrack stops transport", async () => {
+    const Tone = await import("tone");
+    const { startSoundtrack, stopSoundtrack } = await import("./soundtrack.js");
+
+    startSoundtrack();
+    stopSoundtrack();
+
+    expect(Tone.getTransport().stop).toHaveBeenCalled();
+  });
+
+  it("pauseSoundtrack pauses transport", async () => {
+    const Tone = await import("tone");
+    const { startSoundtrack, pauseSoundtrack } = await import("./soundtrack.js");
+
+    startSoundtrack();
+    pauseSoundtrack();
+
+    expect(Tone.getTransport().pause).toHaveBeenCalled();
+  });
+
+  it("setSoundtrackMuted ramps gain to 0 when muted", async () => {
+    const Tone = await import("tone");
+    const { startSoundtrack, setSoundtrackMuted } = await import("./soundtrack.js");
+
+    startSoundtrack();
+    setSoundtrackMuted(true);
+
+    const gainInstance = (Tone.Gain as unknown as ReturnType<typeof vi.fn>).mock.results[0].value;
+    expect(gainInstance.gain.rampTo).toHaveBeenCalledWith(0, 0.3);
+  });
+
+  it("disposeSoundtrack cleans up all resources", async () => {
+    const Tone = await import("tone");
+    const { startSoundtrack, disposeSoundtrack } = await import("./soundtrack.js");
+
+    startSoundtrack();
+    disposeSoundtrack();
+
+    const synthInstance = (Tone.Synth as unknown as ReturnType<typeof vi.fn>).mock.results[0].value;
+    expect(synthInstance.dispose).toHaveBeenCalled();
+  });
+
+  it("calling startSoundtrack twice does not re-initialize", async () => {
+    const Tone = await import("tone");
+    const { startSoundtrack } = await import("./soundtrack.js");
+
+    startSoundtrack();
+    // Simulate transport already running
+    (Tone.getTransport() as unknown as Record<string, string>).state = "started";
+    startSoundtrack();
+
+    // PolySynth should only be constructed once
+    expect(Tone.PolySynth).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/src/sounds/soundtrack.ts
+++ b/app/src/sounds/soundtrack.ts
@@ -1,0 +1,98 @@
+import * as Tone from "tone";
+
+/**
+ * Procedural ambient soundtrack using Tone.js.
+ *
+ * Generates a looping generative ambient track with:
+ * - A low drone pad (two detuned oscillators)
+ * - A slow pentatonic arpeggio that picks random notes
+ *
+ * All sounds are synthesized — no audio files needed.
+ */
+
+const PENTATONIC_NOTES = [
+  "C3", "D3", "E3", "G3", "A3",
+  "C4", "D4", "E4", "G4", "A4",
+] as const;
+
+/** Volume levels (dB) */
+const DRONE_VOLUME = -22;
+const ARPEGGIO_VOLUME = -18;
+const MASTER_VOLUME = -6;
+
+let initialized = false;
+let drone: Tone.PolySynth | null = null;
+let arpSynth: Tone.Synth | null = null;
+let arpLoop: Tone.Loop | null = null;
+let masterGain: Tone.Gain | null = null;
+
+function ensureInit(): void {
+  if (initialized) return;
+  initialized = true;
+
+  masterGain = new Tone.Gain(Tone.dbToGain(MASTER_VOLUME)).toDestination();
+
+  // --- Drone pad: two slightly detuned notes held indefinitely ---
+  drone = new Tone.PolySynth(Tone.Synth, {
+    oscillator: { type: "sine" },
+    envelope: { attack: 4, decay: 0, sustain: 1, release: 4 },
+    volume: DRONE_VOLUME,
+  }).connect(masterGain);
+
+  // --- Arpeggio: gentle pluck picking pentatonic notes ---
+  arpSynth = new Tone.Synth({
+    oscillator: { type: "triangle" },
+    envelope: { attack: 0.05, decay: 1.5, sustain: 0, release: 0.8 },
+    volume: ARPEGGIO_VOLUME,
+  }).connect(masterGain);
+
+  arpLoop = new Tone.Loop((time) => {
+    const note = PENTATONIC_NOTES[Math.floor(Math.random() * PENTATONIC_NOTES.length)];
+    arpSynth!.triggerAttackRelease(note, "4n", time);
+  }, "2n");
+}
+
+export function startSoundtrack(): void {
+  ensureInit();
+  if (Tone.getTransport().state === "started") return;
+
+  drone!.triggerAttack(["C2", "G2"]);
+  arpLoop!.start(0);
+  Tone.getTransport().start();
+}
+
+export function stopSoundtrack(): void {
+  if (!initialized) return;
+  Tone.getTransport().stop();
+  arpLoop?.stop();
+  drone?.releaseAll();
+}
+
+export function pauseSoundtrack(): void {
+  if (!initialized) return;
+  Tone.getTransport().pause();
+}
+
+export function resumeSoundtrack(): void {
+  if (!initialized || Tone.getTransport().state === "started") return;
+  Tone.getTransport().start();
+}
+
+export function setSoundtrackMuted(muted: boolean): void {
+  if (!masterGain) return;
+  masterGain.gain.rampTo(muted ? 0 : Tone.dbToGain(MASTER_VOLUME), 0.3);
+}
+
+export function disposeSoundtrack(): void {
+  if (!initialized) return;
+  stopSoundtrack();
+  arpLoop?.dispose();
+  arpSynth?.dispose();
+  drone?.dispose();
+  masterGain?.dispose();
+  arpLoop = null;
+  arpSynth = null;
+  drone = null;
+  masterGain = null;
+  initialized = false;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
         "@supabase/supabase-js": "^2.49.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "simplex-noise": "^4.0.3"
+        "simplex-noise": "^4.0.3",
+        "tone": "^15.1.22"
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.1.3",
@@ -346,10 +347,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "dev": true,
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2197,6 +2197,19 @@
         "node": ">=12"
       }
     },
+    "node_modules/automation-events": {
+      "version": "7.1.16",
+      "resolved": "https://registry.npmjs.org/automation-events/-/automation-events-7.1.16.tgz",
+      "integrity": "sha512-vAAHG8WO+Cx2PfwmWIAxSD51ZYg+zRam52pzOGVAJOqsqQO6oaPM2k4/cdEF7QQ786FYB8Wzbw//qTWCdyGvzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.2.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.8",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.8.tgz",
@@ -3379,6 +3392,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardized-audio-context": {
+      "version": "25.3.77",
+      "resolved": "https://registry.npmjs.org/standardized-audio-context/-/standardized-audio-context-25.3.77.tgz",
+      "integrity": "sha512-Ki9zNz6pKcC5Pi+QPjPyVsD9GwJIJWgryji0XL9cAJXMGyn+dPOf6Qik1AHei0+UNVcc4BOCa0hWLBzlwqsW/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.6",
+        "automation-events": "^7.0.9",
+        "tslib": "^2.7.0"
+      }
+    },
     "node_modules/std-env": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
@@ -3530,6 +3554,16 @@
       "integrity": "sha512-5WJ2SqFsv4G2Dwi7ZFVRnz6b2H1od39QME1lc2y5Ew3eWiZMAeqOAfWpRP9jHvhUl881406QtZTODvjttJs+ew==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tone": {
+      "version": "15.1.22",
+      "resolved": "https://registry.npmjs.org/tone/-/tone-15.1.22.tgz",
+      "integrity": "sha512-TCScAGD4sLsama5DjvTUXlLDXSqPealhL64nsdV1hhr6frPWve0DeSo63AKnSJwgfg55fhvxj0iPPRwPN5o0ag==",
+      "license": "MIT",
+      "dependencies": {
+        "standardized-audio-context": "^25.3.70",
+        "tslib": "^2.3.1"
+      }
     },
     "node_modules/tough-cookie": {
       "version": "6.0.1",


### PR DESCRIPTION
## Summary

- Add procedural ambient soundtrack via Tone.js — low drone pad + pentatonic arpeggio, no audio files needed
- Mute/unmute toggle in toolbar with localStorage persistence
- Soundtrack pauses/resumes in sync with game state

Closes #586

## Files changed

- `app/src/sounds/soundtrack.ts` — Tone.js synthesizer setup, start/stop/pause/mute controls
- `app/src/sounds/soundtrack.test.ts` — 6 unit tests for soundtrack lifecycle
- `app/src/hooks/useSoundtrack.ts` — React hook managing AudioContext unlock, game sync, mute state
- `app/src/components/Toolbar.tsx` — Added Sound/Muted toggle button
- `app/src/App.tsx` — Integrated `useSoundtrack` hook

## Test plan

- [x] `npm test --workspace=app` passes (128 tests, including 6 new soundtrack tests)
- [x] `npm run build --workspace=app` passes
- [ ] Manual playtest: soundtrack plays on fortress mode entry, pauses when game paused, mute toggle works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Claude Cost
**Claude cost:** $8.58 (12.3M tokens)