### PR TITLE
fix: dwarves now pick up ground items and haul them to stockpiles

### DIFF
--- a/sim/src/__tests__/building-and-hauling-scenario.test.ts
+++ b/sim/src/__tests__/building-and-hauling-scenario.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect } from "vitest";
+import { runScenario } from "../run-scenario.js";
+import { makeDwarf, makeTask, makeSkill, makeItem } from "./test-helpers.js";
+import {
+  WORK_BUILD_WALL,
+  WORK_BUILD_FLOOR,
+  WORK_BUILD_BED,
+  WORK_BUILD_WELL,
+  WORK_BUILD_MUSHROOM_GARDEN,
+} from "@pwarf/shared";
+import type { FortressTile, StockpileTile } from "@pwarf/shared";
+
+function stoneBlock() {
+  return makeItem({ name: "Stone block", category: "raw_material", material: "stone", located_in_civ_id: "test-civ", held_by_dwarf_id: null });
+}
+function woodLog() {
+  return makeItem({ name: "Wood log", category: "raw_material", material: "wood", located_in_civ_id: "test-civ", held_by_dwarf_id: null });
+}
+
+function grassTile(x: number, y: number, z: number): FortressTile {
+  return {
+    id: `grass-${x}-${y}-${z}`,
+    civilization_id: "civ-1",
+    x, y, z,
+    tile_type: "grass",
+    material: null,
+    is_revealed: true,
+    is_mined: false,
+    created_at: new Date().toISOString(),
+  };
+}
+
+function makeStockpileTile(x: number, y: number, z: number): StockpileTile {
+  return {
+    id: `stockpile-${x}-${y}-${z}`,
+    civilization_id: "test-civ",
+    x, y, z,
+    accepts_categories: null,
+    priority: 0,
+    created_at: new Date().toISOString(),
+  };
+}
+
+describe("building scenarios", () => {
+  it("dwarf completes build_wall task", async () => {
+    const dwarf = makeDwarf({ position_x: 9, position_y: 10, position_z: 0 });
+    const buildSkill = makeSkill(dwarf.id, "building", 1);
+    const task = makeTask("build_wall", {
+      status: "pending",
+      target_x: 10, target_y: 10, target_z: 0,
+      work_required: WORK_BUILD_WALL,
+    });
+
+    const tiles = [grassTile(9, 10, 0), grassTile(10, 10, 0)];
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      dwarfSkills: [buildSkill],
+      tasks: [task],
+      items: [stoneBlock()],
+      fortressTileOverrides: tiles,
+      ticks: 200,
+    });
+
+    expect(result.tasks.find(t => t.id === task.id)?.status).toBe("completed");
+    const wallTile = result.fortressTileOverrides.find(t => t.x === 10 && t.y === 10 && t.z === 0);
+    expect(wallTile?.tile_type).toBe("constructed_wall");
+  });
+
+  it("dwarf completes build_floor task", async () => {
+    const dwarf = makeDwarf({ position_x: 9, position_y: 10, position_z: 0 });
+    const buildSkill = makeSkill(dwarf.id, "building", 1);
+    const task = makeTask("build_floor", {
+      status: "pending",
+      target_x: 10, target_y: 10, target_z: 0,
+      work_required: WORK_BUILD_FLOOR,
+    });
+
+    const tiles = [grassTile(9, 10, 0), grassTile(10, 10, 0)];
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      dwarfSkills: [buildSkill],
+      tasks: [task],
+      items: [stoneBlock()],
+      fortressTileOverrides: tiles,
+      ticks: 200,
+    });
+
+    expect(result.tasks.find(t => t.id === task.id)?.status).toBe("completed");
+    const floorTile = result.fortressTileOverrides.find(t => t.x === 10 && t.y === 10 && t.z === 0);
+    expect(floorTile?.tile_type).toBe("constructed_floor");
+  });
+
+  it("dwarf completes build_bed task", async () => {
+    const dwarf = makeDwarf({ position_x: 9, position_y: 10, position_z: 0 });
+    const buildSkill = makeSkill(dwarf.id, "building", 1);
+    const task = makeTask("build_bed", {
+      status: "pending",
+      target_x: 10, target_y: 10, target_z: 0,
+      work_required: WORK_BUILD_BED,
+    });
+
+    const tiles = [grassTile(9, 10, 0), grassTile(10, 10, 0)];
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      dwarfSkills: [buildSkill],
+      tasks: [task],
+      items: [woodLog()],
+      fortressTileOverrides: tiles,
+      ticks: 200,
+    });
+
+    expect(result.tasks.find(t => t.id === task.id)?.status).toBe("completed");
+    const bed = result.structures.find(s => s.type === "bed");
+    expect(bed).toBeDefined();
+    expect(bed?.completion_pct).toBe(100);
+  });
+
+  it("dwarf completes build_well task", async () => {
+    const dwarf = makeDwarf({ position_x: 9, position_y: 10, position_z: 0 });
+    const buildSkill = makeSkill(dwarf.id, "building", 1);
+    const task = makeTask("build_well", {
+      status: "pending",
+      target_x: 10, target_y: 10, target_z: 0,
+      work_required: WORK_BUILD_WELL,
+    });
+
+    const tiles = [grassTile(9, 10, 0), grassTile(10, 10, 0)];
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      dwarfSkills: [buildSkill],
+      tasks: [task],
+      items: [stoneBlock(), stoneBlock()],
+      fortressTileOverrides: tiles,
+      ticks: 200,
+    });
+
+    expect(result.tasks.find(t => t.id === task.id)?.status).toBe("completed");
+    const well = result.structures.find(s => s.type === "well");
+    expect(well).toBeDefined();
+    expect(well?.completion_pct).toBe(100);
+  });
+
+  it("dwarf completes build_mushroom_garden task", async () => {
+    const dwarf = makeDwarf({ position_x: 9, position_y: 10, position_z: 0 });
+    const buildSkill = makeSkill(dwarf.id, "building", 1);
+    const task = makeTask("build_mushroom_garden", {
+      status: "pending",
+      target_x: 10, target_y: 10, target_z: 0,
+      work_required: WORK_BUILD_MUSHROOM_GARDEN,
+    });
+
+    const tiles = [grassTile(9, 10, 0), grassTile(10, 10, 0)];
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      dwarfSkills: [buildSkill],
+      tasks: [task],
+      items: [woodLog()],
+      fortressTileOverrides: tiles,
+      ticks: 200,
+    });
+
+    expect(result.tasks.find(t => t.id === task.id)?.status).toBe("completed");
+    const garden = result.structures.find(s => s.type === "mushroom_garden");
+    expect(garden).toBeDefined();
+    expect(garden?.completion_pct).toBe(100);
+  });
+});
+
+describe("stockpile hauling scenarios", () => {
+  it("idle dwarf picks up ground item and hauls to stockpile", async () => {
+    const dwarf = makeDwarf({ position_x: 5, position_y: 5, position_z: 0 });
+    const groundItem = makeItem({
+      position_x: 7, position_y: 5, position_z: 0,
+      held_by_dwarf_id: null,
+      category: "raw_material",
+      located_in_civ_id: "test-civ",
+    });
+
+    // Grass tiles from x=3..15 for pathfinding
+    const tiles: FortressTile[] = [];
+    for (let x = 3; x <= 15; x++) {
+      tiles.push(grassTile(x, 5, 0));
+    }
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      items: [groundItem],
+      fortressTileOverrides: tiles,
+      stockpileTiles: [makeStockpileTile(12, 5, 0)],
+      ticks: 500,
+    });
+
+    const haulTasks = result.tasks.filter(t => t.task_type === "haul" && t.target_item_id === groundItem.id);
+    expect(haulTasks.length).toBeGreaterThanOrEqual(1);
+    const completed = haulTasks.find(t => t.status === "completed");
+    expect(completed).toBeDefined();
+    expect(completed?.target_x).toBe(12);
+    expect(completed?.target_y).toBe(5);
+  });
+
+  it("does not create duplicate haul tasks", async () => {
+    const dwarf = makeDwarf({ position_x: 5, position_y: 5, position_z: 0 });
+    const groundItem = makeItem({
+      position_x: 7, position_y: 5, position_z: 0,
+      held_by_dwarf_id: null,
+      category: "raw_material",
+      located_in_civ_id: "test-civ",
+    });
+
+    const tiles: FortressTile[] = [];
+    for (let x = 3; x <= 15; x++) {
+      tiles.push(grassTile(x, 5, 0));
+    }
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      items: [groundItem],
+      fortressTileOverrides: tiles,
+      stockpileTiles: [makeStockpileTile(12, 5, 0)],
+      ticks: 50,
+    });
+
+    const activeHaulTasks = result.tasks.filter(
+      t => t.task_type === "haul"
+        && t.target_item_id === groundItem.id
+        && t.status !== "completed" && t.status !== "cancelled" && t.status !== "failed",
+    );
+    expect(activeHaulTasks.length).toBeLessThanOrEqual(1);
+  });
+
+  it("skips items already on a stockpile tile", async () => {
+    const dwarf = makeDwarf({ position_x: 5, position_y: 5, position_z: 0 });
+    const itemOnPile = makeItem({
+      position_x: 12, position_y: 5, position_z: 0,
+      held_by_dwarf_id: null,
+      category: "raw_material",
+      located_in_civ_id: "test-civ",
+    });
+
+    const tiles: FortressTile[] = [];
+    for (let x = 3; x <= 15; x++) {
+      tiles.push(grassTile(x, 5, 0));
+    }
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      items: [itemOnPile],
+      fortressTileOverrides: tiles,
+      stockpileTiles: [makeStockpileTile(12, 5, 0)],
+      ticks: 20,
+    });
+
+    const haulTasks = result.tasks.filter(
+      t => t.task_type === "haul" && t.target_item_id === itemOnPile.id,
+    );
+    expect(haulTasks).toHaveLength(0);
+  });
+});

--- a/sim/src/phases/haul-assignment.test.ts
+++ b/sim/src/phases/haul-assignment.test.ts
@@ -100,6 +100,85 @@ describe("haulAssignment", () => {
     expect(ctx.state.tasks.filter(t => t.task_type === "haul")).toHaveLength(0);
   });
 
+  it("creates haul task for ground item not on a stockpile", async () => {
+    const dwarf = makeDwarf({ position_x: 5, position_y: 5, position_z: 0 });
+    const groundItem = makeItem({
+      position_x: 7, position_y: 7, position_z: 0,
+      held_by_dwarf_id: null,
+      category: "raw_material",
+      located_in_civ_id: "civ-1",
+    });
+    const ctx = makeContext({ dwarves: [dwarf], items: [groundItem] });
+
+    const st = makeStockpileTile(10, 10, 0);
+    ctx.state.stockpileTiles.set("10,10,0", st);
+
+    await haulAssignment(ctx);
+
+    const haulTasks = ctx.state.tasks.filter(t => t.task_type === "haul");
+    expect(haulTasks).toHaveLength(1);
+    expect(haulTasks[0].target_item_id).toBe(groundItem.id);
+    expect(haulTasks[0].target_x).toBe(10);
+  });
+
+  it("skips ground items already on a stockpile tile", async () => {
+    const dwarf = makeDwarf({ position_x: 5, position_y: 5, position_z: 0 });
+    const itemOnPile = makeItem({
+      position_x: 10, position_y: 10, position_z: 0,
+      held_by_dwarf_id: null,
+      category: "raw_material",
+      located_in_civ_id: "civ-1",
+    });
+    const ctx = makeContext({ dwarves: [dwarf], items: [itemOnPile] });
+
+    const st = makeStockpileTile(10, 10, 0);
+    ctx.state.stockpileTiles.set("10,10,0", st);
+
+    await haulAssignment(ctx);
+
+    const haulTasks = ctx.state.tasks.filter(t => t.task_type === "haul");
+    expect(haulTasks).toHaveLength(0);
+  });
+
+  it("does not create duplicate haul tasks for the same ground item", async () => {
+    const dwarf = makeDwarf({ position_x: 5, position_y: 5, position_z: 0 });
+    const groundItem = makeItem({
+      position_x: 7, position_y: 7, position_z: 0,
+      held_by_dwarf_id: null,
+      category: "raw_material",
+      located_in_civ_id: "civ-1",
+    });
+    const ctx = makeContext({ dwarves: [dwarf], items: [groundItem] });
+
+    const st = makeStockpileTile(10, 10, 0);
+    ctx.state.stockpileTiles.set("10,10,0", st);
+
+    await haulAssignment(ctx);
+    await haulAssignment(ctx);
+
+    const haulTasks = ctx.state.tasks.filter(t => t.task_type === "haul");
+    expect(haulTasks).toHaveLength(1);
+  });
+
+  it("skips ground items from other civilizations", async () => {
+    const dwarf = makeDwarf({ position_x: 5, position_y: 5, position_z: 0 });
+    const foreignItem = makeItem({
+      position_x: 7, position_y: 7, position_z: 0,
+      held_by_dwarf_id: null,
+      category: "raw_material",
+      located_in_civ_id: "other-civ",
+    });
+    const ctx = makeContext({ dwarves: [dwarf], items: [foreignItem] });
+
+    const st = makeStockpileTile(10, 10, 0);
+    ctx.state.stockpileTiles.set("10,10,0", st);
+
+    await haulAssignment(ctx);
+
+    const haulTasks = ctx.state.tasks.filter(t => t.task_type === "haul");
+    expect(haulTasks).toHaveLength(0);
+  });
+
   it("picks the nearest stockpile tile", async () => {
     const dwarf = makeDwarf({ position_x: 5, position_y: 5, position_z: 0 });
     const item = makeItem({ held_by_dwarf_id: dwarf.id, weight: 10 });

--- a/sim/src/phases/haul-assignment.ts
+++ b/sim/src/phases/haul-assignment.ts
@@ -9,21 +9,33 @@ import { manhattanDistance } from "../pathfinding.js";
 /**
  * Haul Assignment Phase
  *
- * For each idle dwarf carrying items, find the best stockpile tile (nearest
- * among highest-priority tiles that accept the item's category) and create
- * a haul task. If no stockpile exists, drop items on the ground so the
+ * Phase 1: For each idle dwarf carrying items, find the best stockpile tile
+ * (nearest among highest-priority tiles that accept the item's category) and
+ * create a haul task. If no stockpile exists, drop items on the ground so the
  * dwarf isn't stuck with a full inventory.
+ *
+ * Phase 2: Scan for ground items not on stockpile tiles and create haul tasks
+ * so idle dwarves will pick them up and deliver them.
  */
 export async function haulAssignment(ctx: SimContext): Promise<void> {
   const { state } = ctx;
 
+  // Track which items already have a pending/active haul task
+  const itemsWithHaulTask = new Set<string>();
+  for (const task of state.tasks) {
+    if (task.task_type === 'haul' && task.target_item_id
+      && task.status !== 'completed' && task.status !== 'cancelled' && task.status !== 'failed') {
+      itemsWithHaulTask.add(task.target_item_id);
+    }
+  }
+
+  // Phase 1: dwarves already carrying items
   for (const dwarf of state.dwarves) {
     if (!isDwarfIdle(dwarf)) continue;
 
     const carried = getCarriedItems(dwarf.id, state.items);
     if (carried.length === 0) continue;
 
-    // If no stockpile exists, drop items on the ground to unblock the dwarf
     if (state.stockpileTiles.size === 0) {
       for (const item of carried) {
         dropItem(dwarf, item, state);
@@ -31,11 +43,11 @@ export async function haulAssignment(ctx: SimContext): Promise<void> {
       continue;
     }
 
-    // Create a haul task for the first carried item
     const item = carried[0];
+    if (itemsWithHaulTask.has(item.id)) continue;
+
     const target = findBestStockpile(ctx, dwarf.position_x, dwarf.position_y, dwarf.position_z, item.category);
     if (!target) {
-      // No suitable stockpile tile (all full or wrong category) — drop items
       for (const c of carried) {
         dropItem(dwarf, c, state);
       }
@@ -51,6 +63,34 @@ export async function haulAssignment(ctx: SimContext): Promise<void> {
       target_item_id: item.id,
       work_required: WORK_HAUL,
     });
+    itemsWithHaulTask.add(item.id);
+  }
+
+  // Phase 2: ground items not on stockpiles
+  if (state.stockpileTiles.size === 0) return;
+
+  for (const item of state.items) {
+    if (item.held_by_dwarf_id !== null) continue;
+    if (item.position_x === null || item.position_y === null || item.position_z === null) continue;
+    if (item.located_in_civ_id !== ctx.civilizationId) continue;
+    if (itemsWithHaulTask.has(item.id)) continue;
+
+    const itemKey = `${item.position_x},${item.position_y},${item.position_z}`;
+    if (state.stockpileTiles.has(itemKey)) continue;
+
+    const target = findBestStockpile(ctx, item.position_x, item.position_y, item.position_z, item.category);
+    if (!target) continue;
+
+    createTask(ctx, {
+      task_type: 'haul',
+      priority: 4,
+      target_x: target.x,
+      target_y: target.y,
+      target_z: target.z,
+      target_item_id: item.id,
+      work_required: WORK_HAUL,
+    });
+    itemsWithHaulTask.add(item.id);
   }
 }
 

--- a/sim/src/phases/task-execution.ts
+++ b/sim/src/phases/task-execution.ts
@@ -14,6 +14,7 @@ import type { SimContext } from "../sim-context.js";
 import { getDwarfSkillLevel, getRequiredSkill } from "../task-helpers.js";
 import { bfsNextStep } from "../pathfinding.js";
 import { buildTileLookup } from "../tile-lookup.js";
+import { canPickUp, pickUpItem } from "../inventory.js";
 import { handleDeprivationDeaths } from "./deprivation.js";
 import { completeTask } from "./task-completion.js";
 
@@ -58,6 +59,52 @@ export async function taskExecution(ctx: SimContext): Promise<void> {
     if (task.status === 'claimed') {
       task.status = 'in_progress';
       state.dirtyTaskIds.add(task.id);
+    }
+
+    // Haul tasks: if the dwarf doesn't hold the target item yet, walk to it and pick it up
+    if (task.task_type === 'haul' && task.target_item_id) {
+      const haulItem = state.items.find(i => i.id === task.target_item_id);
+      if (haulItem && haulItem.held_by_dwarf_id !== dwarf.id) {
+        if (haulItem.position_x !== null && haulItem.position_y !== null && haulItem.position_z !== null) {
+          const atItem = dwarf.position_x === haulItem.position_x
+            && dwarf.position_y === haulItem.position_y
+            && dwarf.position_z === haulItem.position_z;
+          if (atItem) {
+            if (canPickUp(dwarf.id, haulItem, state.items)) {
+              pickUpItem(dwarf, haulItem, state);
+            } else {
+              failTask(dwarf, task, state);
+            }
+          } else {
+            const getTile = buildTileLookup(ctx);
+            const nextStep = bfsNextStep(
+              { x: dwarf.position_x, y: dwarf.position_y, z: dwarf.position_z },
+              { x: haulItem.position_x, y: haulItem.position_y, z: haulItem.position_z },
+              getTile,
+              false,
+            );
+            if (nextStep) {
+              const nextKey = `${nextStep.x},${nextStep.y},${nextStep.z}`;
+              if (!occupiedTiles.has(nextKey)) {
+                const prevKey = `${dwarf.position_x},${dwarf.position_y},${dwarf.position_z}`;
+                occupiedTiles.delete(prevKey);
+                occupiedTiles.add(nextKey);
+                dwarf.position_x = nextStep.x;
+                dwarf.position_y = nextStep.y;
+                dwarf.position_z = nextStep.z;
+                state.dirtyDwarfIds.add(dwarf.id);
+              }
+            } else {
+              failTask(dwarf, task, state);
+            }
+          }
+          continue;
+        }
+        if (haulItem.held_by_dwarf_id !== null) {
+          failTask(dwarf, task, state);
+          continue;
+        }
+      }
     }
 
     // Check if dwarf needs to move to the task site

--- a/sim/src/run-scenario.ts
+++ b/sim/src/run-scenario.ts
@@ -1,6 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { STEPS_PER_YEAR, STEPS_PER_DAY } from "@pwarf/shared";
-import type { Dwarf, DwarfSkill, FortressTile, Item, Structure, Monster, Task, WorldEvent } from "@pwarf/shared";
+import type { Dwarf, DwarfSkill, FortressTile, Item, StockpileTile, Structure, Monster, Task, WorldEvent } from "@pwarf/shared";
 import type { SimContext, CachedState } from "./sim-context.js";
 import { createEmptyCachedState, createRng } from "./sim-context.js";
 import { DEFAULT_TEST_SEED } from "./rng.js";
@@ -38,6 +38,8 @@ export interface ScenarioConfig {
   tasks?: Task[];
   /** Pre-placed fortress tiles — bypasses the fortress deriver for controlled map fixtures. */
   fortressTileOverrides?: FortressTile[];
+  /** Pre-placed stockpile tiles for haul testing. */
+  stockpileTiles?: StockpileTile[];
   ticks: number;
   seed?: number;
 }
@@ -81,6 +83,11 @@ export async function runScenario(config: ScenarioConfig): Promise<ScenarioResul
   if (config.fortressTileOverrides) {
     for (const tile of config.fortressTileOverrides) {
       state.fortressTileOverrides.set(`${tile.x},${tile.y},${tile.z}`, { ...tile });
+    }
+  }
+  if (config.stockpileTiles) {
+    for (const tile of config.stockpileTiles) {
+      state.stockpileTiles.set(`${tile.x},${tile.y},${tile.z}`, { ...tile });
     }
   }
   const ctx: SimContext = {


### PR DESCRIPTION
Closes #587

## Summary
- Dwarves now automatically pick up ground items and haul them to stockpiles (previously only items already in inventory were hauled)
- `haulAssignment` Phase 2 scans for ground items not on stockpile tiles and creates haul tasks
- `taskExecution` handles two-step haul: walk to item → pick up → walk to stockpile → drop
- Added `stockpileTiles` field to `ScenarioConfig` for headless testing
- Added scenario tests for all 5 building types (wall, floor, bed, well, mushroom garden)
- Added 3 stockpile hauling scenario tests + 4 unit tests

## Test plan
- [x] All 5 building types complete in headless scenarios
- [x] Ground items get hauled to stockpiles
- [x] Items already on stockpiles are not re-hauled
- [x] No duplicate haul tasks created for the same item
- [x] Foreign civilization items are not hauled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Claude Cost
**Claude cost:** $0.22 (59k tokens)