### PR TITLE
feat: show material costs in build menu, improve blocked-build visibility

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -114,18 +114,22 @@ export default function App() {
     return map;
   }, [liveTasks, zLevel]);
 
+  // Count available raw materials in the civilization's stockpiles
+  const materialCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    if (!world.civId) return counts;
+    for (const item of (snapshot?.items ?? [])) {
+      if (item.category === 'raw_material' && item.material && item.located_in_civ_id === world.civId && item.held_by_dwarf_id === null) {
+        counts.set(item.material, (counts.get(item.material) ?? 0) + 1);
+      }
+    }
+    return counts;
+  }, [snapshot?.items, world.civId]);
+
   // Compute which build tasks are blocked due to missing resources
   const blockedBuildTiles = useMemo(() => {
     const set = new Set<string>();
     if (!world.civId) return set;
-
-    // Count available resources by material
-    const availableCounts = new Map<string, number>();
-    for (const item of (snapshot?.items ?? [])) {
-      if (item.category === 'raw_material' && item.material && item.located_in_civ_id === world.civId && item.held_by_dwarf_id === null) {
-        availableCounts.set(item.material, (availableCounts.get(item.material) ?? 0) + 1);
-      }
-    }
 
     // Count how many resources are already reserved by earlier (non-blocked) build tasks
     const reservedCounts = new Map<string, number>();
@@ -142,7 +146,7 @@ export default function App() {
 
       let blocked = false;
       for (const cost of costs) {
-        const available = (availableCounts.get(cost.material) ?? 0) - (reservedCounts.get(cost.material) ?? 0);
+        const available = (materialCounts.get(cost.material) ?? 0) - (reservedCounts.get(cost.material) ?? 0);
         if (available < cost.count) {
           blocked = true;
           break;
@@ -160,7 +164,7 @@ export default function App() {
     }
 
     return set;
-  }, [liveTasks, snapshot?.items, world.civId, zLevel]);
+  }, [liveTasks, materialCounts, world.civId, zLevel]);
 
   const designation = useDesignation({
     civId: world.civId,
@@ -528,6 +532,7 @@ export default function App() {
           <BuildMenu
             onSelect={designation.handleBuildSelect}
             onClose={() => designation.setBuildMenuOpen(false)}
+            inventory={materialCounts}
           />
         )}
         {designation.prioritiesOpen && (

--- a/app/src/components/BuildMenu.tsx
+++ b/app/src/components/BuildMenu.tsx
@@ -1,4 +1,5 @@
 import type { TaskType } from "@pwarf/shared";
+import { BUILDING_COSTS } from "@pwarf/shared";
 
 export type BuildOption = {
   label: string;
@@ -18,11 +19,12 @@ const BUILD_OPTIONS: BuildOption[] = [
 interface BuildMenuProps {
   onSelect: (taskType: TaskType) => void;
   onClose: () => void;
+  inventory: Map<string, number>;
 }
 
-export default function BuildMenu({ onSelect, onClose }: BuildMenuProps) {
+export default function BuildMenu({ onSelect, onClose, inventory }: BuildMenuProps) {
   return (
-    <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-50 bg-[var(--bg-panel)] border border-[var(--amber)] p-3 min-w-[200px]">
+    <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-50 bg-[var(--bg-panel)] border border-[var(--amber)] p-3 min-w-[260px]">
       <div className="flex justify-between items-center mb-2 border-b border-[var(--border)] pb-1">
         <span className="text-[var(--amber)] font-bold text-sm">Build</span>
         <button
@@ -33,17 +35,38 @@ export default function BuildMenu({ onSelect, onClose }: BuildMenuProps) {
         </button>
       </div>
       <ul className="space-y-0.5">
-        {BUILD_OPTIONS.map((opt) => (
-          <li key={opt.taskType}>
-            <button
-              onClick={() => onSelect(opt.taskType)}
-              className="w-full text-left px-1 py-0.5 text-xs text-[var(--text)] hover:bg-[var(--bg-hover)] hover:text-[var(--green)] cursor-pointer"
-            >
-              <kbd className="text-[var(--amber)] mr-2">{opt.key}</kbd>
-              {opt.label}
-            </button>
-          </li>
-        ))}
+        {BUILD_OPTIONS.map((opt) => {
+          const costs = BUILDING_COSTS[opt.taskType];
+          return (
+            <li key={opt.taskType}>
+              <button
+                onClick={() => onSelect(opt.taskType)}
+                className="w-full text-left px-1 py-0.5 text-xs text-[var(--text)] hover:bg-[var(--bg-hover)] hover:text-[var(--green)] cursor-pointer flex justify-between items-center gap-2"
+              >
+                <span>
+                  <kbd className="text-[var(--amber)] mr-2">{opt.key}</kbd>
+                  {opt.label}
+                </span>
+                {costs && (
+                  <span className="text-[var(--text)] opacity-70">
+                    {costs.map((c) => {
+                      const avail = inventory.get(c.material) ?? 0;
+                      const hasEnough = avail >= c.count;
+                      return (
+                        <span key={c.material}>
+                          {c.count}&times; {c.material}{" "}
+                          <span className={hasEnough ? "text-[var(--green)]" : "text-[var(--red)]"}>
+                            ({avail})
+                          </span>
+                        </span>
+                      );
+                    })}
+                  </span>
+                )}
+              </button>
+            </li>
+          );
+        })}
       </ul>
     </div>
   );

--- a/app/src/components/MainViewport.tsx
+++ b/app/src/components/MainViewport.tsx
@@ -218,7 +218,7 @@ export default function MainViewport({
             const buildPct = buildProgressTilesRef.current?.get(key);
             // Blocked tasks get a red background; normal tasks interpolate brown → amber
             const bg = isBlocked
-              ? "#661111"
+              ? "#993333"
               : buildPct !== undefined && buildPct > 0
                 ? `rgb(${Math.round(0x44 + (0x88 - 0x44) * buildPct / 100)},${Math.round(0x22 + (0x66 - 0x22) * buildPct / 100)},0)`
                 : "#442200";


### PR DESCRIPTION
## Summary
- Display material costs and current stock count next to each build option in the BuildMenu (e.g. `Wall [w]  1× stone (12)`)
- Insufficient materials shown in red, sufficient in green
- Brightened blocked-build tile background from `#661111` to `#993333` for better visibility on the map
- Extracted `materialCounts` as a shared `useMemo` in App.tsx (used by both `blockedBuildTiles` and `BuildMenu`)

Closes #607

## Test plan
- [x] `npm test` — all 1740 tests pass
- [x] `npm run build` — pre-existing type errors only (unrelated `body_parts`/`injuries` on Monster/Dwarf types)
- [ ] Visual check: open build menu, verify costs display with correct counts
- [ ] Visual check: place a build with insufficient materials, verify brighter red tile

## Claude Cost
**Claude cost:** $0.63 (593k tokens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)