### PR TITLE
fix: clear mine designation overlay when task completes

### DIFF
--- a/sim/src/sim-runner.ts
+++ b/sim/src/sim-runner.ts
@@ -243,7 +243,7 @@ export class SimRunner {
       this.onTick({
         dwarves: this.ctx.state.dwarves,
         items: this.ctx.state.items,
-        tasks: this.ctx.state.tasks,
+        tasks: [...this.ctx.state.tasks],
         events: this.ctx.state.worldEvents,
         fortressTileOverrides: [...this.ctx.state.fortressTileOverrides.values()],
         monsters: this.ctx.state.monsters,


### PR DESCRIPTION
## Summary
- **Bug:** After mining a tile, the orange "X" designation overlay stayed permanently instead of clearing.
- **Root cause:** `SimRunner.tick()` sent `tasks: this.ctx.state.tasks` in the snapshot — the same array reference every tick. When a mine task completed and its `status` was mutated in-place to `'completed'`, React's `useMemo` in `App.tsx` never recomputed because `liveTasks` was always the same array object.
- **Fix:** Spread the tasks array (`[...this.ctx.state.tasks]`) so React sees a new reference on each tick, matching how `fortressTileOverrides` was already handled.

Closes #613

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (1638 tests)
- [ ] Playtest: designate mine on rock tile, verify orange "X" disappears after dwarf completes mining

🤖 Generated with [Claude Code](https://claude.com/claude-code)