### PR TITLE
fix: sanitize dangling FK refs before flushing to Supabase (closes #622)

### DIFF
--- a/sim/src/__tests__/flush-state.test.ts
+++ b/sim/src/__tests__/flush-state.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeDanglingRefs } from "../flush-state.js";
+import { makeDwarf, makeTask, makeItem, makeStructure } from "./test-helpers.js";
+import { createEmptyCachedState } from "../sim-context.js";
+
+describe("sanitizeDanglingRefs", () => {
+  it("nulls target_item_id when referenced item no longer exists", () => {
+    const state = createEmptyCachedState();
+    const item = makeItem({ name: "Food" });
+    // Item was consumed — NOT in state.items
+    const task = makeTask("eat", {
+      target_item_id: item.id,
+      status: "completed",
+    });
+    state.tasks.push(task);
+
+    sanitizeDanglingRefs(state);
+
+    expect(task.target_item_id).toBeNull();
+    expect(state.dirtyTaskIds.has(task.id)).toBe(true);
+  });
+
+  it("preserves target_item_id when referenced item still exists", () => {
+    const state = createEmptyCachedState();
+    const item = makeItem({ name: "Food" });
+    state.items.push(item);
+    const task = makeTask("eat", {
+      target_item_id: item.id,
+      status: "in_progress",
+    });
+    state.tasks.push(task);
+
+    sanitizeDanglingRefs(state);
+
+    expect(task.target_item_id).toBe(item.id);
+  });
+
+  it("preserves target_item_id when it references a structure (sleep/bed)", () => {
+    const state = createEmptyCachedState();
+    const bed = makeStructure({ type: "bed" });
+    state.structures.push(bed);
+    const task = makeTask("sleep", {
+      target_item_id: bed.id,
+      status: "in_progress",
+    });
+    state.tasks.push(task);
+
+    sanitizeDanglingRefs(state);
+
+    expect(task.target_item_id).toBe(bed.id);
+  });
+
+  it("removes completed new tasks with dangling item refs", () => {
+    const state = createEmptyCachedState();
+    const task = makeTask("eat", {
+      target_item_id: "deleted-food-id",
+      status: "completed",
+    });
+    state.tasks.push(task);
+    state.newTasks.push(task);
+
+    sanitizeDanglingRefs(state);
+
+    // target_item_id nulled first, then task removed from newTasks
+    expect(task.target_item_id).toBeNull();
+    expect(state.newTasks).not.toContain(task);
+    expect(state.dirtyTaskIds.has(task.id)).toBe(false);
+  });
+
+  it("keeps pending new tasks even with dangling refs (they may be retried)", () => {
+    const state = createEmptyCachedState();
+    const task = makeTask("haul", {
+      target_item_id: "deleted-item-id",
+      status: "pending",
+    });
+    state.tasks.push(task);
+    state.newTasks.push(task);
+
+    sanitizeDanglingRefs(state);
+
+    // target_item_id is nulled, but task stays in newTasks (it's still pending)
+    expect(task.target_item_id).toBeNull();
+    expect(state.newTasks).toContain(task);
+  });
+
+  it("handles tasks with null target_item_id (no-op)", () => {
+    const state = createEmptyCachedState();
+    const task = makeTask("mine", {
+      target_item_id: null,
+      status: "pending",
+    });
+    state.tasks.push(task);
+
+    sanitizeDanglingRefs(state);
+
+    expect(task.target_item_id).toBeNull();
+    // Should NOT be marked dirty since nothing changed
+    expect(state.dirtyTaskIds.has(task.id)).toBe(false);
+  });
+});

--- a/sim/src/flush-state.ts
+++ b/sim/src/flush-state.ts
@@ -10,6 +10,12 @@ import type { SimContext } from "./sim-context.js";
 export async function flushToSupabase(ctx: SimContext): Promise<void> {
   const { state, supabase } = ctx;
 
+  // ── Pre-flush cleanup: fix dangling foreign keys ──────────────────────
+  // Items can be consumed (spliced from state.items) between flush cycles.
+  // Tasks and dwarves that reference those items via target_item_id or
+  // current_task_id will violate FK constraints if flushed as-is.
+  sanitizeDanglingRefs(state);
+
   const dirtyDwarves = state.dwarves.filter((d) =>
     state.dirtyDwarfIds.has(d.id),
   );
@@ -227,15 +233,17 @@ export async function flushToSupabase(ctx: SimContext): Promise<void> {
   }
 
   if (events.length > 0) {
-    // Stamp world_id on events (phases leave it empty)
+    // Stamp world_id on events (phases leave it empty).
+    // Use upsert with ignoreDuplicates to prevent "duplicate key" errors
+    // when a previous flush partially succeeded and is retried.
     const worldId = ctx.worldId;
     const stamped = events.map((e) => ({ ...e, world_id: worldId }));
     promises.push(
       supabase
         .from("world_events")
-        .insert(stamped)
+        .upsert(stamped, { onConflict: "id", ignoreDuplicates: true })
         .then(({ error }) => {
-          if (error) console.warn(`[flush] events insert failed: ${error.message}`);
+          if (error) console.warn(`[flush] events upsert failed: ${error.message}`);
         }),
     );
   }
@@ -257,4 +265,53 @@ export async function flushToSupabase(ctx: SimContext): Promise<void> {
   state.newDwarfRelationships = [];
   state.pendingEvents = [];
   state.civDirty = false;
+}
+
+/**
+ * Fix dangling foreign key references before flushing to the database.
+ *
+ * Items can be created and consumed within a single flush window. Tasks
+ * referencing those items via target_item_id will violate the FK constraint
+ * when inserted. This function:
+ *
+ * 1. Builds a set of all live item + structure IDs (items in memory)
+ * 2. Nulls out target_item_id on any task pointing to a deleted entity
+ * 3. Removes new tasks that were created AND completed in the same window
+ *    with a dangling item ref (no point inserting a completed eat task
+ *    whose food is already gone)
+ *
+ * Exported for unit testing.
+ */
+export function sanitizeDanglingRefs(state: SimContext['state']): void {
+  // Build lookup of all live item IDs and structure IDs
+  const liveItemIds = new Set<string>();
+  for (const item of state.items) {
+    liveItemIds.add(item.id);
+  }
+  for (const structure of state.structures) {
+    liveItemIds.add(structure.id);
+  }
+
+  // Fix dangling target_item_id on all tasks (dirty + new)
+  for (const task of state.tasks) {
+    if (task.target_item_id && !liveItemIds.has(task.target_item_id)) {
+      task.target_item_id = null;
+      state.dirtyTaskIds.add(task.id);
+    }
+  }
+
+  // Drop new tasks that were created and already completed/failed with a
+  // null target_item_id — they carry no useful information for the DB.
+  // (e.g., an eat task where the food was consumed in the same flush window)
+  state.newTasks = state.newTasks.filter((task) => {
+    if (task.status === 'completed' || task.status === 'failed') {
+      // If this task had a dangling ref that we just nulled, skip inserting it
+      if (task.target_item_id === null) {
+        // Check if there's a corresponding dirty entry — remove that too
+        state.dirtyTaskIds.delete(task.id);
+        return false;
+      }
+    }
+    return true;
+  });
 }


### PR DESCRIPTION
## Summary
- Added `sanitizeDanglingRefs()` pre-flush cleanup that nulls `target_item_id` on tasks referencing deleted items/structures
- Drops completed new tasks with dangling refs from the insert batch (no point sending them)
- Changed events from `insert` to `upsert` with `ignoreDuplicates: true` to prevent duplicate key cascade on flush retries

## Root cause
Items consumed between flush cycles (eat, drink, brew, cook, build) leave tasks with stale `target_item_id` FK references. The flush sends these to Supabase which rejects with FK violation → duplicate key errors on retried events → auth lock timeouts → total flush failure → unresponsive UI (slow panning, state desync).

## Test plan
- [x] Unit test: nulls dangling target_item_id when item deleted
- [x] Unit test: preserves target_item_id when item still exists
- [x] Unit test: preserves target_item_id when referencing a structure (bed)
- [x] Unit test: removes completed new tasks with dangling refs
- [x] Unit test: keeps pending tasks with dangling refs (may be retried)
- [x] Unit test: no-op for tasks with null target_item_id
- [x] All 924 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)