### PR TITLE
test: flush FK integration tests with fake Supabase (closes #630)

### DIFF
--- a/sim/src/__tests__/flush-fk-integration.test.ts
+++ b/sim/src/__tests__/flush-fk-integration.test.ts
@@ -1,0 +1,367 @@
+import { describe, it, expect } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { STEPS_PER_YEAR, STEPS_PER_DAY } from "@pwarf/shared";
+import type { SimContext, CachedState } from "../sim-context.js";
+import { createEmptyCachedState, createRng } from "../sim-context.js";
+import { DEFAULT_TEST_SEED } from "../rng.js";
+import { runTick, advanceTime, maybeYearRollup } from "../tick.js";
+import { flushToSupabase } from "../flush-state.js";
+import { makeDwarf, makeSkill, makeTask, makeItem, makeMapTile } from "./test-helpers.js";
+
+// ─── Fake Supabase client that enforces FK constraints ───────────────────────
+
+interface FkConstraint {
+  column: string;
+  referencedTable: string;
+}
+
+/**
+ * Creates a fake Supabase client that tracks rows per table and enforces
+ * foreign key constraints. Throws on FK violation instead of returning
+ * a Supabase error — this makes test failures obvious.
+ */
+function createFakeSupabase() {
+  const tables = new Map<string, Map<string, Record<string, unknown>>>();
+  const fkConstraints = new Map<string, FkConstraint[]>();
+  const violations: string[] = [];
+
+  // Define FK constraints matching the real schema
+  fkConstraints.set("tasks", [
+    { column: "target_item_id", referencedTable: "items" },
+    // tasks.assigned_dwarf_id → dwarves.id (nullable)
+    { column: "assigned_dwarf_id", referencedTable: "dwarves" },
+  ]);
+  fkConstraints.set("dwarves", [
+    { column: "current_task_id", referencedTable: "tasks" },
+  ]);
+
+  function getTable(name: string): Map<string, Record<string, unknown>> {
+    if (!tables.has(name)) tables.set(name, new Map());
+    return tables.get(name)!;
+  }
+
+  function checkFks(tableName: string, row: Record<string, unknown>): string | null {
+    const constraints = fkConstraints.get(tableName);
+    if (!constraints) return null;
+
+    for (const fk of constraints) {
+      const value = row[fk.column];
+      if (value === null || value === undefined) continue;
+
+      const refTable = getTable(fk.referencedTable);
+      if (!refTable.has(value as string)) {
+        return `insert or update on table "${tableName}" violates foreign key constraint "${tableName}_${fk.column}_fkey": ${fk.column}=${value} not found in ${fk.referencedTable}`;
+      }
+    }
+    return null;
+  }
+
+  function upsertRows(tableName: string, rows: Record<string, unknown>[]) {
+    const table = getTable(tableName);
+    for (const row of rows) {
+      const fkError = checkFks(tableName, row);
+      if (fkError) {
+        violations.push(fkError);
+        return { error: { message: fkError } };
+      }
+      table.set(row.id as string, { ...row });
+    }
+    return { error: null };
+  }
+
+  // Build a chainable query builder that mimics Supabase's API
+  function from(tableName: string) {
+    return {
+      insert(rows: Record<string, unknown> | Record<string, unknown>[]) {
+        const arr = Array.isArray(rows) ? rows : [rows];
+        const result = upsertRows(tableName, arr);
+        return {
+          then: (fn: (r: { error: { message: string } | null }) => void) => {
+            fn(result);
+            return Promise.resolve();
+          },
+        };
+      },
+      upsert(rows: Record<string, unknown> | Record<string, unknown>[], _opts?: unknown) {
+        const arr = Array.isArray(rows) ? rows : [rows];
+        const result = upsertRows(tableName, arr);
+        return {
+          then: (fn: (r: { error: { message: string } | null }) => void) => {
+            fn(result);
+            return Promise.resolve();
+          },
+        };
+      },
+      update(_data: Record<string, unknown>) {
+        return {
+          eq(_col: string, _val: string) {
+            return {
+              then: (fn: (r: { error: null }) => void) => {
+                fn({ error: null });
+                return Promise.resolve();
+              },
+            };
+          },
+        };
+      },
+    };
+  }
+
+  return {
+    client: { from } as unknown as SupabaseClient,
+    tables,
+    violations,
+    getTable,
+  };
+}
+
+// ─── Helper: run N ticks then flush, checking for FK violations ──────────────
+
+async function runSimWithFlush(opts: {
+  ticks: number;
+  flushEvery: number;
+  dwarves?: ReturnType<typeof makeDwarf>[];
+  skills?: ReturnType<typeof makeSkill>[];
+  items?: ReturnType<typeof makeItem>[];
+  tasks?: ReturnType<typeof makeTask>[];
+  tiles?: ReturnType<typeof makeMapTile>[];
+  seed?: number;
+}) {
+  const fake = createFakeSupabase();
+  const state: CachedState = createEmptyCachedState();
+
+  const dwarves = (opts.dwarves ?? []).map(d => ({ ...d }));
+  state.dwarves = dwarves;
+  state.dwarfSkills = (opts.skills ?? []).map(s => ({ ...s }));
+  state.items = (opts.items ?? []).map(i => ({ ...i }));
+  state.tasks = (opts.tasks ?? []).map(t => ({ ...t }));
+
+  if (opts.tiles) {
+    for (const tile of opts.tiles) {
+      state.fortressTileOverrides.set(`${tile.x},${tile.y},${tile.z}`, { ...tile });
+    }
+  }
+
+  const ctx: SimContext = {
+    supabase: fake.client,
+    civilizationId: "test-civ",
+    worldId: "test-world",
+    civName: "Test Fortress",
+    civTileX: 0,
+    civTileY: 0,
+    fortressDeriver: null,
+    step: 0,
+    year: 1,
+    day: 1,
+    rng: createRng(opts.seed ?? DEFAULT_TEST_SEED),
+    state,
+  };
+
+  // Pre-seed the fake DB with initial dwarves (they exist before the sim starts)
+  const dwarfTable = fake.getTable("dwarves");
+  for (const d of state.dwarves) {
+    dwarfTable.set(d.id, { ...d });
+  }
+  // Pre-seed items
+  const itemTable = fake.getTable("items");
+  for (const i of state.items) {
+    itemTable.set(i.id, { ...i });
+  }
+  // Pre-seed structures
+  const structTable = fake.getTable("structures");
+  for (const s of state.structures) {
+    structTable.set(s.id, { ...s });
+  }
+
+  let stepCount = 0;
+  let currentYear = 1;
+
+  for (let i = 0; i < opts.ticks; i++) {
+    stepCount++;
+    advanceTime(ctx, stepCount, currentYear);
+
+    await runTick(ctx);
+
+    currentYear = await maybeYearRollup(ctx, stepCount, currentYear);
+
+    // Flush pending events into worldEvents (mirrors run-scenario)
+    if (state.pendingEvents.length > 0) {
+      state.worldEvents.push(...state.pendingEvents);
+      state.pendingEvents = [];
+    }
+
+    // Flush to fake DB at the specified interval
+    if (stepCount % opts.flushEvery === 0) {
+      await flushToSupabase(ctx);
+    }
+  }
+
+  // Final flush
+  await flushToSupabase(ctx);
+
+  return {
+    violations: fake.violations,
+    tables: fake.tables,
+    state,
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("flush FK integration", () => {
+  it("no FK violations during a 500-tick sim with frequent flushes", async () => {
+    // Full scenario: 2 dwarves, mine trees + rock, build structures.
+    // Flush every 10 ticks (aggressive — mimics real-world flush interval).
+    // This exercises all the auto-phases (eat, drink, cook, brew, forage)
+    // that create and consume items within flush windows.
+
+    const dwarf1 = makeDwarf({
+      name: "Urist", position_x: 5, position_y: 5, position_z: 0,
+      need_food: 100, need_drink: 100, need_sleep: 100, need_social: 80,
+    });
+    const dwarf2 = makeDwarf({
+      name: "Bomrek", position_x: 6, position_y: 5, position_z: 0,
+      need_food: 100, need_drink: 100, need_sleep: 100, need_social: 80,
+    });
+
+    const tiles = [
+      makeMapTile(3, 5, 0, "tree"),
+      makeMapTile(3, 6, 0, "tree"),
+      makeMapTile(8, 5, 0, "rock"),
+      makeMapTile(8, 6, 0, "rock"),
+      makeMapTile(8, 7, 0, "rock"),
+      ...Array.from({ length: 15 }, (_, x) =>
+        Array.from({ length: 15 }, (_, y) => ({ x, y })),
+      ).flat()
+        .filter(({ x, y }) => !["3,5", "3,6", "8,5", "8,6", "8,7"].includes(`${x},${y}`))
+        .map(({ x, y }) => makeMapTile(x, y, 0, "grass")),
+    ];
+
+    const tasks = [
+      makeTask("mine", { status: "pending", target_x: 3, target_y: 5, target_z: 0, work_required: 100, priority: 10 }),
+      makeTask("mine", { status: "pending", target_x: 3, target_y: 6, target_z: 0, work_required: 100, priority: 10 }),
+      makeTask("mine", { status: "pending", target_x: 8, target_y: 5, target_z: 0, work_required: 100, priority: 8 }),
+      makeTask("mine", { status: "pending", target_x: 8, target_y: 6, target_z: 0, work_required: 100, priority: 8 }),
+      makeTask("mine", { status: "pending", target_x: 8, target_y: 7, target_z: 0, work_required: 100, priority: 8 }),
+      makeTask("build_floor", { status: "pending", target_x: 5, target_y: 8, target_z: 0, work_required: 25, priority: 6 }),
+      makeTask("build_wall", { status: "pending", target_x: 4, target_y: 8, target_z: 0, work_required: 40, priority: 6 }),
+      makeTask("build_door", { status: "pending", target_x: 5, target_y: 9, target_z: 0, work_required: 35, priority: 6 }),
+      makeTask("build_well", { status: "pending", target_x: 5, target_y: 11, target_z: 0, work_required: 60, priority: 5 }),
+    ];
+
+    const items = [
+      makeItem({ name: "Plump helmet", category: "food", position_x: 5, position_y: 5, position_z: 0, located_in_civ_id: "test-civ" }),
+      makeItem({ name: "Plump helmet", category: "food", position_x: 5, position_y: 5, position_z: 0, located_in_civ_id: "test-civ" }),
+      makeItem({ name: "Plump helmet brew", category: "drink", material: "plant", position_x: 5, position_y: 5, position_z: 0, located_in_civ_id: "test-civ" }),
+      makeItem({ name: "Plump helmet brew", category: "drink", material: "plant", position_x: 5, position_y: 5, position_z: 0, located_in_civ_id: "test-civ" }),
+    ];
+
+    const result = await runSimWithFlush({
+      ticks: 500,
+      flushEvery: 10,
+      dwarves: [dwarf1, dwarf2],
+      skills: [
+        makeSkill(dwarf1.id, "mining", 3),
+        makeSkill(dwarf1.id, "building", 1),
+        makeSkill(dwarf2.id, "building", 3),
+        makeSkill(dwarf2.id, "mining", 1),
+      ],
+      items,
+      tasks,
+      tiles,
+    });
+
+    if (result.violations.length > 0) {
+      console.error("FK violations detected:");
+      for (const v of result.violations) {
+        console.error(`  ${v}`);
+      }
+    }
+    expect(result.violations).toEqual([]);
+  });
+
+  it("no FK violations when items are rapidly created and consumed", async () => {
+    // Stress test: dwarf with low food/drink rapidly creates and consumes
+    // eat/drink tasks. Flush every 5 ticks to maximize the chance of
+    // catching a dangling ref.
+
+    const dwarf = makeDwarf({
+      name: "Hungry", position_x: 5, position_y: 5, position_z: 0,
+      need_food: 20, need_drink: 20, need_sleep: 100, need_social: 80,
+    });
+
+    const tiles = Array.from({ length: 10 }, (_, x) =>
+      Array.from({ length: 10 }, (_, y) => makeMapTile(x, y, 0, "grass")),
+    ).flat();
+
+    // Lots of food and drink so the dwarf keeps eating/drinking
+    const items = [
+      ...Array.from({ length: 20 }, () =>
+        makeItem({ name: "Plump helmet", category: "food", position_x: 5, position_y: 5, position_z: 0, located_in_civ_id: "test-civ" }),
+      ),
+      ...Array.from({ length: 20 }, () =>
+        makeItem({ name: "Plump helmet brew", category: "drink", material: "plant", position_x: 5, position_y: 5, position_z: 0, located_in_civ_id: "test-civ" }),
+      ),
+    ];
+
+    const result = await runSimWithFlush({
+      ticks: 300,
+      flushEvery: 5,
+      dwarves: [dwarf],
+      skills: [],
+      items,
+      tasks: [],
+      tiles,
+    });
+
+    if (result.violations.length > 0) {
+      console.error("FK violations detected:");
+      for (const v of result.violations) {
+        console.error(`  ${v}`);
+      }
+    }
+    expect(result.violations).toEqual([]);
+  });
+
+  it("no FK violations with flush every single tick", async () => {
+    // Extreme: flush after every tick. This is the worst case for
+    // items being created in one tick and referenced by tasks before
+    // the item is flushed.
+
+    const dwarf = makeDwarf({
+      name: "Worker", position_x: 5, position_y: 5, position_z: 0,
+      need_food: 50, need_drink: 50, need_sleep: 100, need_social: 80,
+    });
+
+    const tiles = Array.from({ length: 10 }, (_, x) =>
+      Array.from({ length: 10 }, (_, y) => makeMapTile(x, y, 0, "grass")),
+    ).flat();
+
+    const items = [
+      ...Array.from({ length: 10 }, () =>
+        makeItem({ name: "Plump helmet", category: "food", position_x: 5, position_y: 5, position_z: 0, located_in_civ_id: "test-civ" }),
+      ),
+      ...Array.from({ length: 10 }, () =>
+        makeItem({ name: "Plump helmet brew", category: "drink", material: "plant", position_x: 5, position_y: 5, position_z: 0, located_in_civ_id: "test-civ" }),
+      ),
+    ];
+
+    const result = await runSimWithFlush({
+      ticks: 200,
+      flushEvery: 1,
+      dwarves: [dwarf],
+      skills: [],
+      items,
+      tasks: [],
+      tiles,
+    });
+
+    if (result.violations.length > 0) {
+      console.error("FK violations detected:");
+      for (const v of result.violations) {
+        console.error(`  ${v}`);
+      }
+    }
+    expect(result.violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a fake Supabase client that enforces FK constraints in memory (tasks.target_item_id → items.id, dwarves.current_task_id → tasks.id)
- Runs the full sim + flush cycle and asserts zero FK violations
- Three scenarios: normal gameplay (500 ticks/flush every 10), rapid eat/drink (300 ticks/flush every 5), extreme flush-every-tick (200 ticks)

This means future flush FK bugs can be caught and fixed without manual browser testing.

## Test plan
- [x] All 3 new integration tests pass
- [x] Full suite (937 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)