### PR TITLE
fix: deduplicate tasks before upsert to prevent duplicate-row error (closes #630)

### DIFF
--- a/sim/src/__tests__/flush-fk-integration.test.ts
+++ b/sim/src/__tests__/flush-fk-integration.test.ts
@@ -58,6 +58,20 @@ function createFakeSupabase() {
 
   function upsertRows(tableName: string, rows: Record<string, unknown>[]) {
     const table = getTable(tableName);
+
+    // PostgreSQL rejects upsert batches with duplicate IDs:
+    // "ON CONFLICT DO UPDATE command cannot affect row a second time"
+    const idsInBatch = new Set<string>();
+    for (const row of rows) {
+      const id = row.id as string;
+      if (idsInBatch.has(id)) {
+        const msg = `ON CONFLICT DO UPDATE command cannot affect row a second time: duplicate id=${id} in ${tableName} batch`;
+        violations.push(msg);
+        return { error: { message: msg } };
+      }
+      idsInBatch.add(id);
+    }
+
     for (const row of rows) {
       const fkError = checkFks(tableName, row);
       if (fkError) {

--- a/sim/src/flush-state.ts
+++ b/sim/src/flush-state.ts
@@ -1,3 +1,4 @@
+import type { Task } from "@pwarf/shared";
 import type { SimContext } from "./sim-context.js";
 
 /**
@@ -45,13 +46,15 @@ export async function flushToSupabase(ctx: SimContext): Promise<void> {
   }
 
   // 2. Tasks second — dwarves reference them via current_task_id
-  //    Use upsert for both new and dirty tasks. Plain insert fails with
-  //    "duplicate key" when a previous flush partially succeeded (some tasks
-  //    inserted, batch reported as failed, newTasks cleared, then the same
-  //    task appears in dirtyTasks on the next cycle and gets re-created).
-  const allDirtyTasks = [...newTasks, ...dirtyTasks];
-  if (allDirtyTasks.length > 0) {
-    const { error } = await supabase.from("tasks").upsert(allDirtyTasks);
+  //    Use upsert for both new and dirty tasks. A task can appear in both
+  //    newTasks AND dirtyTasks (created then modified in the same window),
+  //    so deduplicate by ID — dirtyTasks version wins (more recent state).
+  const taskById = new Map<string, Task>();
+  for (const t of newTasks) taskById.set(t.id, t);
+  for (const t of dirtyTasks) taskById.set(t.id, t); // overwrites newTasks entry
+  const dedupedTasks = [...taskById.values()];
+  if (dedupedTasks.length > 0) {
+    const { error } = await supabase.from("tasks").upsert(dedupedTasks);
     if (error) console.warn(`[flush] tasks upsert failed: ${error.message}`);
   }
 


### PR DESCRIPTION
## Summary
- Deduplicate tasks by ID before upserting — a task in both `newTasks` and `dirtyTasks` caused PostgreSQL to reject with "ON CONFLICT DO UPDATE cannot affect row a second time"
- Updated fake Supabase in integration tests to also reject duplicate IDs in a single batch (matches real PostgreSQL behavior)

## Root cause
A task created and modified in the same flush window appears in both `newTasks` and `dirtyTasks`. The merged `[...newTasks, ...dirtyTasks]` array contained the same task ID twice. PostgreSQL's upsert cannot process the same row twice in one statement.

## Test plan
- [x] Fake Supabase now enforces duplicate-ID-in-batch rejection
- [x] All 3 integration tests pass (500-tick, rapid eat/drink, flush-every-tick)
- [x] All 934 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)