### PR TITLE
fix: dwarves can now use held items to build

### DIFF
--- a/playtest-reports/playtest-2026-03-25.md
+++ b/playtest-reports/playtest-2026-03-25.md
@@ -1,0 +1,166 @@
+# Playtest Report: 2026-03-25
+
+**Tester:** Automated headless playtest (Claude Code)
+**Build:** feat/expedition-system @ 56fb543
+**Date:** 2026-03-25
+
+---
+
+## Scenarios Tested (Batch)
+
+| Scenario | Ticks | Pop Start | Pop End (alive/dead) | Deaths | Tasks Completed | Notes |
+|---|---|---|---|---|---|---|
+| starvation | 500 | 7 | 7/0 | 0 | 7 | All alive, needs all ok/good |
+| idle-fortress | 300 | 7 | 7/0 | 0 | 0 | No tasks designated — correct |
+| long-run-stability | 5000 | 7 | 7/0 | 0 | 0 | Needs gradually declining but still ok |
+| overcrowding | 500 | 20 | 20/0 | 0 | 10 | All alive, morale 97-100 |
+
+All four batch scenarios pass — no crashes, no deaths, no stuck states.
+
+---
+
+## Interactive Investigation Results
+
+### Investigation 1: Mine-Then-Build Pattern
+
+**Commands:** Designate 3 mine tasks at (100,100,0), (101,100,0), (102,100,0), then tick 200, then designate 2 build_wall tasks, then tick 400 more.
+
+**Result: FAIL — Mine tasks never complete, build tasks never start.**
+
+After 700 total ticks:
+- All 3 mine tasks remain `claimed` with `0%` progress.
+- Both build_wall tasks remain `pending` with `0%` progress.
+- `tasks_completed = 0` throughout.
+- Dwarves report activity as `mine at (100, 100, 0)` etc., showing they are assigned — but no work occurs.
+
+**Root cause analysis (mine tasks stuck):**
+
+The step-mode session sets `fortressDeriver: null`, causing all tiles to default to `open_air` (the fallback in `tile-lookup.ts`). Mine is an `ADJACENT_TASK_TYPES` task — dwarves must be adjacent, not on the target. The 7 dwarves start densely packed at (100-104, 100) and (100-101, 101). When 3 mine tasks are designated at (100,100), (101,100), (102,100), the adjacent tiles are fully or heavily occupied by other dwarves. The occupancy-blocking path in `moveTowardTarget` returns `true` (wait, not fail) when all routes are blocked, so the dwarves perpetually wait without accumulating work progress. Tasks cycle: `claimed` (jobClaiming) → `in_progress` (taskExecution transition) → blocked → `in_progress` with 0 progress added → same next tick.
+
+Additionally, the `open_air` tile type means there is no real tile to mine — the hardness defaults to `HARDNESS_STONE = 1.0`, so work would accrue if adjacency were achievable, but the `task_completion` logic would need to handle what happens when an `open_air` tile is "mined."
+
+**Root cause analysis (build_wall tasks permanently pending):**
+
+`hasResources('build_wall', items, civId)` checks for `stone` material items. The scenario starts with zero stone in inventory — only food (plant) and drink (plant). With no stone blocks available, no dwarf can ever claim a build_wall task. Build tasks stay `pending` forever.
+
+**Related: `constructionProgress` is a stub.**
+
+`sim/src/phases/construction-progress.ts` contains only `// stub` — the function is empty. This is a separate issue from the above, but means even if build tasks were claimable, the construction progress phase does not advance them. (Build tasks use `taskExecution` for progress via `work_progress`, not `constructionProgress`, so this stub may not block basic builds — but it signals incomplete feature work.)
+
+---
+
+### Investigation 2: Build a Room with Door
+
+**Commands:** Designate 12 build_wall + 1 build_door + 1 build_bed tasks, tick 700 total.
+
+**Result: FAIL — All 14 tasks remain permanently `pending` with 0% progress.**
+
+Same root cause as Investigation 1: no stone or wood items in the scenario inventory. All build tasks require materials (`BUILDING_COSTS` in shared):
+- `build_wall` → 1 stone
+- `build_door` → 1 stone (or wood, per implementation)
+- `build_bed` → 1 wood
+
+The scenario starts with food and drink only. Every dwarf skips all build tasks in `jobClaiming` because `hasResources` returns false. Dwarves remain idle at their starting positions for all 700 ticks.
+
+---
+
+### Investigation 3: Long Survival Check
+
+**Commands:** Tick 1000, then 2000, then 2000 more (5000 ticks total) — no tasks designated.
+
+**Result: PASS with concern.**
+
+All 7 dwarves survive all 5000 ticks. Needs are autonomously maintained by eat/drink/sleep task generation.
+
+**Need drift at tick 5000 (long-run-stability scenario):**
+
+| Dwarf | Food | Drink | Sleep |
+|---|---|---|---|
+| Urist McTestdwarf | ok (70) | ok (73) | ok (72) |
+| Zon Hammerfall | ok (64) | ok (60) | ok (70) |
+| Meng Stonebrew | ok (60) | ok (57) | ok (64) |
+| Ast Gravelfoot | ok (61) | ok (60) | ok (73) |
+
+Several dwarves are settling into the 57-70 range — safely above critical thresholds but trending downward. This is inherent to the auto-replenishment system (forage + brew + cook) keeping pace with decay but not surplus. No deaths or tantrums observed.
+
+Morale stays at 100 for all dwarves across all ticks (same issue noted in prior reports — social proximity restore overwhelms decay).
+
+---
+
+## Balance Issues
+
+### 1. Needs hover in "ok" range, never crisis in survival scenarios
+
+At 5000 ticks with no player input, all needs stay in the 57-88 range. The autonomous systems (autoForage, autoBrew, autoCook) are functioning correctly. This is good for stability but may feel like the game is playing itself — players have little urgency.
+
+### 2. Starting morale is "low" for most dwarves
+
+At tick 0 in the idle-fortress scenario, 5 of 7 dwarves have morale in the `low (41-46)` range and 2 are `ok (52-55)`. After a few ticks, morale rockets to 100 for all (social proximity restore). This creates an unrealistic morale "bounce" at session start that may mask the social decay mechanic entirely.
+
+### 3. Overcrowding scenario shows no stress
+
+With 20 dwarves and only 10 food + 10 drink, all 20 dwarves survive 500 ticks with morale 97-100 and stress calm (0). The scenario's design intent was to test "stress accumulation and social need collapse," but the social proximity restore bonus is so strong that overcrowding reads as beneficial (more neighbors = faster morale restore).
+
+---
+
+## Bugs / Unexpected Behavior
+
+### BUG 1: Mine tasks never complete in step mode (CRITICAL)
+
+**Reproduction:** Designate a mine task on any tile in step-mode (interactive). Tick indefinitely. Task stays claimed at 0% progress.
+
+**Cause:** Dense dwarf starting positions (5 dwarves in a row at y=100, 2 more at y=101) create occupancy deadlock around adjacent mine targets. With `moveTowardTarget` returning `true` (wait) instead of `false` (fail) when blocked, dwarves indefinitely wait without making progress. No task failure, no retry, no completion.
+
+This is functionally a dwarf stuck state — they report as `mine at (x,y,z)` but never progress.
+
+**Affected file:** `sim/src/phases/task-execution.ts` — `moveTowardTarget` and `isAdjacentToTarget` interaction.
+
+**Possible fix:** Spread dwarf starting positions to avoid adjacency deadlock, or add a maximum-wait counter before failing a task that has made zero progress for N ticks.
+
+### BUG 2: Build tasks require materials that scenarios never provide (MAJOR)
+
+**Reproduction:** Designate any build_wall, build_door, or build_bed task in step-mode interactive. Tasks stay permanently `pending`.
+
+**Cause:** `hasResources` correctly enforces material costs, but scenario states include zero stone/wood. There is no tutorial or guidance that mining must happen first to gather stone. In the step-mode interactive context, users can designate builds but they will never execute without first mining.
+
+**Affected file:** `sim/src/scenarios.ts` — `buildScenarioState` provides no stone/wood starting items.
+
+**Possible fix:** Either (a) add a small stone/wood starting inventory to scenarios intended for build testing, or (b) document that mine → build is the required workflow and ensure mine works first (see Bug 1).
+
+### BUG 3: `constructionProgress` phase is a stub (MINOR / INCOMPLETE)
+
+**File:** `sim/src/phases/construction-progress.ts`
+
+The function body is `// stub`. It is called in the tick loop but does nothing. The comment in the file describes an intended "multi-step construction" system. Currently, builds proceed via `taskExecution` work progress accumulation. This may be intentional (stub placeholder), but it represents unfinished work and the phase is wasted overhead.
+
+### OBSERVATION: Mine on open_air tiles behaves unexpectedly
+
+In step mode without a fortress deriver, all tiles resolve to `open_air`. Designating a mine task on an `open_air` tile is conceptually wrong (nothing to mine), but no validation error is raised. If adjacency were achievable, the mine task would complete (work accumulates via BASE_WORK_RATE / hardness), converting `open_air` to whatever the `completeTask` logic sets. This warrants a review of `task-completion.ts` for mine task on `open_air`.
+
+---
+
+## Suggestions
+
+1. **Spread dwarf starting positions** in scenarios to avoid initial adjacency deadlock. Currently all 7 dwarves spawn in a 5×2 cluster at (100-104, 100) and (100-101, 101) — mine tasks at those coordinates will always deadlock immediately.
+
+2. **Add a task-stall timeout.** A task that has been `in_progress` with zero work_progress change for more than ~50 ticks should trigger a `failTask` so the dwarf releases it and others can retry from a different position. This would break occupancy deadlocks.
+
+3. **Add starting stone to interactive/test scenarios.** At minimum, for investigation-style use of step-mode, seeding the scenario with 5-10 stone items would allow build tasks to be tested without requiring mining to work first.
+
+4. **Review morale restore rate.** The social proximity restore mechanic is too aggressive for clustered dwarves, making the "overcrowding" scenario feel like a prosperity bonus rather than a stress test.
+
+5. **Add mine-task tile validation.** Before creating a mine task, check that the target tile is actually a mineable type (rock, soil, ore, gem). Reject or warn on `open_air` mine designations.
+
+---
+
+## Verdict
+
+| Area | Status |
+|---|---|
+| Basic survival (eat/drink/sleep autonomy) | PASS |
+| Long-run stability (no crash, no death at 5000 ticks) | PASS |
+| Mining tasks | FAIL — stuck at 0% progress, occupancy deadlock |
+| Building tasks | FAIL — permanently pending, no materials in scenarios |
+| Morale balance | WARN — restores too fast, no meaningful stress in overcrowding |
+
+**Overall: WARN.** Core survival systems are stable. Task execution for mining and building is broken in step-mode testing due to starting dwarf density and missing materials. These issues would also affect real gameplay whenever dwarves are densely packed near a mining target.

--- a/sim/src/__tests__/building-costs.test.ts
+++ b/sim/src/__tests__/building-costs.test.ts
@@ -151,13 +151,13 @@ describe("building resource costs", () => {
     expect(stones).toHaveLength(1);
   });
 
-  it("does not consume items held by dwarves", () => {
+  it("consumes items held by the building dwarf", () => {
     const dwarf = makeDwarf();
     const ctx = makeContext({
       dwarves: [dwarf],
       skills: [makeSkill(dwarf.id, "building", 1)],
       items: [
-        // This stone is held by a dwarf — should not be consumed
+        // This stone is held by the building dwarf — should be consumed
         makeItem({ name: "Stone block", category: "raw_material", material: "stone", located_in_civ_id: "civ-1", held_by_dwarf_id: dwarf.id }),
       ],
     });
@@ -175,9 +175,9 @@ describe("building resource costs", () => {
 
     completeTask(dwarf, task, ctx);
 
-    expect(task.status).toBe("pending");
-    // Stone should still be held
-    expect(ctx.state.items).toHaveLength(1);
+    // Dwarf should be able to use the stone it's carrying to build
+    expect(task.status).toBe("completed");
+    expect(ctx.state.items).toHaveLength(0);
   });
 
   it("BUILDING_COSTS defines costs for all build task types", () => {

--- a/sim/src/__tests__/stuck-dwarf-scenarios.test.ts
+++ b/sim/src/__tests__/stuck-dwarf-scenarios.test.ts
@@ -1,0 +1,683 @@
+/**
+ * Stuck-dwarf scenario tests (issue investigation)
+ *
+ * Each scenario exercises a realistic gameplay pattern where dwarves commonly
+ * get stuck: mining corridors, hauling to stockpiles, pathfinding through doors,
+ * chained tasks, crowded workspaces.
+ *
+ * Failures here indicate real bugs, not test setup errors (after setup was
+ * validated against the existing test patterns).
+ */
+import { describe, it, expect } from "vitest";
+import { runScenario } from "../run-scenario.js";
+import { makeDwarf, makeTask, makeSkill, makeItem } from "./test-helpers.js";
+import {
+  WORK_MINE_BASE,
+  WORK_BUILD_WALL,
+  WORK_BUILD_FLOOR,
+  WORK_BUILD_DOOR,
+} from "@pwarf/shared";
+import type { Dwarf, FortressTile, Item, StockpileTile } from "@pwarf/shared";
+
+// ---------------------------------------------------------------------------
+// Helper factories
+// ---------------------------------------------------------------------------
+
+function stoneBlock(x: number, y: number, z = 0): Item {
+  return makeItem({
+    name: "Stone block",
+    category: "raw_material",
+    material: "stone",
+    located_in_civ_id: "test-civ",
+    held_by_dwarf_id: null,
+    position_x: x,
+    position_y: y,
+    position_z: z,
+  });
+}
+
+function woodLog(x: number, y: number, z = 0): Item {
+  return makeItem({
+    name: "Wood log",
+    category: "raw_material",
+    material: "wood",
+    located_in_civ_id: "test-civ",
+    held_by_dwarf_id: null,
+    position_x: x,
+    position_y: y,
+    position_z: z,
+  });
+}
+
+/** Suppress autonomous needs so dwarves focus on designated tasks */
+function highNeeds(): Partial<Dwarf> {
+  return { need_food: 100, need_drink: 100, need_sleep: 100, need_social: 80 };
+}
+
+/** Prevent auto-brew from triggering (need 15+ drinks in stock) */
+function suppressDrinks(count = 15): Item[] {
+  return Array.from({ length: count }, (_, i) =>
+    makeItem({
+      name: "Dwarven ale",
+      category: "drink",
+      material: "plant",
+      position_x: 0,
+      position_y: i,
+      position_z: 0,
+      located_in_civ_id: "test-civ",
+    }),
+  );
+}
+
+/**
+ * Prevent auto-cook from triggering (need MIN_COOK_STOCK=15 food items).
+ * Without this, auto-cook fires and dwarves pick up cook tasks with no raw food,
+ * which can be in a freshly-claimed (work_progress=0) state at the end of a run.
+ */
+function suppressAutocook(count = 15): Item[] {
+  return Array.from({ length: count }, (_, i) =>
+    makeItem({
+      name: "Prepared meal",
+      category: "food",
+      material: "cooked",
+      position_x: 1,
+      position_y: i,
+      position_z: 0,
+      located_in_civ_id: "test-civ",
+    }),
+  );
+}
+
+function grassTile(x: number, y: number, z = 0): FortressTile {
+  return {
+    id: `grass-${x}-${y}-${z}`,
+    civilization_id: "civ-1",
+    x, y, z,
+    tile_type: "grass",
+    material: null,
+    is_revealed: true,
+    is_mined: false,
+    created_at: new Date().toISOString(),
+  };
+}
+
+function rockTile(x: number, y: number, z = 0): FortressTile {
+  return {
+    id: `rock-${x}-${y}-${z}`,
+    civilization_id: "civ-1",
+    x, y, z,
+    tile_type: "rock",
+    material: "granite",
+    is_revealed: true,
+    is_mined: false,
+    created_at: new Date().toISOString(),
+  };
+}
+
+function constructedWallTile(x: number, y: number, z = 0): FortressTile {
+  return {
+    id: `cwall-${x}-${y}-${z}`,
+    civilization_id: "civ-1",
+    x, y, z,
+    tile_type: "constructed_wall",
+    material: "stone",
+    is_revealed: true,
+    is_mined: false,
+    created_at: new Date().toISOString(),
+  };
+}
+
+function doorTile(x: number, y: number, z = 0): FortressTile {
+  return {
+    id: `door-${x}-${y}-${z}`,
+    civilization_id: "civ-1",
+    x, y, z,
+    tile_type: "door",
+    material: "wood",
+    is_revealed: true,
+    is_mined: false,
+    created_at: new Date().toISOString(),
+  };
+}
+
+function makeStockpileTile(x: number, y: number, z = 0): StockpileTile {
+  return {
+    id: `stockpile-${x}-${y}-${z}`,
+    civilization_id: "test-civ",
+    x, y, z,
+    accepts_categories: null,
+    priority: 0,
+    created_at: new Date().toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Universal stuck-detection helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Assert no dwarf is truly stuck.
+ * A dwarf is "stuck" if they hold an in_progress task with zero work done.
+ * A freshly claimed task (status = 'claimed') with zero progress is fine —
+ * the dwarf may have just picked it up on the last tick.
+ */
+function assertNoDwarfStuck(result: Awaited<ReturnType<typeof runScenario>>): void {
+  for (const d of result.dwarves.filter(d => d.status === "alive")) {
+    if (d.current_task_id) {
+      const t = result.tasks.find(t => t.id === d.current_task_id);
+      // Only flag in_progress tasks with no work done — those are truly stuck.
+      // Claimed tasks may have 0 progress if just assigned on the final tick.
+      if (t?.status === "in_progress") {
+        expect(
+          t.work_progress,
+          `Dwarf ${d.name} stuck on in_progress task ${t.task_type} with 0 work done`,
+        ).toBeGreaterThan(0);
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 1: Mine-and-Build Corridor
+// ---------------------------------------------------------------------------
+
+describe("Scenario 1: Mine-and-Build Corridor", () => {
+  it("dwarf mines a corridor and builds walls on both sides without walling itself in", async () => {
+    const dwarf = makeDwarf({ position_x: 1, position_y: 5, position_z: 0, ...highNeeds() });
+    const miningSkill = makeSkill(dwarf.id, "mining", 1);
+    const buildSkill = makeSkill(dwarf.id, "building", 1);
+
+    // Map layout:
+    //   Y=4: rock at X=2..6 (north wall)
+    //   Y=5: rock at X=2..6 (corridor to mine)
+    //   Y=6: rock at X=2..6 (south wall)
+    //   Grass elsewhere for movement
+    const tiles: FortressTile[] = [];
+
+    // Open grass rows for the dwarf to walk around
+    for (let x = 0; x <= 8; x++) {
+      for (let y = 3; y <= 7; y++) {
+        tiles.push(grassTile(x, y));
+      }
+    }
+    // Overwrite the rock tiles (rock is walkable per WALKABLE_TILES, but mine tasks target it)
+    for (let x = 2; x <= 6; x++) {
+      tiles.push(rockTile(x, 4)); // north wall
+      tiles.push(rockTile(x, 5)); // corridor to mine
+      tiles.push(rockTile(x, 6)); // south wall
+    }
+
+    // Mine tasks for corridor (priority 10)
+    const mineTasks = [2, 3, 4, 5, 6].map(x =>
+      makeTask("mine", {
+        status: "pending",
+        priority: 10,
+        target_x: x, target_y: 5, target_z: 0,
+        work_required: WORK_MINE_BASE,
+      }),
+    );
+
+    // Build wall tasks for north side (priority 5, after mining)
+    const buildNorthTasks = [2, 3, 4, 5, 6].map(x =>
+      makeTask("build_wall", {
+        status: "pending",
+        priority: 5,
+        target_x: x, target_y: 4, target_z: 0,
+        work_required: WORK_BUILD_WALL,
+      }),
+    );
+
+    // Build wall tasks for south side (priority 5)
+    const buildSouthTasks = [2, 3, 4, 5, 6].map(x =>
+      makeTask("build_wall", {
+        status: "pending",
+        priority: 5,
+        target_x: x, target_y: 6, target_z: 0,
+        work_required: WORK_BUILD_WALL,
+      }),
+    );
+
+    // Pre-place 10 stone blocks near the dwarf
+    const items: Item[] = [
+      ...suppressDrinks(),
+      ...Array.from({ length: 10 }, (_, i) => stoneBlock(0, i)),
+    ];
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      dwarfSkills: [miningSkill, buildSkill],
+      tasks: [...mineTasks, ...buildNorthTasks, ...buildSouthTasks],
+      items,
+      fortressTileOverrides: tiles,
+      ticks: 1500,
+    });
+
+    // All mine tasks should complete
+    for (const t of mineTasks) {
+      const task = result.tasks.find(r => r.id === t.id);
+      expect(task?.status, `Mine task at (${t.target_x},5) should complete`).toBe("completed");
+    }
+
+    // All build tasks should complete
+    for (const t of [...buildNorthTasks, ...buildSouthTasks]) {
+      const task = result.tasks.find(r => r.id === t.id);
+      expect(task?.status, `Build task at (${t.target_x},${t.target_y}) should complete`).toBe("completed");
+    }
+
+    // Dwarf should be alive
+    expect(result.dwarves[0]?.status).toBe("alive");
+
+    assertNoDwarfStuck(result);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 2: Stockpile Hauling After Mining
+// ---------------------------------------------------------------------------
+
+describe("Scenario 2: Stockpile Hauling After Mining", () => {
+  it("dwarf mines rocks and items get hauled to stockpile", async () => {
+    const dwarf = makeDwarf({ position_x: 0, position_y: 5, position_z: 0, ...highNeeds() });
+    const miningSkill = makeSkill(dwarf.id, "mining", 1);
+
+    // Grass row at y=5, with rock at x=4,5,6
+    const tiles: FortressTile[] = [];
+    for (let x = 0; x <= 12; x++) {
+      tiles.push(grassTile(x, 5));
+    }
+    tiles.push(rockTile(4, 5));
+    tiles.push(rockTile(5, 5));
+    tiles.push(rockTile(6, 5));
+
+    const mineTasks = [4, 5, 6].map(x =>
+      makeTask("mine", {
+        status: "pending",
+        priority: 10,
+        target_x: x, target_y: 5, target_z: 0,
+        work_required: WORK_MINE_BASE,
+      }),
+    );
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      dwarfSkills: [miningSkill],
+      tasks: mineTasks,
+      items: suppressDrinks(),
+      fortressTileOverrides: tiles,
+      stockpileTiles: [makeStockpileTile(10, 5), makeStockpileTile(11, 5)],
+      ticks: 800,
+    });
+
+    // All mine tasks should complete
+    for (const t of mineTasks) {
+      const task = result.tasks.find(r => r.id === t.id);
+      expect(task?.status, `Mine task at (${t.target_x},5) should complete`).toBe("completed");
+    }
+
+    // Stone blocks should have been produced
+    const stoneBlocks = result.items.filter(
+      i => i.category === "raw_material" && i.material === "stone",
+    );
+    expect(stoneBlocks.length).toBeGreaterThanOrEqual(1);
+
+    // Some items should be at stockpile positions
+    const itemsAtStockpile = result.items.filter(
+      i => (i.position_x === 10 || i.position_x === 11) && i.position_y === 5 && i.position_z === 0,
+    );
+    expect(itemsAtStockpile.length).toBeGreaterThanOrEqual(1);
+
+    assertNoDwarfStuck(result);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 3: Walled Compound With Door
+// ---------------------------------------------------------------------------
+
+describe("Scenario 3: Walled Compound With Door", () => {
+  it("dwarf paths through door to build_floor task inside compound", async () => {
+    // Pre-built walled compound: walls at (1,4),(2,4),(4,4),(5,4) + door at (3,4)
+    // Floor task at (3,3) inside, dwarf at (3,6) outside
+    const dwarf = makeDwarf({ position_x: 3, position_y: 6, position_z: 0, ...highNeeds() });
+    const buildSkill = makeSkill(dwarf.id, "building", 1);
+
+    const tiles: FortressTile[] = [];
+
+    // Open grass area (outside and inside compound)
+    for (let x = 0; x <= 6; x++) {
+      for (let y = 2; y <= 7; y++) {
+        tiles.push(grassTile(x, y));
+      }
+    }
+
+    // Pre-built walls forming a box: row y=4, x=1..5 with door at x=3
+    tiles.push(constructedWallTile(1, 4));
+    tiles.push(constructedWallTile(2, 4));
+    tiles.push(doorTile(3, 4)); // door — walkable
+    tiles.push(constructedWallTile(4, 4));
+    tiles.push(constructedWallTile(5, 4));
+
+    const floorTask = makeTask("build_floor", {
+      status: "pending",
+      priority: 5,
+      target_x: 3, target_y: 3, target_z: 0,
+      work_required: WORK_BUILD_FLOOR,
+    });
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      dwarfSkills: [buildSkill],
+      tasks: [floorTask],
+      items: [stoneBlock(3, 6), ...suppressDrinks()],
+      fortressTileOverrides: tiles,
+      ticks: 300,
+    });
+
+    const task = result.tasks.find(r => r.id === floorTask.id);
+    expect(task?.status, "build_floor inside compound should complete").toBe("completed");
+
+    const floorTile = result.fortressTileOverrides.find(t => t.x === 3 && t.y === 3 && t.z === 0);
+    expect(floorTile?.tile_type).toBe("constructed_floor");
+
+    assertNoDwarfStuck(result);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 4: L-Shaped Mining Then Build at Far End
+// ---------------------------------------------------------------------------
+
+describe("Scenario 4: L-Shaped Mining Then Build at Far End", () => {
+  it("dwarf mines an L-shaped tunnel and builds at the far end", async () => {
+    const dwarf = makeDwarf({ position_x: 1, position_y: 3, position_z: 0, ...highNeeds() });
+    const miningSkill = makeSkill(dwarf.id, "mining", 1);
+    const buildSkill = makeSkill(dwarf.id, "building", 1);
+
+    const tiles: FortressTile[] = [];
+
+    // Open grass for movement access
+    for (let x = 0; x <= 7; x++) {
+      for (let y = 2; y <= 9; y++) {
+        tiles.push(grassTile(x, y));
+      }
+    }
+
+    // Rock forming an L: vertical at x=2 (y=3..7), horizontal at y=7 (x=3..5)
+    for (let y = 3; y <= 7; y++) {
+      tiles.push(rockTile(2, y));
+    }
+    for (let x = 3; x <= 5; x++) {
+      tiles.push(rockTile(x, 7));
+    }
+
+    // Mine vertical arm (x=2, y=3..7)
+    const mineVertical = [3, 4, 5, 6, 7].map(y =>
+      makeTask("mine", {
+        status: "pending",
+        priority: 10,
+        target_x: 2, target_y: y, target_z: 0,
+        work_required: WORK_MINE_BASE,
+      }),
+    );
+
+    // Mine horizontal arm (y=7, x=3..5)
+    const mineHorizontal = [3, 4, 5].map(x =>
+      makeTask("mine", {
+        status: "pending",
+        priority: 10,
+        target_x: x, target_y: 7, target_z: 0,
+        work_required: WORK_MINE_BASE,
+      }),
+    );
+
+    // Build wall at far end (5, 8) — south of the horizontal arm
+    const buildTask = makeTask("build_wall", {
+      status: "pending",
+      priority: 5,
+      target_x: 5, target_y: 8, target_z: 0,
+      work_required: WORK_BUILD_WALL,
+    });
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      dwarfSkills: [miningSkill, buildSkill],
+      tasks: [...mineVertical, ...mineHorizontal, buildTask],
+      items: [stoneBlock(0, 2), ...suppressDrinks()],
+      fortressTileOverrides: tiles,
+      ticks: 1500,
+    });
+
+    for (const t of [...mineVertical, ...mineHorizontal]) {
+      const task = result.tasks.find(r => r.id === t.id);
+      expect(task?.status, `Mine task at (${t.target_x},${t.target_y}) should complete`).toBe("completed");
+    }
+
+    const wall = result.tasks.find(r => r.id === buildTask.id);
+    expect(wall?.status, "build_wall at far end should complete").toBe("completed");
+
+    assertNoDwarfStuck(result);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 5: Resource Chain (Mine → Build, No Pre-placed Items)
+// ---------------------------------------------------------------------------
+
+describe("Scenario 5: Resource Chain (Mine -> Build, No Pre-placed Items)", () => {
+  it("dwarf mines a rock then uses the stone block to build a wall", async () => {
+    const dwarf = makeDwarf({ position_x: 1, position_y: 5, position_z: 0, ...highNeeds() });
+    const miningSkill = makeSkill(dwarf.id, "mining", 1);
+    const buildSkill = makeSkill(dwarf.id, "building", 1);
+
+    const tiles: FortressTile[] = [];
+    for (let x = 0; x <= 6; x++) {
+      tiles.push(grassTile(x, 5));
+    }
+    tiles.push(rockTile(2, 5)); // to be mined
+
+    const mineTask = makeTask("mine", {
+      status: "pending",
+      priority: 10,
+      target_x: 2, target_y: 5, target_z: 0,
+      work_required: WORK_MINE_BASE,
+    });
+
+    // Build wall at x=4 — needs 1 stone block (produced by mining)
+    const buildTask = makeTask("build_wall", {
+      status: "pending",
+      priority: 5,
+      target_x: 4, target_y: 5, target_z: 0,
+      work_required: WORK_BUILD_WALL,
+    });
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      dwarfSkills: [miningSkill, buildSkill],
+      tasks: [mineTask, buildTask],
+      items: [...suppressDrinks(), ...suppressAutocook()], // no pre-placed stone — mine must produce it
+      fortressTileOverrides: tiles,
+      ticks: 500,
+    });
+
+    // Mine must finish first
+    const mine = result.tasks.find(r => r.id === mineTask.id);
+    expect(mine?.status, "mine task should complete").toBe("completed");
+
+    // Build should then complete using the produced stone.
+    // BUG: This currently FAILS. The mined stone block is picked up by the dwarf
+    // (held_by_dwarf_id = dwarf.id), but consumeResources() only counts items
+    // where held_by_dwarf_id === null. So the dwarf cannot use the stone it is
+    // carrying to satisfy the build_wall resource cost. The task stays pending
+    // forever — a real stuck-dwarf bug.
+    const build = result.tasks.find(r => r.id === buildTask.id);
+    expect(build?.status, "build_wall should complete after mining provides stone").toBe("completed");
+
+    // Confirm a constructed_wall tile exists at (4,5)
+    const wallTile = result.fortressTileOverrides.find(t => t.x === 4 && t.y === 5 && t.z === 0);
+    expect(wallTile?.tile_type).toBe("constructed_wall");
+
+    assertNoDwarfStuck(result);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 6: Crowded Workspace (4 Dwarves)
+// ---------------------------------------------------------------------------
+
+describe("Scenario 6: Crowded Workspace (4 Dwarves)", () => {
+  it("4 dwarves complete mining and building tasks without deadlocking", async () => {
+    // 10×10 grass grid, rocks at (5,2),(6,2),(7,2)
+    const dwarves = [
+      makeDwarf({ position_x: 3, position_y: 2, position_z: 0, name: "Urist", ...highNeeds() }),
+      makeDwarf({ position_x: 3, position_y: 3, position_z: 0, name: "Bomrek", ...highNeeds() }),
+      makeDwarf({ position_x: 3, position_y: 4, position_z: 0, name: "Kadol", ...highNeeds() }),
+      makeDwarf({ position_x: 3, position_y: 5, position_z: 0, name: "Doren", ...highNeeds() }),
+    ];
+    const skills = dwarves.flatMap(d => [
+      makeSkill(d.id, "mining", 1),
+      makeSkill(d.id, "building", 1),
+    ]);
+
+    const tiles: FortressTile[] = [];
+    for (let x = 0; x <= 10; x++) {
+      for (let y = 0; y <= 10; y++) {
+        tiles.push(grassTile(x, y));
+      }
+    }
+    tiles.push(rockTile(5, 2));
+    tiles.push(rockTile(6, 2));
+    tiles.push(rockTile(7, 2));
+
+    const mineTasks = [5, 6, 7].map(x =>
+      makeTask("mine", {
+        status: "pending",
+        priority: 10,
+        target_x: x, target_y: 2, target_z: 0,
+        work_required: WORK_MINE_BASE,
+      }),
+    );
+
+    // Build walls at (5,0) and (7,0) — away from the mine sites so dwarves need to walk
+    const buildTasks = [5, 7].map(x =>
+      makeTask("build_wall", {
+        status: "pending",
+        priority: 5,
+        target_x: x, target_y: 0, target_z: 0,
+        work_required: WORK_BUILD_WALL,
+      }),
+    );
+
+    const result = await runScenario({
+      dwarves,
+      dwarfSkills: skills,
+      tasks: [...mineTasks, ...buildTasks],
+      items: [
+        stoneBlock(0, 0), stoneBlock(1, 0),
+        ...suppressDrinks(),
+        ...suppressAutocook(),
+      ],
+      fortressTileOverrides: tiles,
+      ticks: 1200,
+    });
+
+    // All mine tasks must complete
+    for (const t of mineTasks) {
+      const task = result.tasks.find(r => r.id === t.id);
+      expect(task?.status, `Mine at (${t.target_x},2) should complete`).toBe("completed");
+    }
+
+    // At least 1 build task must complete (2 dwarves + 2 tasks — may compete)
+    const completedBuilds = buildTasks.filter(t =>
+      result.tasks.find(r => r.id === t.id)?.status === "completed",
+    );
+    expect(completedBuilds.length).toBeGreaterThanOrEqual(1);
+
+    // All dwarves must be alive
+    for (const d of result.dwarves) {
+      expect(d.status, `Dwarf ${d.name} should be alive`).toBe("alive");
+    }
+
+    assertNoDwarfStuck(result);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 7: Build Walls Then Door, Path Through
+// ---------------------------------------------------------------------------
+
+describe("Scenario 7: Build Walls Then Door, Path Through", () => {
+  it("dwarf builds a wall+door barrier and then builds floor on the other side", async () => {
+    // Dwarf at (0,5). Build walls at (1,4),(2,4),(4,4),(5,4), door at (3,4),
+    // then build_floor at (3,3) inside.
+    const dwarf = makeDwarf({ position_x: 0, position_y: 5, position_z: 0, ...highNeeds() });
+    const buildSkill = makeSkill(dwarf.id, "building", 1);
+
+    const tiles: FortressTile[] = [];
+    for (let x = 0; x <= 7; x++) {
+      for (let y = 2; y <= 7; y++) {
+        tiles.push(grassTile(x, y));
+      }
+    }
+
+    // Wall tasks (priority 10)
+    const wallTasks = [1, 2, 4, 5].map(x =>
+      makeTask("build_wall", {
+        status: "pending",
+        priority: 10,
+        target_x: x, target_y: 4, target_z: 0,
+        work_required: WORK_BUILD_WALL,
+      }),
+    );
+
+    // Door task (priority 8)
+    const doorTask = makeTask("build_door", {
+      status: "pending",
+      priority: 8,
+      target_x: 3, target_y: 4, target_z: 0,
+      work_required: WORK_BUILD_DOOR,
+    });
+
+    // Floor task inside (priority 5)
+    const floorTask = makeTask("build_floor", {
+      status: "pending",
+      priority: 5,
+      target_x: 3, target_y: 3, target_z: 0,
+      work_required: WORK_BUILD_FLOOR,
+    });
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      dwarfSkills: [buildSkill],
+      tasks: [...wallTasks, doorTask, floorTask],
+      items: [
+        // 4 walls need 4 stone, door needs 1 wood, floor needs 1 stone = 5 stone + 1 wood
+        stoneBlock(0, 5), stoneBlock(0, 5), stoneBlock(0, 5),
+        stoneBlock(0, 5), stoneBlock(0, 5),
+        woodLog(0, 5),
+        ...suppressDrinks(),
+      ],
+      fortressTileOverrides: tiles,
+      ticks: 600,
+    });
+
+    // All wall tasks should complete
+    for (const t of wallTasks) {
+      const task = result.tasks.find(r => r.id === t.id);
+      expect(task?.status, `Wall at (${t.target_x},4) should complete`).toBe("completed");
+    }
+
+    // Door should complete
+    const door = result.tasks.find(r => r.id === doorTask.id);
+    expect(door?.status, "build_door should complete").toBe("completed");
+
+    // Floor task (inside) should complete — dwarf must path through door
+    const floor = result.tasks.find(r => r.id === floorTask.id);
+    expect(floor?.status, "build_floor inside compound should complete (dwarf pathed through door)").toBe("completed");
+
+    // Verify floor tile placed
+    const floorTile = result.fortressTileOverrides.find(t => t.x === 3 && t.y === 3 && t.z === 0);
+    expect(floorTile?.tile_type).toBe("constructed_floor");
+
+    assertNoDwarfStuck(result);
+  });
+});

--- a/sim/src/phases/job-claiming.ts
+++ b/sim/src/phases/job-claiming.ts
@@ -55,8 +55,8 @@ export async function jobClaiming(ctx: SimContext): Promise<void> {
         continue;
       }
 
-      // Skip build tasks when resources are unavailable
-      if (!hasResources(task.task_type, state.items, ctx.civilizationId)) {
+      // Skip build tasks when resources are unavailable (include dwarf's held items)
+      if (!hasResources(task.task_type, state.items, ctx.civilizationId, dwarf.id)) {
         continue;
       }
 

--- a/sim/src/phases/task-completion.ts
+++ b/sim/src/phases/task-completion.ts
@@ -48,19 +48,19 @@ export function completeTask(dwarf: Dwarf, task: Task, ctx: SimContext): void {
   switch (task.task_type) {
     case 'build_wall':
     case 'build_floor':
-      buildSuccess = completeBuild(task, ctx);
+      buildSuccess = completeBuild(task, ctx, dwarf.id);
       break;
     case 'build_bed':
-      buildSuccess = completeBuildBed(task, ctx);
+      buildSuccess = completeBuildBed(task, ctx, dwarf.id);
       break;
     case 'build_well':
-      buildSuccess = completeBuildStructure(task, ctx, 'well', 'well');
+      buildSuccess = completeBuildStructure(task, ctx, 'well', 'well', dwarf.id);
       break;
     case 'build_mushroom_garden':
-      buildSuccess = completeBuildStructure(task, ctx, 'mushroom_garden', 'mushroom_garden');
+      buildSuccess = completeBuildStructure(task, ctx, 'mushroom_garden', 'mushroom_garden', dwarf.id);
       break;
     case 'build_door':
-      buildSuccess = completeBuildStructure(task, ctx, 'door', 'door');
+      buildSuccess = completeBuildStructure(task, ctx, 'door', 'door', dwarf.id);
       break;
   }
 
@@ -315,13 +315,13 @@ export function getMineProduct(tileType: string | null): {
   }
 }
 
-function completeBuild(task: Task, ctx: SimContext): boolean {
+function completeBuild(task: Task, ctx: SimContext, builderId: string): boolean {
   if (task.target_x === null || task.target_y === null || task.target_z === null) return false;
 
   const tileType = BUILD_TILE_MAP[task.task_type];
   if (!tileType) return false;
 
-  if (!consumeResources(task.task_type, ctx)) return false;
+  if (!consumeResources(task.task_type, ctx, builderId)) return false;
 
   upsertFortressTile(ctx, task.target_x, task.target_y, task.target_z, tileType, 'stone', false);
   return true;
@@ -480,10 +480,10 @@ function completeSleep(dwarf: Dwarf, task: Task, ctx: SimContext): void {
   ctx.state.dirtyDwarfIds.add(dwarf.id);
 }
 
-function completeBuildBed(task: Task, ctx: SimContext): boolean {
+function completeBuildBed(task: Task, ctx: SimContext, builderId: string): boolean {
   if (task.target_x === null || task.target_y === null || task.target_z === null) return false;
 
-  if (!consumeResources(task.task_type, ctx)) return false;
+  if (!consumeResources(task.task_type, ctx, builderId)) return false;
 
   const bed: Structure = {
     id: ctx.rng.uuid(),
@@ -518,10 +518,11 @@ function completeBuildStructure(
   ctx: SimContext,
   structureType: string,
   tileType: FortressTileType,
+  builderId?: string,
 ): boolean {
   if (task.target_x === null || task.target_y === null || task.target_z === null) return false;
 
-  if (!consumeResources(task.task_type, ctx)) return false;
+  if (!consumeResources(task.task_type, ctx, builderId)) return false;
 
   const structure: Structure = {
     id: ctx.rng.uuid(),

--- a/sim/src/resource-check.ts
+++ b/sim/src/resource-check.ts
@@ -4,13 +4,14 @@ import type { SimContext } from "./sim-context.js";
 
 /**
  * Checks whether the fortress has enough resources to pay for a build task.
+ * When `includeDwarfId` is provided, items held by that dwarf also count.
  */
-export function hasResources(taskType: string, items: readonly Item[], civId: string): boolean {
+export function hasResources(taskType: string, items: readonly Item[], civId: string, includeDwarfId?: string): boolean {
   const costs = BUILDING_COSTS[taskType];
   if (!costs) return true; // no cost defined = free
 
   for (const cost of costs) {
-    const available = countAvailableItems(items, civId, cost.category, cost.material);
+    const available = countAvailableItems(items, civId, cost.category, cost.material, includeDwarfId);
     if (available < cost.count) return false;
   }
   return true;
@@ -19,19 +20,27 @@ export function hasResources(taskType: string, items: readonly Item[], civId: st
 /**
  * Consumes resources for a build task. Returns true if successful, false if
  * insufficient resources (no items are consumed in that case).
+ *
+ * When `builderId` is provided, items held by that dwarf also count as
+ * available. This prevents the "mine-then-build" deadlock where a dwarf
+ * picks up a stone block and then can't use it to build.
  */
-export function consumeResources(taskType: string, ctx: SimContext): boolean {
+export function consumeResources(taskType: string, ctx: SimContext, builderId?: string): boolean {
   const costs = BUILDING_COSTS[taskType];
   if (!costs) return true;
 
   const { state } = ctx;
 
-  // First pass: verify all costs can be met
-  if (!hasResources(taskType, state.items, ctx.civilizationId)) return false;
+  // First pass: verify all costs can be met (include builder's inventory)
+  for (const cost of costs) {
+    const available = countAvailableItems(state.items, ctx.civilizationId, cost.category, cost.material, builderId);
+    if (available < cost.count) return false;
+  }
 
-  // Second pass: consume items
+  // Second pass: consume items (prefer ground items, then builder's held items)
   for (const cost of costs) {
     let remaining = cost.count;
+    // First consume ground items
     for (let i = state.items.length - 1; i >= 0 && remaining > 0; i--) {
       const item = state.items[i];
       if (
@@ -44,6 +53,21 @@ export function consumeResources(taskType: string, ctx: SimContext): boolean {
         remaining--;
       }
     }
+    // Then consume builder's held items if still needed
+    if (remaining > 0 && builderId) {
+      for (let i = state.items.length - 1; i >= 0 && remaining > 0; i--) {
+        const item = state.items[i];
+        if (
+          item.category === cost.category &&
+          item.material === cost.material &&
+          item.located_in_civ_id === ctx.civilizationId &&
+          item.held_by_dwarf_id === builderId
+        ) {
+          state.items.splice(i, 1);
+          remaining--;
+        }
+      }
+    }
   }
 
   return true;
@@ -52,6 +76,7 @@ export function consumeResources(taskType: string, ctx: SimContext): boolean {
 /**
  * Counts items in the fortress matching the given category and material
  * that are not held by a dwarf (i.e., on the ground or in stockpiles).
+ * When `includeDwarfId` is provided, items held by that dwarf also count.
  * Exported for use in the app to show resource availability.
  */
 export function countAvailableItems(
@@ -59,6 +84,7 @@ export function countAvailableItems(
   civId: string,
   category: string,
   material: string,
+  includeDwarfId?: string,
 ): number {
   let count = 0;
   for (const item of items) {
@@ -66,7 +92,7 @@ export function countAvailableItems(
       item.category === category &&
       item.material === material &&
       item.located_in_civ_id === civId &&
-      item.held_by_dwarf_id === null
+      (item.held_by_dwarf_id === null || item.held_by_dwarf_id === includeDwarfId)
     ) {
       count++;
     }


### PR DESCRIPTION
## Summary
- Fixed `consumeResources()` and `hasResources()` to count items held by the building dwarf, not just ground items. This caused a mine→build deadlock where dwarves pick up mined stone and then can't use it to build.
- Added 7 complex scenario tests covering: mine-and-build corridors, stockpile hauling, walled compounds with doors, L-shaped mining, resource chains, crowded workspaces, and wall+door construction.
- Includes headless playtest report documenting additional bugs found.

## Test plan
- [x] All 7 new stuck-dwarf scenario tests pass
- [x] Existing building-costs test updated to reflect correct behavior
- [x] Full sim test suite passes (749 tests)
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)