### PR TITLE
fix: remove redundant getSession() to eliminate auth lock contention

### DIFF
--- a/app/src/hooks/useAuth.ts
+++ b/app/src/hooks/useAuth.ts
@@ -7,29 +7,27 @@ export function useAuth() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const timeout = new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error("timeout")), 5000),
-    );
-
-    Promise.race([supabase.auth.getSession(), timeout])
-      .then(({ data: { session: s } }) => {
-        setSession(s);
-      })
-      .catch(() => {
-        // getSession hung or failed — show login screen
-        setSession(null);
-      })
-      .finally(() => {
-        setLoading(false);
-      });
+    // onAuthStateChange fires INITIAL_SESSION synchronously with the current
+    // session, so a separate getSession() call is unnecessary and causes lock
+    // contention in @supabase/auth-js (the "lock not released within 5000ms"
+    // warning).  A safety timeout ensures we still show the login screen if
+    // the initial event never arrives.
+    const timer = setTimeout(() => {
+      setLoading(false); // show login screen on timeout
+    }, 5000);
 
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((_event, s) => {
+      clearTimeout(timer);
       setSession(s);
+      setLoading(false);
     });
 
-    return () => subscription.unsubscribe();
+    return () => {
+      clearTimeout(timer);
+      subscription.unsubscribe();
+    };
   }, []);
 
   const signIn = useCallback(async (email: string, password: string) => {


### PR DESCRIPTION
## Summary
- Remove redundant `getSession()` call from `useAuth` that caused lock contention with `onAuthStateChange()` in `@supabase/auth-js`
- `onAuthStateChange` already fires `INITIAL_SESSION` with the current session, making the separate call unnecessary
- Eliminates the "lock not released within 5000ms" warning (seen 641+ times per session in production)

Closes #647

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (945 tests)
- [ ] Deploy and verify no more lock warnings in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Claude Cost
**Claude cost:** $1.54 (1.7M tokens)