### PR TITLE
feat: add cave scout confirmation modal

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -23,6 +23,7 @@ import BuildMenu, { BUILD_OPTIONS } from "./components/BuildMenu";
 import TaskPriorities from "./components/TaskPriorities";
 import { DwarfModal } from "./components/DwarfModal";
 import { InventoryModal } from "./components/InventoryModal";
+import { CaveScoutModal } from "./components/CaveScoutModal";
 import { EpitaphScreen } from "./components/EpitaphScreen";
 import { TutorialOverlay } from "./components/TutorialOverlay";
 import { useTutorial } from "./hooks/useTutorial";
@@ -406,6 +407,29 @@ export default function App() {
     setFollowedDwarfId(dwarf.id);
   }, []);
 
+  // Cave scout modal state
+  const [caveScoutModal, setCaveScoutModal] = useState<{
+    caveName: string;
+    alreadyScouting: boolean;
+    entranceX: number;
+    entranceY: number;
+  } | null>(null);
+
+  const handleConfirmScout = useCallback(() => {
+    if (!caveScoutModal || caveScoutModal.alreadyScouting || !world.civId) return;
+    void supabase.from('tasks').insert({
+      civilization_id: world.civId,
+      task_type: 'scout_cave',
+      status: 'pending',
+      priority: 5,
+      target_x: caveScoutModal.entranceX,
+      target_y: caveScoutModal.entranceY,
+      target_z: 0,
+      work_required: WORK_SCOUT_CAVE,
+    });
+    setCaveScoutModal(null);
+  }, [caveScoutModal, world.civId]);
+
   // Handle clicking a cave entrance tile — scout or enter
   const handleFortressTileClick = useCallback((x: number, y: number) => {
     setSelectedFortressTile({ x, y });
@@ -436,27 +460,17 @@ export default function App() {
         center - Math.floor(vpRows / 2),
       );
     } else {
-      // Check if there's already a scout task for this entrance
+      // Show confirmation modal instead of directly creating the task
+      const caveName = deriver.getCaveName(caveZ) ?? "Unknown Cave";
       const alreadyScouting = liveTasks.some(
         t => t.task_type === 'scout_cave'
           && t.target_x === x
           && t.target_y === y
           && ['pending', 'claimed', 'in_progress'].includes(t.status),
       );
-      if (!alreadyScouting && world.civId) {
-        void supabase.from('tasks').insert({
-          civilization_id: world.civId,
-          task_type: 'scout_cave',
-          status: 'pending',
-          priority: 5,
-          target_x: x,
-          target_y: y,
-          target_z: 0,
-          work_required: WORK_SCOUT_CAVE,
-        });
-      }
+      setCaveScoutModal({ caveName, alreadyScouting, entranceX: x, entranceY: y });
     }
-  }, [zLevel, getFortressTile, getFortressTileResult.deriver, snapshot?.fortressTileOverrides, liveTasks, world.civId, viewport, vpCols, vpRows]);
+  }, [zLevel, getFortressTile, getFortressTileResult.deriver, snapshot?.fortressTileOverrides, liveTasks, viewport, vpCols, vpRows]);
 
   // Dwarf info modal
   const [modalDwarfId, setModalDwarfId] = useState<string | null>(null);
@@ -662,6 +676,15 @@ export default function App() {
             onGoTo={handleGoToDwarf}
             items={liveItems}
             tasks={liveTasks}
+          />
+        )}
+
+        {caveScoutModal && (
+          <CaveScoutModal
+            caveName={caveScoutModal.caveName}
+            alreadyScouting={caveScoutModal.alreadyScouting}
+            onScout={handleConfirmScout}
+            onClose={() => setCaveScoutModal(null)}
           />
         )}
 

--- a/app/src/components/CaveScoutModal.tsx
+++ b/app/src/components/CaveScoutModal.tsx
@@ -1,0 +1,62 @@
+import { useEffect } from "react";
+
+interface CaveScoutModalProps {
+  caveName: string;
+  alreadyScouting: boolean;
+  onScout: () => void;
+  onClose: () => void;
+}
+
+export function CaveScoutModal({ caveName, alreadyScouting, onScout, onClose }: CaveScoutModalProps) {
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+      if (e.key === "Enter" && !alreadyScouting) onScout();
+    }
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [onClose, onScout, alreadyScouting]);
+
+  return (
+    <div
+      className="absolute inset-0 z-50 flex items-center justify-center"
+      onClick={onClose}
+    >
+      <div
+        className="bg-[var(--bg-panel)] border border-[var(--amber)] p-4 min-w-[260px] max-w-[320px] text-xs"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="text-[var(--green)] font-bold text-sm mb-2">
+          {caveName}
+        </h2>
+
+        {alreadyScouting ? (
+          <p className="text-[var(--text)] mb-3">
+            A dwarf is already scouting this entrance.
+          </p>
+        ) : (
+          <p className="text-[var(--text)] mb-3">
+            Send a dwarf to scout this cave entrance?
+          </p>
+        )}
+
+        <div className="flex justify-end gap-2">
+          {!alreadyScouting && (
+            <button
+              onClick={onScout}
+              className="px-3 py-1 border border-[var(--green)] text-[var(--green)] hover:bg-[var(--green)] hover:text-[var(--bg-panel)] cursor-pointer"
+            >
+              Scout
+            </button>
+          )}
+          <button
+            onClick={onClose}
+            className="px-3 py-1 border border-[var(--text)] text-[var(--text)] hover:text-[var(--amber)] hover:border-[var(--amber)] cursor-pointer"
+          >
+            {alreadyScouting ? "OK" : "Cancel"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #649

## Summary
- Clicking an undiscovered cave entrance now shows a confirmation modal with the cave name and Scout/Cancel buttons
- If a scout task already exists for that entrance, the modal shows "A dwarf is already scouting this entrance" with an OK button
- Supports Enter to confirm and Escape to dismiss
- **Bugfix:** Fixed `operator does not exist: task_type ~~ unknown` error when deconstructing — replaced `.like('task_type', 'build_%')` with `.in('task_type', BUILD_TASK_TYPES)` since `task_type` is a Postgres enum

## Test plan
- [ ] Click undiscovered cave entrance — modal appears with cave name
- [ ] Click Scout — task created, modal closes
- [ ] Click Cancel or press Escape — modal dismissed, no task
- [ ] Click entrance with existing scout task — shows "already scouting" message
- [ ] Deconstruct mode cancels pending build tasks without error
- [ ] `npm run build` passes, `npm test` passes (945 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Claude Cost
**Claude cost:** $1.79 (1.7M tokens)