### PR TITLE
fix: prevent wrong dwarf from claiming haul tasks for held items (closes #658)

### DIFF
--- a/sim/src/phases/job-claiming.ts
+++ b/sim/src/phases/job-claiming.ts
@@ -55,6 +55,14 @@ export async function jobClaiming(ctx: SimContext): Promise<void> {
         continue;
       }
 
+      // Haul tasks for held items can only be claimed by the holding dwarf
+      if (task.task_type === 'haul' && task.target_item_id) {
+        const haulItem = state.items.find(i => i.id === task.target_item_id);
+        if (haulItem && haulItem.held_by_dwarf_id !== null && haulItem.held_by_dwarf_id !== dwarf.id) {
+          continue;
+        }
+      }
+
       // Skip build tasks when resources are unavailable (include dwarf's held items)
       if (!hasResources(task.task_type, state.items, ctx.civilizationId, dwarf.id)) {
         continue;


### PR DESCRIPTION
## Summary
- Dwarves were getting stuck at haul 0% when trying to place items in stockpiles
- Root cause: when a haul task is created for an item held by dwarf A, dwarf B (closer to the stockpile) could claim it, immediately fail, and the task would cycle endlessly at 0%
- Fix: in `jobClaiming`, skip haul tasks where the target item is held by a different dwarf — only the holding dwarf can claim such tasks

## Test plan
- [x] All 857 sim tests pass
- [x] `npm run build` passes
- [ ] Verify in-game that dwarves successfully haul held items to stockpiles without getting stuck

🤖 Generated with [Claude Code](https://claude.com/claude-code)