### PR TITLE
fix: prevent dwarf oscillation between two tiles

### DIFF
--- a/sim/src/__tests__/oscillation-scenario.test.ts
+++ b/sim/src/__tests__/oscillation-scenario.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from "vitest";
+import { runScenario } from "../run-scenario.js";
+import { makeDwarf, makeTask, makeMapTile, makeItem } from "./test-helpers.js";
+import type { FortressDeriver } from "@pwarf/shared";
+
+/** A deriver that returns walls everywhere — only overrides are walkable. */
+function wallDeriver(): FortressDeriver {
+  return {
+    deriveTile: () => ({ tileType: 'constructed_wall' as any, material: 'stone', isMined: false }),
+    baseTileType: 'constructed_wall' as any,
+    getZForEntrance: () => null,
+    getEntranceForZ: () => null,
+    getCaveName: () => null,
+  } as any;
+}
+
+describe("dwarf oscillation prevention", () => {
+  it("dwarf in a narrow corridor with a blocker does not ping-pong", async () => {
+    // Corridor: (0,0) → (1,0) → (2,0) → (3,0) → (4,0)
+    // Dwarf A at (0,0) needs to reach (4,0)
+    // Dwarf B (sleeping) blocks at (2,0) and won't move
+    //
+    // Without the fix, A would oscillate between (1,0) and (0,0):
+    //   tick 1: A moves to (1,0). Next step (2,0) blocked, alt goes back to (0,0)
+    //   tick 2: A at (0,0), BFS says go to (1,0). Moves.
+    //   tick 3: same as tick 1 — oscillation
+    //
+    // With the fix, A detects the back-step and waits instead. After
+    // MAX_OCCUPANCY_WAIT_TICKS (10), the task fails and gets reassigned.
+
+    const dwarfA = makeDwarf({
+      position_x: 0,
+      position_y: 0,
+      position_z: 0,
+      need_food: 100,
+      need_drink: 100,
+      need_sleep: 100,
+    });
+
+    // Blocker dwarf doing a long sleep task — will not move
+    const sleepTask = makeTask("sleep", {
+      status: "in_progress",
+      target_x: 2,
+      target_y: 0,
+      target_z: 0,
+      work_required: 600,
+      work_progress: 0,
+    });
+    const dwarfB = makeDwarf({
+      position_x: 2,
+      position_y: 0,
+      position_z: 0,
+      need_food: 100,
+      need_drink: 100,
+      need_sleep: 10,
+      current_task_id: sleepTask.id,
+    });
+    sleepTask.assigned_dwarf_id = dwarfB.id;
+
+    const farmTask = makeTask("farm_till", {
+      status: "pending",
+      target_x: 4,
+      target_y: 0,
+      target_z: 0,
+      work_required: 100,
+      work_progress: 0,
+    });
+
+    // Place food/drink so autonomous tasks don't interfere
+    const food = makeItem({ category: "food", position_x: 0, position_y: 0, position_z: 0 });
+    const drink = makeItem({ category: "drink", name: "Water", position_x: 0, position_y: 0, position_z: 0 });
+
+    // Narrow corridor tiles
+    const tiles = [];
+    for (let x = 0; x <= 4; x++) {
+      tiles.push(makeMapTile(x, 0, 0, "open_air"));
+    }
+
+    const result = await runScenario({
+      dwarves: [dwarfA, dwarfB],
+      tasks: [sleepTask, farmTask],
+      items: [food, drink],
+      fortressTileOverrides: tiles,
+      fortressDeriver: wallDeriver(),
+      ticks: 30,
+    });
+
+    // Track dwarf A's position history
+    const finalA = result.dwarves.find(d => d.name === dwarfA.name)!;
+
+    // The key assertion: dwarf A should NOT be stuck oscillating between (0,0)
+    // and (1,0). With the fix, A either waits in place (and eventually the task
+    // fails after 10 wait ticks), or advances once the blocker moves.
+    // After 30 ticks, if A were oscillating, it would still be at (0,0) or (1,0)
+    // with 0 task progress. With the fix, the farm task should have failed and
+    // been released (since the blocker won't move for 600 ticks).
+    const farmTaskResult = result.tasks.find(t => t.task_type === "farm_till")!;
+
+    // The task should not still be in_progress with 0 progress after 30 ticks.
+    // Either it was released (pending, no assignee) or the dwarf found a way.
+    if (farmTaskResult.status === "in_progress") {
+      // If still in progress, it should have made actual work progress
+      expect(farmTaskResult.work_progress).toBeGreaterThan(0);
+    }
+
+    // Verify no oscillation: dwarf A should not be flip-flopping.
+    // It should be at a stable position (either waiting at 1,0 or back at 0,0
+    // after the task was released, not randomly switching each tick).
+    expect(finalA.position_x).toBeLessThanOrEqual(1);
+  });
+
+  it("dwarf advances normally when path is clear (no false positive)", async () => {
+    // Simple corridor, no blocker — dwarf should walk to target and complete work.
+    // Pre-assign the task to skip jobClaiming timing issues.
+    const task = makeTask("farm_till", {
+      status: "claimed",
+      target_x: 3,
+      target_y: 0,
+      target_z: 0,
+      work_required: 5,
+      work_progress: 0,
+    });
+
+    const dwarf = makeDwarf({
+      position_x: 0,
+      position_y: 0,
+      position_z: 0,
+      need_food: 100,
+      need_drink: 100,
+      need_sleep: 100,
+      current_task_id: task.id,
+    });
+    task.assigned_dwarf_id = dwarf.id;
+
+    const food = makeItem({ category: "food", position_x: 0, position_y: 0, position_z: 0 });
+    const drink = makeItem({ category: "drink", name: "Water", position_x: 0, position_y: 0, position_z: 0 });
+
+    const tiles = [];
+    for (let x = 0; x <= 3; x++) {
+      tiles.push(makeMapTile(x, 0, 0, "open_air"));
+    }
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      tasks: [task],
+      items: [food, drink],
+      fortressTileOverrides: tiles,
+      fortressDeriver: wallDeriver(),
+      ticks: 20,
+    });
+
+    // Task should be completed — dwarf walked 3 tiles then did 5 work
+    const farmTask = result.tasks.find(t => t.task_type === "farm_till")!;
+    expect(farmTask.status).toBe("completed");
+  });
+});

--- a/sim/src/phases/task-execution.test.ts
+++ b/sim/src/phases/task-execution.test.ts
@@ -521,4 +521,98 @@ describe("taskExecution", () => {
       expect(soilTask.work_progress).toBeGreaterThan(stoneTask.work_progress);
     });
   });
+
+  describe("anti-oscillation", () => {
+    it("prevents a dwarf from oscillating via alt-path backtracking", async () => {
+      // Narrow 1-wide corridor: (0,0) → (1,0) → (2,0) → (3,0)
+      // Everything else is wall. Dwarf at (1,0), blocker at (2,0), task at (3,0).
+      // Primary BFS says go to (2,0), but it's occupied. Alt BFS can only
+      // route back to (0,0). With anti-oscillation: dwarf waits instead.
+      const blocker = makeDwarf({
+        position_x: 2,
+        position_y: 0,
+        position_z: 0,
+      });
+
+      const task = makeTask("farm_till", {
+        status: "in_progress",
+        target_x: 3,
+        target_y: 0,
+        target_z: 0,
+        work_required: 100,
+        work_progress: 0,
+      });
+
+      const dwarf = makeDwarf({
+        current_task_id: task.id,
+        position_x: 1,
+        position_y: 0,
+        position_z: 0,
+      });
+      task.assigned_dwarf_id = dwarf.id;
+
+      const ctx = makeContext({ dwarves: [dwarf, blocker], tasks: [task] });
+
+      // Use a deriver that returns walls everywhere — only overrides are walkable
+      ctx.fortressDeriver = {
+        deriveTile: () => ({ tileType: 'constructed_wall' as const, material: 'stone', isMined: false }),
+        baseTileType: 'constructed_wall' as any,
+        getZForEntrance: () => null,
+        getEntranceForZ: () => null,
+        getCaveName: () => null,
+      } as any;
+
+      // Only the corridor tiles are walkable
+      for (let x = 0; x <= 3; x++) {
+        ctx.state.fortressTileOverrides.set(`${x},0,0`, makeMapTile(x, 0, 0, "open_air"));
+      }
+
+      // Simulate that the dwarf previously came from (0,0)
+      ctx.state._previousPositions = new Map();
+      ctx.state._previousPositions.set(dwarf.id, "0,0,0");
+
+      await taskExecution(ctx);
+
+      // The dwarf should NOT have moved back to (0,0) — should stay at (1,0)
+      expect(dwarf.position_x).toBe(1);
+      expect(dwarf.position_y).toBe(0);
+
+      // Occupancy wait counter should have incremented
+      expect(ctx.state._occupancyWaitTicks?.get(dwarf.id)).toBe(1);
+    });
+
+    it("records previous position on successful movement", async () => {
+      const task = makeTask("farm_till", {
+        status: "in_progress",
+        target_x: 3,
+        target_y: 0,
+        target_z: 0,
+        work_required: 100,
+        work_progress: 0,
+      });
+
+      const dwarf = makeDwarf({
+        current_task_id: task.id,
+        position_x: 0,
+        position_y: 0,
+        position_z: 0,
+      });
+      task.assigned_dwarf_id = dwarf.id;
+
+      const ctx = makeContext({ dwarves: [dwarf], tasks: [task] });
+
+      // Set up walkable corridor
+      for (let x = 0; x <= 3; x++) {
+        ctx.state.fortressTileOverrides.set(`${x},0,0`, makeMapTile(x, 0, 0, "open_air"));
+      }
+
+      await taskExecution(ctx);
+
+      // Dwarf should have moved to (1,0,0)
+      expect(dwarf.position_x).toBe(1);
+
+      // Previous position should be recorded as (0,0,0)
+      expect(ctx.state._previousPositions?.get(dwarf.id)).toBe("0,0,0");
+    });
+  });
 });

--- a/sim/src/phases/task-execution.ts
+++ b/sim/src/phases/task-execution.ts
@@ -99,21 +99,28 @@ export async function taskExecution(ctx: SimContext): Promise<void> {
               }
               const finalKey = `${haulNext.x},${haulNext.y},${haulNext.z}`;
               if (!occupiedTiles.has(finalKey)) {
-                ctx.state._occupancyWaitTicks?.delete(dwarf.id);
-                const prevKey = `${dwarf.position_x},${dwarf.position_y},${dwarf.position_z}`;
-                occupiedTiles.delete(prevKey);
-                occupiedTiles.add(finalKey);
-                dwarf.position_x = haulNext.x;
-                dwarf.position_y = haulNext.y;
-                dwarf.position_z = haulNext.z;
-                state.dirtyDwarfIds.add(dwarf.id);
+                // Check anti-oscillation only when we used the alt path
+                const haulUsedAlt = nextKey !== finalKey;
+                const haulPrevPos = ctx.state._previousPositions?.get(dwarf.id);
+                if (haulUsedAlt && haulPrevPos && haulPrevPos === finalKey) {
+                  if (!incrementOccupancyWait(dwarf, ctx)) {
+                    failTask(dwarf, task, state);
+                  }
+                } else {
+                  ctx.state._occupancyWaitTicks?.delete(dwarf.id);
+                  if (!ctx.state._previousPositions) ctx.state._previousPositions = new Map();
+                  ctx.state._previousPositions.set(dwarf.id, `${dwarf.position_x},${dwarf.position_y},${dwarf.position_z}`);
+                  const prevKey = `${dwarf.position_x},${dwarf.position_y},${dwarf.position_z}`;
+                  occupiedTiles.delete(prevKey);
+                  occupiedTiles.add(finalKey);
+                  dwarf.position_x = haulNext.x;
+                  dwarf.position_y = haulNext.y;
+                  dwarf.position_z = haulNext.z;
+                  state.dirtyDwarfIds.add(dwarf.id);
+                }
               } else {
                 // Blocked by occupancy — track wait and fail after threshold
-                const waitTicks = (ctx.state._occupancyWaitTicks?.get(dwarf.id) ?? 0) + 1;
-                if (!ctx.state._occupancyWaitTicks) ctx.state._occupancyWaitTicks = new Map();
-                ctx.state._occupancyWaitTicks.set(dwarf.id, waitTicks);
-                if (waitTicks >= MAX_OCCUPANCY_WAIT_TICKS) {
-                  ctx.state._occupancyWaitTicks.delete(dwarf.id);
+                if (!incrementOccupancyWait(dwarf, ctx)) {
                   failTask(dwarf, task, state);
                 }
               }
@@ -223,32 +230,38 @@ function moveTowardTarget(dwarf: Dwarf, task: Task, ctx: SimContext, occupiedTil
 
   // If the next step is occupied, retry BFS routing around occupied tiles.
   // This prevents dwarves from waiting forever when an alternative path exists.
+  let usedAltPath = false;
   const nextKey = `${nextStep.x},${nextStep.y},${nextStep.z}`;
   if (occupiedTiles.has(nextKey)) {
     const altStep = bfsNextStep(start, goal, getTile, needsAdjacent, zResolver, occupiedTiles);
     if (altStep) {
       nextStep = altStep;
+      usedAltPath = true;
     } else {
       // All paths blocked by occupancy — track wait ticks and fail after threshold
       // so the task gets released and can be reclaimed when the area clears.
-      const waitKey = dwarf.id;
-      const waitTicks = (ctx.state._occupancyWaitTicks?.get(waitKey) ?? 0) + 1;
-      if (!ctx.state._occupancyWaitTicks) ctx.state._occupancyWaitTicks = new Map();
-      ctx.state._occupancyWaitTicks.set(waitKey, waitTicks);
-      if (waitTicks >= MAX_OCCUPANCY_WAIT_TICKS) {
-        ctx.state._occupancyWaitTicks.delete(waitKey);
-        return false; // Give up — release the task
-      }
-      return true; // Wait a bit longer
+      return incrementOccupancyWait(dwarf, ctx);
     }
   }
 
-  // Successfully moving — clear any occupancy wait counter
+  // Anti-oscillation: when using an alternate path around occupied tiles,
+  // if BFS wants to send us back to where we just were, wait instead of
+  // ping-ponging between two tiles every tick.
+  const finalKey = `${nextStep.x},${nextStep.y},${nextStep.z}`;
+  if (usedAltPath) {
+    const prevPos = ctx.state._previousPositions?.get(dwarf.id);
+    if (prevPos && prevPos === finalKey) {
+      return incrementOccupancyWait(dwarf, ctx);
+    }
+  }
+
+  // Successfully moving — clear any occupancy wait counter and record position
   ctx.state._occupancyWaitTicks?.delete(dwarf.id);
+  if (!ctx.state._previousPositions) ctx.state._previousPositions = new Map();
+  ctx.state._previousPositions.set(dwarf.id, `${dwarf.position_x},${dwarf.position_y},${dwarf.position_z}`);
 
   // Update occupancy tracking
   const prevKey = `${dwarf.position_x},${dwarf.position_y},${dwarf.position_z}`;
-  const finalKey = `${nextStep.x},${nextStep.y},${nextStep.z}`;
   occupiedTiles.delete(prevKey);
   occupiedTiles.add(finalKey);
 
@@ -304,6 +317,18 @@ export function getTileHardness(tileType: string | null): number {
     case 'cavern_wall': return HARDNESS_IGNITE; // 1.5 — slow
     default:           return HARDNESS_STONE;   // 1.0 — rock, open_air, etc.
   }
+}
+
+/** Increment the occupancy wait counter for a dwarf. Returns false (= fail task) when threshold is reached. */
+function incrementOccupancyWait(dwarf: Dwarf, ctx: SimContext): boolean {
+  const waitTicks = (ctx.state._occupancyWaitTicks?.get(dwarf.id) ?? 0) + 1;
+  if (!ctx.state._occupancyWaitTicks) ctx.state._occupancyWaitTicks = new Map();
+  ctx.state._occupancyWaitTicks.set(dwarf.id, waitTicks);
+  if (waitTicks >= MAX_OCCUPANCY_WAIT_TICKS) {
+    ctx.state._occupancyWaitTicks.delete(dwarf.id);
+    return false; // Give up — release the task
+  }
+  return true; // Wait a bit longer
 }
 
 function failTask(dwarf: Dwarf, task: Task, state: SimContext['state']): void {

--- a/sim/src/sim-context.ts
+++ b/sim/src/sim-context.ts
@@ -124,6 +124,15 @@ export interface CachedState {
    * In-memory only; not persisted.
    */
   _occupancyWaitTicks?: Map<string, number>;
+
+  /**
+   * Tracks the previous position of each dwarf (before last movement).
+   * Used to detect oscillation: if BFS suggests moving back to the previous
+   * position, we treat it as blocked instead of ping-ponging.
+   * Keyed by dwarf ID → "x,y,z".
+   * In-memory only; not persisted.
+   */
+  _previousPositions?: Map<string, string>;
 }
 
 /** Returns a fresh CachedState with empty arrays and sets. */


### PR DESCRIPTION
## Summary
- Track each dwarf's previous position in `_previousPositions` map on `CachedState`
- When the alternate BFS (routing around occupied tiles) suggests moving back to the previous position, treat it as blocked and wait instead of ping-ponging
- Only applies to occupancy-avoidance alt paths — legitimate backtracking (after completing a task) is unaffected
- Extracted `incrementOccupancyWait()` helper to deduplicate wait/fail logic

Closes #657

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (1020 tests)
- [x] New unit tests: anti-oscillation blocks backward alt-path, records previous position on move
- [x] New scenario tests: dwarf in blocked corridor waits instead of oscillating; dwarf with clear path completes task normally (no false positives)
- [x] Existing stuck-dwarf, build-deconstruct, and hauling scenarios all pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Claude Cost
**Claude cost:** $10.42 (14.7M tokens)