### PR TITLE
fix: await scout_cave task insert instead of silent fire-and-forget

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -415,9 +415,9 @@ export default function App() {
     entranceY: number;
   } | null>(null);
 
-  const handleConfirmScout = useCallback(() => {
+  const handleConfirmScout = useCallback(async () => {
     if (!caveScoutModal || caveScoutModal.alreadyScouting || !world.civId) return;
-    void supabase.from('tasks').insert({
+    const { error } = await supabase.from('tasks').insert({
       civilization_id: world.civId,
       task_type: 'scout_cave',
       status: 'pending',
@@ -427,6 +427,7 @@ export default function App() {
       target_z: 0,
       work_required: WORK_SCOUT_CAVE,
     });
+    if (error) console.error('[scout] failed to create task:', error.message);
     setCaveScoutModal(null);
   }, [caveScoutModal, world.civId]);
 


### PR DESCRIPTION
## Summary
- The `handleConfirmScout` callback used `void` on the Supabase insert, silently discarding any errors — if the insert failed (expired auth, RLS rejection, etc.), the modal closed and the player saw nothing happen
- Now properly `await`s the insert and logs errors to the console
- Closes #662

## Test plan
- [x] `npm run build` passes
- [x] DB schema confirmed: `scout_cave` enum value exists, constraints are valid, direct SQL insert succeeds
- [x] No sim test regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)