### PR TITLE
feat: fix ore/gem mining drops, add cave mushrooms and rare artifacts

### DIFF
--- a/app/src/components/tile-glyphs.ts
+++ b/app/src/components/tile-glyphs.ts
@@ -43,6 +43,7 @@ export const FORTRESS_GLYPHS: Record<FortressTileType, { ch: string; fg: string 
   ice:                { ch: "≈",  fg: "#aaddff" },
   mud:                { ch: "≈",  fg: "#665533" },
   cave_entrance:      { ch: "\u25BC", fg: "#ff9944" },
+  cave_mushroom:      { ch: "\u2660", fg: "#55aa55" },
   empty:              { ch: " ",  fg: "#000" },
 };
 

--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -482,6 +482,7 @@ export const HARDNESS_STONE = 1.0;
 export const HARDNESS_IGNITE = 1.5;
 export const HARDNESS_ORE = 1.2;
 export const HARDNESS_GEM = 1.4;
+export const HARDNESS_CAVE_MUSHROOM = 0.2;
 
 // ============================================================
 // XP awards

--- a/shared/src/db-types.ts
+++ b/shared/src/db-types.ts
@@ -182,6 +182,7 @@ export type FortressTileType =
   | 'ice'
   | 'mud'
   | 'cave_entrance'
+  | 'cave_mushroom'
   | 'empty';
 
 // ============================================================

--- a/shared/src/fortress-gen-helpers.ts
+++ b/shared/src/fortress-gen-helpers.ts
@@ -166,11 +166,14 @@ function caveSeed(baseSeed: bigint, entranceX: number, entranceY: number): bigin
   return baseSeed ^ BigInt(entranceX * 7919 + entranceY * 6271);
 }
 
+/** Noise threshold for cave mushroom patches (lower = more common). */
+const CAVE_MUSHROOM_THRESHOLD = 0.78;
+
 function buildCaveForEntrance(
   baseSeed: bigint,
   entranceX: number,
   entranceY: number,
-): { grid: boolean[]; materialNoises: NoiseFunction2D[] } {
+): { grid: boolean[]; materialNoises: NoiseFunction2D[]; mushroomNoise: NoiseFunction2D } {
   const seed = caveSeed(baseSeed, entranceX, entranceY);
   const rng = createAleaRng(seed);
   const noise = createNoise2D(rng);
@@ -189,7 +192,8 @@ function buildCaveForEntrance(
   }
 
   const materialNoises: NoiseFunction2D[] = CAVE_MATERIALS.map(() => createNoise2D(rng));
-  return { grid, materialNoises };
+  const mushroomNoise = createNoise2D(rng);
+  return { grid, materialNoises, mushroomNoise };
 }
 
 // ============================================================
@@ -456,7 +460,7 @@ export function createFortressDeriver(
     entrances.map(e => [e.z, e]),
   );
 
-  const caveCache = new Map<number, { grid: boolean[]; materialNoises: NoiseFunction2D[] }>();
+  const caveCache = new Map<number, { grid: boolean[]; materialNoises: NoiseFunction2D[]; mushroomNoise: NoiseFunction2D }>();
 
   function getCaveData(z: number) {
     const entrance = entranceByZ.get(z);
@@ -515,6 +519,11 @@ export function createFortressDeriver(
         }
 
         if (cave.grid[cy * CAVE_SIZE + cx]) {
+          // Check for mushroom patches on cave floor tiles
+          const mushroomVal = (cave.mushroomNoise(cx * 0.06, cy * 0.06) + 1) / 2;
+          if (mushroomVal > CAVE_MUSHROOM_THRESHOLD) {
+            return { tileType: "cave_mushroom", material: "mushroom" };
+          }
           return { tileType: "cavern_floor", material: null };
         }
 

--- a/sim/src/__tests__/cave-mining-scenario.test.ts
+++ b/sim/src/__tests__/cave-mining-scenario.test.ts
@@ -1,0 +1,344 @@
+import { describe, it, expect } from "vitest";
+import { runScenario } from "../run-scenario.js";
+import { makeDwarf, makeTask, makeSkill } from "./test-helpers.js";
+import {
+  createFortressDeriver,
+  WORK_MINE_BASE,
+  type FortressTile,
+} from "@pwarf/shared";
+
+const SEED = 42n;
+const CIV_ID = "test-civ";
+
+describe("cave mining scenario", () => {
+  it("mining an ore tile produces the correct ore item", async () => {
+    const deriver = createFortressDeriver(SEED, CIV_ID);
+    const entrance = deriver.entrances[0]!;
+    const caveZ = deriver.getZForEntrance(entrance.x, entrance.y)!;
+
+    // Find an ore tile in this cave by probing the deriver
+    let oreX = -1, oreY = -1;
+    let oreMaterial = "";
+    for (let x = 192; x < 320 && oreX < 0; x++) {
+      for (let y = 192; y < 320 && oreX < 0; y++) {
+        const tile = deriver.deriveTile(x, y, caveZ);
+        if (tile.tileType === "ore" && tile.material) {
+          oreX = x;
+          oreY = y;
+          oreMaterial = tile.material;
+        }
+      }
+    }
+    expect(oreX).toBeGreaterThan(0);
+    expect(oreMaterial).toBeTruthy();
+
+    // Place dwarf right next to the ore tile
+    const dwarf = makeDwarf({
+      id: "d1",
+      civilization_id: CIV_ID,
+      name: "Urist",
+      position_x: oreX,
+      position_y: oreY,
+      position_z: caveZ,
+      need_food: 100,
+      need_drink: 100,
+      need_sleep: 100,
+    });
+
+    const mineTask = makeTask("mine", {
+      civilization_id: CIV_ID,
+      status: "pending",
+      target_x: oreX,
+      target_y: oreY,
+      target_z: caveZ,
+      work_required: WORK_MINE_BASE,
+    });
+
+    const skills = [
+      makeSkill(dwarf.id, "mining", 3),
+      makeSkill(dwarf.id, "building", 1),
+      makeSkill(dwarf.id, "farming", 1),
+      makeSkill(dwarf.id, "fighting", 1),
+    ];
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      dwarfSkills: skills,
+      tasks: [mineTask],
+      fortressDeriver: deriver,
+      ticks: 300,
+      seed: 42,
+    });
+
+    // Task should be completed
+    const task = result.tasks.find(t => t.task_type === "mine");
+    expect(task).toBeDefined();
+    expect(task!.status).toBe("completed");
+
+    // An ore item should have been produced with the correct material
+    const expectedName = `${oreMaterial.charAt(0).toUpperCase() + oreMaterial.slice(1)} ore`;
+    const oreItem = result.items.find(i => i.name === expectedName);
+    expect(oreItem).toBeDefined();
+    expect(oreItem!.material).toBe(oreMaterial);
+    expect(oreItem!.category).toBe("raw_material");
+    expect(oreItem!.value).toBe(5);
+
+    // The mined tile should now be open_air
+    const minedTile = result.fortressTileOverrides.find(
+      t => t.x === oreX && t.y === oreY && t.z === caveZ,
+    );
+    expect(minedTile).toBeDefined();
+    expect(minedTile!.tile_type).toBe("open_air");
+  });
+
+  it("mining a gem tile produces the correct gem item", async () => {
+    const deriver = createFortressDeriver(SEED, CIV_ID);
+
+    // Search all cave levels for a gem tile
+    let gemX = -1, gemY = -1, gemZ = 0;
+    let gemMaterial = "";
+    for (const entrance of deriver.entrances) {
+      const z = deriver.getZForEntrance(entrance.x, entrance.y)!;
+      for (let x = 192; x < 320 && gemX < 0; x++) {
+        for (let y = 192; y < 320 && gemX < 0; y++) {
+          const tile = deriver.deriveTile(x, y, z);
+          if (tile.tileType === "gem" && tile.material) {
+            gemX = x;
+            gemY = y;
+            gemZ = z;
+            gemMaterial = tile.material;
+          }
+        }
+      }
+      if (gemX > 0) break;
+    }
+    expect(gemX).toBeGreaterThan(0);
+    expect(gemMaterial).toBeTruthy();
+
+    const dwarf = makeDwarf({
+      id: "d1",
+      civilization_id: CIV_ID,
+      name: "Urist",
+      position_x: gemX,
+      position_y: gemY,
+      position_z: gemZ,
+      need_food: 100,
+      need_drink: 100,
+      need_sleep: 100,
+    });
+
+    const mineTask = makeTask("mine", {
+      civilization_id: CIV_ID,
+      status: "pending",
+      target_x: gemX,
+      target_y: gemY,
+      target_z: gemZ,
+      work_required: WORK_MINE_BASE,
+    });
+
+    const skills = [
+      makeSkill(dwarf.id, "mining", 3),
+      makeSkill(dwarf.id, "building", 1),
+      makeSkill(dwarf.id, "farming", 1),
+      makeSkill(dwarf.id, "fighting", 1),
+    ];
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      dwarfSkills: skills,
+      tasks: [mineTask],
+      fortressDeriver: deriver,
+      ticks: 300,
+      seed: 42,
+    });
+
+    const task = result.tasks.find(t => t.task_type === "mine");
+    expect(task).toBeDefined();
+    expect(task!.status).toBe("completed");
+
+    // A gem item should have been produced
+    const expectedName = gemMaterial.charAt(0).toUpperCase() + gemMaterial.slice(1);
+    const gemItem = result.items.find(i => i.name === expectedName);
+    expect(gemItem).toBeDefined();
+    expect(gemItem!.material).toBe(gemMaterial);
+    expect(gemItem!.category).toBe("gem");
+    expect(gemItem!.value).toBe(15);
+
+    // The mined tile should now be open_air
+    const minedTile = result.fortressTileOverrides.find(
+      t => t.x === gemX && t.y === gemY && t.z === gemZ,
+    );
+    expect(minedTile).toBeDefined();
+    expect(minedTile!.tile_type).toBe("open_air");
+  });
+
+  it("mining an ore tile via override uses the override material", async () => {
+    const deriver = createFortressDeriver(SEED, CIV_ID);
+    const entrance = deriver.entrances[0]!;
+    const caveZ = deriver.getZForEntrance(entrance.x, entrance.y)!;
+
+    // Find a cavern_floor tile to place our override on
+    let floorX = -1, floorY = -1;
+    for (let x = 192; x < 320 && floorX < 0; x++) {
+      for (let y = 192; y < 320 && floorX < 0; y++) {
+        const tile = deriver.deriveTile(x, y, caveZ);
+        if (tile.tileType === "cavern_floor") {
+          floorX = x;
+          floorY = y;
+        }
+      }
+    }
+    expect(floorX).toBeGreaterThan(0);
+
+    // Place a gold ore override at this position
+    const oreOverride: FortressTile = {
+      id: "override-ore",
+      civilization_id: CIV_ID,
+      x: floorX,
+      y: floorY,
+      z: caveZ,
+      tile_type: "ore",
+      material: "gold",
+      is_revealed: true,
+      is_mined: false,
+      created_at: new Date().toISOString(),
+    };
+
+    const dwarf = makeDwarf({
+      id: "d1",
+      civilization_id: CIV_ID,
+      name: "Urist",
+      position_x: floorX,
+      position_y: floorY,
+      position_z: caveZ,
+      need_food: 100,
+      need_drink: 100,
+      need_sleep: 100,
+    });
+
+    const mineTask = makeTask("mine", {
+      civilization_id: CIV_ID,
+      status: "pending",
+      target_x: floorX,
+      target_y: floorY,
+      target_z: caveZ,
+      work_required: WORK_MINE_BASE,
+    });
+
+    const skills = [
+      makeSkill(dwarf.id, "mining", 3),
+      makeSkill(dwarf.id, "building", 1),
+      makeSkill(dwarf.id, "farming", 1),
+      makeSkill(dwarf.id, "fighting", 1),
+    ];
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      dwarfSkills: skills,
+      tasks: [mineTask],
+      fortressDeriver: deriver,
+      fortressTileOverrides: [oreOverride],
+      ticks: 300,
+      seed: 42,
+    });
+
+    const task = result.tasks.find(t => t.task_type === "mine");
+    expect(task!.status).toBe("completed");
+
+    const goldOre = result.items.find(i => i.name === "Gold ore");
+    expect(goldOre).toBeDefined();
+    expect(goldOre!.material).toBe("gold");
+    expect(goldOre!.category).toBe("raw_material");
+  });
+
+  it("mining a cave_mushroom tile produces food and reverts to cavern_floor", async () => {
+    const deriver = createFortressDeriver(SEED, CIV_ID);
+    const entrance = deriver.entrances[0]!;
+    const caveZ = deriver.getZForEntrance(entrance.x, entrance.y)!;
+
+    // Find a cave_mushroom tile
+    let mushX = -1, mushY = -1;
+    for (let x = 192; x < 320 && mushX < 0; x++) {
+      for (let y = 192; y < 320 && mushX < 0; y++) {
+        const tile = deriver.deriveTile(x, y, caveZ);
+        if (tile.tileType === "cave_mushroom") {
+          mushX = x;
+          mushY = y;
+        }
+      }
+    }
+    expect(mushX).toBeGreaterThan(0);
+
+    const dwarf = makeDwarf({
+      id: "d1",
+      civilization_id: CIV_ID,
+      name: "Urist",
+      position_x: mushX,
+      position_y: mushY,
+      position_z: caveZ,
+      need_food: 100,
+      need_drink: 100,
+      need_sleep: 100,
+    });
+
+    const mineTask = makeTask("mine", {
+      civilization_id: CIV_ID,
+      status: "pending",
+      target_x: mushX,
+      target_y: mushY,
+      target_z: caveZ,
+      work_required: WORK_MINE_BASE,
+    });
+
+    const skills = [
+      makeSkill(dwarf.id, "mining", 3),
+      makeSkill(dwarf.id, "building", 1),
+      makeSkill(dwarf.id, "farming", 1),
+      makeSkill(dwarf.id, "fighting", 1),
+    ];
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      dwarfSkills: skills,
+      tasks: [mineTask],
+      fortressDeriver: deriver,
+      ticks: 200,
+      seed: 42,
+    });
+
+    const task = result.tasks.find(t => t.task_type === "mine");
+    expect(task!.status).toBe("completed");
+
+    // The mine should produce a food item. It may have been auto-cooked into
+    // a "Prepared meal" by the time the scenario ends, so check for either.
+    const mushroom = result.items.find(i => i.name === "Cave mushroom");
+    const meal = result.items.find(i => i.name === "Prepared meal");
+    expect(mushroom ?? meal).toBeDefined();
+
+    // Tile should revert to cavern_floor, not open_air
+    const minedTile = result.fortressTileOverrides.find(
+      t => t.x === mushX && t.y === mushY && t.z === caveZ,
+    );
+    expect(minedTile).toBeDefined();
+    expect(minedTile!.tile_type).toBe("cavern_floor");
+  });
+
+  it("cave_mushroom tiles are generated in caves", () => {
+    const deriver = createFortressDeriver(SEED, CIV_ID);
+    const entrance = deriver.entrances[0]!;
+    const caveZ = deriver.getZForEntrance(entrance.x, entrance.y)!;
+
+    let mushroomCount = 0;
+    for (let x = 192; x < 320; x++) {
+      for (let y = 192; y < 320; y++) {
+        const tile = deriver.deriveTile(x, y, caveZ);
+        if (tile.tileType === "cave_mushroom") mushroomCount++;
+      }
+    }
+
+    // Mushrooms should exist in caves (threshold 0.78 = ~22% of floor tiles)
+    expect(mushroomCount).toBeGreaterThan(0);
+    // But not dominate (should be significantly less than total floor tiles)
+    expect(mushroomCount).toBeLessThan(5000);
+  });
+});

--- a/sim/src/__tests__/mine-hardness.test.ts
+++ b/sim/src/__tests__/mine-hardness.test.ts
@@ -8,6 +8,7 @@ import {
   HARDNESS_ORE,
   HARDNESS_GEM,
   HARDNESS_IGNITE,
+  HARDNESS_CAVE_MUSHROOM,
   WORK_MINE_BASE,
 } from "@pwarf/shared";
 
@@ -35,6 +36,11 @@ describe("getTileHardness", () => {
   it("gem is harder than ore", () => {
     expect(getTileHardness("gem")).toBe(HARDNESS_GEM);
     expect(HARDNESS_GEM).toBeGreaterThan(HARDNESS_ORE);
+  });
+
+  it("cave_mushroom has very low hardness (fastest to mine)", () => {
+    expect(getTileHardness("cave_mushroom")).toBe(HARDNESS_CAVE_MUSHROOM);
+    expect(HARDNESS_CAVE_MUSHROOM).toBeLessThan(HARDNESS_SOIL);
   });
 
   it("lava_stone and cavern_wall have highest hardness", () => {

--- a/sim/src/__tests__/mine-product.test.ts
+++ b/sim/src/__tests__/mine-product.test.ts
@@ -1,17 +1,19 @@
 import { describe, it, expect } from "vitest";
-import { getMineProduct } from "../phases/task-completion.js";
+import { getMineProduct, ARTIFACT_CHANCE_GEM } from "../phases/task-completion.js";
 
 describe("getMineProduct", () => {
   it("tree produces wood log", () => {
     const result = getMineProduct("tree");
     expect(result.itemName).toBe("Wood log");
     expect(result.itemMaterial).toBe("wood");
+    expect(result.itemCategory).toBe("raw_material");
   });
 
   it("rock produces stone block", () => {
     const result = getMineProduct("rock");
     expect(result.itemName).toBe("Stone block");
     expect(result.itemMaterial).toBe("stone");
+    expect(result.itemCategory).toBe("raw_material");
   });
 
   it("bush produces nothing", () => {
@@ -25,13 +27,85 @@ describe("getMineProduct", () => {
     expect(result.itemMaterial).toBe("stone");
   });
 
-  it("ore produces stone block (default)", () => {
-    const result = getMineProduct("ore");
+  it("cavern_wall produces stone block", () => {
+    const result = getMineProduct("cavern_wall");
     expect(result.itemName).toBe("Stone block");
+    expect(result.itemMaterial).toBe("stone");
   });
 
   it("null tile type produces stone block (default)", () => {
     const result = getMineProduct(null);
     expect(result.itemName).toBe("Stone block");
+  });
+
+  // Ore cases
+  it("ore with iron material produces Iron ore", () => {
+    const result = getMineProduct("ore", "iron");
+    expect(result.itemName).toBe("Iron ore");
+    expect(result.itemMaterial).toBe("iron");
+    expect(result.itemCategory).toBe("raw_material");
+    expect(result.itemValue).toBe(5);
+    expect(result.itemWeight).toBe(8);
+  });
+
+  it("ore with copper material produces Copper ore", () => {
+    const result = getMineProduct("ore", "copper");
+    expect(result.itemName).toBe("Copper ore");
+    expect(result.itemMaterial).toBe("copper");
+  });
+
+  it("ore with gold material produces Gold ore", () => {
+    const result = getMineProduct("ore", "gold");
+    expect(result.itemName).toBe("Gold ore");
+    expect(result.itemMaterial).toBe("gold");
+  });
+
+  it("ore with null material defaults to Iron ore", () => {
+    const result = getMineProduct("ore", null);
+    expect(result.itemName).toBe("Iron ore");
+    expect(result.itemMaterial).toBe("iron");
+  });
+
+  it("ore with no material arg defaults to Iron ore", () => {
+    const result = getMineProduct("ore");
+    expect(result.itemName).toBe("Iron ore");
+    expect(result.itemMaterial).toBe("iron");
+  });
+
+  // Gem cases
+  it("gem with ruby material produces Ruby", () => {
+    const result = getMineProduct("gem", "ruby");
+    expect(result.itemName).toBe("Ruby");
+    expect(result.itemMaterial).toBe("ruby");
+    expect(result.itemCategory).toBe("gem");
+    expect(result.itemValue).toBe(15);
+    expect(result.itemWeight).toBe(2);
+  });
+
+  it("gem with sapphire material produces Sapphire", () => {
+    const result = getMineProduct("gem", "sapphire");
+    expect(result.itemName).toBe("Sapphire");
+    expect(result.itemMaterial).toBe("sapphire");
+  });
+
+  it("gem with null material defaults to Gem", () => {
+    const result = getMineProduct("gem", null);
+    expect(result.itemName).toBe("Gem");
+    expect(result.itemMaterial).toBe("gem");
+  });
+
+  // Artifact chance
+  it("ARTIFACT_CHANCE_GEM is 5%", () => {
+    expect(ARTIFACT_CHANCE_GEM).toBe(0.05);
+  });
+
+  // Cave mushroom cases
+  it("cave_mushroom produces food item", () => {
+    const result = getMineProduct("cave_mushroom", "mushroom");
+    expect(result.itemName).toBe("Cave mushroom");
+    expect(result.itemMaterial).toBe("mushroom");
+    expect(result.itemCategory).toBe("food");
+    expect(result.itemWeight).toBe(1);
+    expect(result.itemValue).toBe(2);
   });
 });

--- a/sim/src/__tests__/pathfinding.test.ts
+++ b/sim/src/__tests__/pathfinding.test.ts
@@ -90,6 +90,10 @@ describe("isWalkable", () => {
   it("gem is not walkable (underground wall)", () => {
     expect(isWalkable("gem")).toBe(false);
   });
+
+  it("cave_mushroom is walkable (cave floor feature)", () => {
+    expect(isWalkable("cave_mushroom")).toBe(true);
+  });
 });
 
 describe("getNeighbors", () => {

--- a/sim/src/pathfinding.ts
+++ b/sim/src/pathfinding.ts
@@ -32,6 +32,7 @@ const WALKABLE_TILES: ReadonlySet<FortressTileType> = new Set([
   'rock',
   'bed',
   'door',
+  'cave_mushroom',
 ]);
 
 /** Check if a tile type is walkable. */

--- a/sim/src/phases/auto-forage.ts
+++ b/sim/src/phases/auto-forage.ts
@@ -3,7 +3,7 @@ import type { SimContext } from "../sim-context.js";
 import { createTask } from "../task-helpers.js";
 
 /** Tile types that dwarves can forage food from. */
-const FORAGEABLE_TILES = new Set(['grass', 'tree', 'bush']);
+const FORAGEABLE_TILES = new Set(['grass', 'tree', 'bush', 'cave_mushroom']);
 
 /**
  * Auto-Forage Phase

--- a/sim/src/phases/task-completion.ts
+++ b/sim/src/phases/task-completion.ts
@@ -22,12 +22,16 @@ import {
   generateCaveName,
   getCaveSeed,
 } from "@pwarf/shared";
-import type { Dwarf, FortressTile, FortressTileType, Task, Item, Structure } from "@pwarf/shared";
+import type { Dwarf, FortressTile, FortressTileType, Task, Item, ItemCategory, Structure } from "@pwarf/shared";
 import type { SimContext } from "../sim-context.js";
 import { canPickUp } from "../inventory.js";
 import { dwarfName } from "../dwarf-utils.js";
 import { createTask } from "../task-helpers.js";
 import { consumeResources } from "../resource-check.js";
+import { generateArtifactName, randomArtifactQuality } from "../artifact-names.js";
+
+/** Chance of finding a rare artifact when mining a gem tile. */
+export const ARTIFACT_CHANCE_GEM = 0.05;
 
 /** Build task type → resulting fortress tile type. */
 const BUILD_TILE_MAP: Record<string, FortressTileType> = {
@@ -242,21 +246,24 @@ export function restoreMoraleOnTaskComplete(dwarf: Dwarf, taskType: string): voi
 function completeMine(dwarf: Dwarf, task: Task, ctx: SimContext): void {
   if (task.target_x === null || task.target_y === null || task.target_z === null) return;
 
-  // Look up the tile type being mined (check overrides first, then deriver)
+  // Look up the tile type and material being mined (check overrides first, then deriver)
   const key = `${task.target_x},${task.target_y},${task.target_z}`;
   const override = ctx.state.fortressTileOverrides.get(key);
   let tileType = override?.tile_type ?? null;
+  let tileMaterial = override?.material ?? null;
   if (!tileType && ctx.fortressDeriver) {
-    tileType = ctx.fortressDeriver.deriveTile(task.target_x, task.target_y, task.target_z).tileType;
+    const derived = ctx.fortressDeriver.deriveTile(task.target_x, task.target_y, task.target_z);
+    tileType = derived.tileType;
+    tileMaterial = derived.material;
   }
 
-  const { itemName, itemMaterial, itemWeight, itemValue } = getMineProduct(tileType);
+  const { itemName, itemCategory, itemMaterial, itemWeight, itemValue } = getMineProduct(tileType, tileMaterial);
 
   if (itemName) {
     const minedItem: Item = {
       id: ctx.rng.uuid(),
       name: itemName,
-      category: 'raw_material',
+      category: itemCategory,
       quality: 'standard',
       material: itemMaterial,
       weight: itemWeight,
@@ -289,29 +296,77 @@ function completeMine(dwarf: Dwarf, task: Task, ctx: SimContext): void {
     ctx.state.dirtyItemIds.add(minedItem.id);
   }
 
+  // Rare artifact find: 5% chance when mining gem tiles
+  if (tileType === 'gem' && ctx.rng.random() < ARTIFACT_CHANCE_GEM) {
+    const artifact = createGemArtifact(dwarf, task, ctx, tileMaterial);
+    ctx.state.items.push(artifact);
+    ctx.state.dirtyItemIds.add(artifact.id);
+
+    const dwarfLabel = dwarfName(dwarf);
+    ctx.state.pendingEvents.push({
+      id: ctx.rng.uuid(),
+      world_id: '',
+      year: ctx.year,
+      category: 'discovery',
+      civilization_id: ctx.civilizationId,
+      ruin_id: null,
+      dwarf_id: dwarf.id,
+      item_id: artifact.id,
+      faction_id: null,
+      monster_id: null,
+      description: `${dwarfLabel} unearthed ${artifact.name}!`,
+      event_data: { action: 'artifact_find', item_name: artifact.name },
+      created_at: new Date().toISOString(),
+    });
+  }
+
   // Surface features (z=0) become the biome base tile (grass, mud, sand, etc.);
-  // underground becomes open_air
+  // underground becomes open_air (cave mushrooms revert to cavern_floor since they grow on the floor)
   const baseTile = ctx.fortressDeriver?.baseTileType ?? 'grass';
-  const resultTile: FortressTileType = task.target_z === 0 ? baseTile : 'open_air';
-  upsertFortressTile(ctx, task.target_x, task.target_y, task.target_z, resultTile, null, true);
+  let resultTile: FortressTileType;
+  if (task.target_z === 0) {
+    resultTile = baseTile;
+  } else if (tileType === 'cave_mushroom') {
+    resultTile = 'cavern_floor';
+  } else {
+    resultTile = 'open_air';
+  }
+  upsertFortressTile(ctx, task.target_x, task.target_y, task.target_z, resultTile, null, tileType !== 'cave_mushroom');
+}
+
+/** Capitalize the first letter of a string. */
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
 /** Returns the item produced when mining a given tile type. */
-export function getMineProduct(tileType: string | null): {
+export function getMineProduct(tileType: string | null, material: string | null = null): {
   itemName: string | null;
+  itemCategory: ItemCategory;
   itemMaterial: string;
   itemWeight: number;
   itemValue: number;
 } {
   switch (tileType) {
     case 'tree':
-      return { itemName: 'Wood log', itemMaterial: 'wood', itemWeight: 8, itemValue: 2 };
+      return { itemName: 'Wood log', itemCategory: 'raw_material', itemMaterial: 'wood', itemWeight: 8, itemValue: 2 };
     case 'rock':
-      return { itemName: 'Stone block', itemMaterial: 'stone', itemWeight: 10, itemValue: 1 };
+    case 'cavern_wall':
+      return { itemName: 'Stone block', itemCategory: 'raw_material', itemMaterial: 'stone', itemWeight: 10, itemValue: 1 };
+    case 'ore': {
+      const mat = material ?? 'iron';
+      return { itemName: `${capitalize(mat)} ore`, itemCategory: 'raw_material', itemMaterial: mat, itemWeight: 8, itemValue: 5 };
+    }
+    case 'gem': {
+      const mat = material ?? 'gem';
+      return { itemName: capitalize(mat), itemCategory: 'gem', itemMaterial: mat, itemWeight: 2, itemValue: 15 };
+    }
+    case 'cave_mushroom':
+      return { itemName: 'Cave mushroom', itemCategory: 'food', itemMaterial: 'mushroom', itemWeight: 1, itemValue: 2 };
     case 'bush':
-      return { itemName: null, itemMaterial: '', itemWeight: 0, itemValue: 0 };
+      return { itemName: null, itemCategory: 'raw_material', itemMaterial: '', itemWeight: 0, itemValue: 0 };
     default:
-      return { itemName: 'Stone block', itemMaterial: 'stone', itemWeight: 10, itemValue: 1 };
+      return { itemName: 'Stone block', itemCategory: 'raw_material', itemMaterial: 'stone', itemWeight: 10, itemValue: 1 };
   }
 }
 
@@ -762,6 +817,34 @@ export function completeScoutCave(dwarf: Dwarf, task: Task, ctx: SimContext): vo
     event_data: { action: 'scout_cave', cave_name: caveName, cave_z: caveZ },
     created_at: new Date().toISOString(),
   });
+}
+
+/** Creates a rare artifact item when mining gems. */
+function createGemArtifact(dwarf: Dwarf, task: Task, ctx: SimContext, material: string | null): Item {
+  const name = generateArtifactName(dwarf, ctx.rng);
+  const quality = randomArtifactQuality(ctx.rng);
+  return {
+    id: ctx.rng.uuid(),
+    name,
+    category: 'gem',
+    quality,
+    material: material ?? 'crystal',
+    weight: 1,
+    value: 50,
+    is_artifact: true,
+    created_by_dwarf_id: dwarf.id,
+    created_in_civ_id: ctx.civilizationId,
+    created_year: ctx.year,
+    held_by_dwarf_id: null,
+    located_in_civ_id: ctx.civilizationId,
+    located_in_ruin_id: null,
+    position_x: task.target_x,
+    position_y: task.target_y,
+    position_z: task.target_z,
+    lore: `Unearthed from deep beneath the earth by ${dwarfName(dwarf)} in year ${ctx.year}.`,
+    properties: {},
+    created_at: new Date().toISOString(),
+  };
 }
 
 /** Find the first item at a given tile position with the given category (and optionally material). */

--- a/sim/src/phases/task-execution.ts
+++ b/sim/src/phases/task-execution.ts
@@ -7,6 +7,7 @@ import {
   HARDNESS_IGNITE,
   HARDNESS_ORE,
   HARDNESS_GEM,
+  HARDNESS_CAVE_MUSHROOM,
   CONSCIENTIOUSNESS_WORK_MULTIPLIER,
 } from "@pwarf/shared";
 import type { Dwarf, Task } from "@pwarf/shared";
@@ -310,9 +311,10 @@ function stepOffTarget(dwarf: Dwarf, task: Task, ctx: SimContext, occupiedTiles:
  */
 export function getTileHardness(tileType: string | null): number {
   switch (tileType) {
-    case 'soil':       return HARDNESS_SOIL;    // 0.3 — fast
-    case 'ore':        return HARDNESS_ORE;     // 1.2
-    case 'gem':        return HARDNESS_GEM;     // 1.4
+    case 'soil':           return HARDNESS_SOIL;           // 0.3 — fast
+    case 'cave_mushroom':  return HARDNESS_CAVE_MUSHROOM;  // 0.2 — very fast
+    case 'ore':            return HARDNESS_ORE;            // 1.2
+    case 'gem':            return HARDNESS_GEM;            // 1.4
     case 'lava_stone':
     case 'cavern_wall': return HARDNESS_IGNITE; // 1.5 — slow
     default:           return HARDNESS_STONE;   // 1.0 — rock, open_air, etc.

--- a/supabase/migrations/00027_cave_mushroom_tile_type.sql
+++ b/supabase/migrations/00027_cave_mushroom_tile_type.sql
@@ -1,0 +1,1 @@
+ALTER TYPE fortress_tile_type ADD VALUE IF NOT EXISTS 'cave_mushroom';


### PR DESCRIPTION
## Summary
- **Bug fix**: Mining ore (`$`) and gem (`♦`) tiles now produces correct items (Iron ore, Ruby, etc.) instead of generic Stone block. `getMineProduct()` accepts material from the fortress deriver.
- **Cave mushrooms**: New `cave_mushroom` tile type scattered on cave floors (♠ glyph). Walkable, fast to mine (hardness 0.2), produces food, auto-forageable. Reverts to `cavern_floor` when mined.
- **Rare artifacts**: 5% chance when mining gem tiles to find a unique artifact with generated name, lore, and discovery event.

Closes #668

## Test plan
- [x] `getMineProduct` unit tests: ore with all materials, gem with all materials, cave_mushroom, cavern_wall (16 tests)
- [x] Cave mining scenario tests: mine ore tile → correct ore item, mine gem tile → correct gem, mine mushroom → food item + tile reverts to cavern_floor, mushroom generation check (5 tests)
- [x] Hardness unit test: cave_mushroom returns HARDNESS_CAVE_MUSHROOM (0.2)
- [x] Walkability test: cave_mushroom is walkable
- [x] Full test suite: 1047 tests passing
- [x] `npm run build` passes
- [x] DB migration applied via Supabase MCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Claude Cost
**Claude cost:** $55.24 (75.3M tokens)