### PR TITLE
fix: broken npm run reset — migration ordering + missing sim build

### DIFF
--- a/scripts/reset-and-start.mjs
+++ b/scripts/reset-and-start.mjs
@@ -46,8 +46,9 @@ run("supabase db reset");
 // 4. Install deps (in case node_modules is stale)
 run("npm install");
 
-// 5. Build shared (sim and app depend on it)
+// 5. Build shared and sim (app depends on both)
 run("npm run build --workspace=shared");
+run("npm run build --workspace=sim");
 
 // 6. Start dev server
 console.log("\nStarting dev app...");

--- a/supabase/migrations/00022_expedition_travel.sql
+++ b/supabase/migrations/00022_expedition_travel.sql
@@ -1,10 +1,3 @@
--- Add travel and party fields to the expeditions table for the expedition system.
-
-ALTER TABLE expeditions ADD COLUMN IF NOT EXISTS civilization_id UUID REFERENCES civilizations(id);
-ALTER TABLE expeditions ADD COLUMN IF NOT EXISTS travel_ticks_remaining INT NOT NULL DEFAULT 0;
-ALTER TABLE expeditions ADD COLUMN IF NOT EXISTS return_ticks_remaining INT NOT NULL DEFAULT 0;
-ALTER TABLE expeditions ADD COLUMN IF NOT EXISTS destination_tile_x INT;
-ALTER TABLE expeditions ADD COLUMN IF NOT EXISTS destination_tile_y INT;
-ALTER TABLE expeditions ADD COLUMN IF NOT EXISTS party_strength INT NOT NULL DEFAULT 0;
-
-CREATE INDEX IF NOT EXISTS expeditions_civ_idx ON expeditions(civilization_id);
+-- Originally added columns to expeditions table, but that table is created
+-- in 00025_create_expeditions_table.sql which already includes these columns.
+-- This migration is intentionally a no-op.


### PR DESCRIPTION
Closes #672

## Summary
- Make migration `00022_expedition_travel.sql` a no-op — it tried to `ALTER TABLE expeditions` before the table existed (created in `00025`). Migration 00025 already includes all those columns.
- Add `npm run build --workspace=sim` to `reset-and-start.mjs` so Vite can resolve `@pwarf/sim` on startup.

## Test plan
- [x] `npm run reset` completes successfully (all migrations apply, Vite starts)
- [x] `npm run build` passes
- [x] `npm test` — 1047 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Claude Cost
**Claude cost:** $1.34 (1.6M tokens)