### PR TITLE
docs: audit and fix all outdated design docs

### DIFF
--- a/.claude/skills/docs-audit/skill.md
+++ b/.claude/skills/docs-audit/skill.md
@@ -1,0 +1,120 @@
+---
+name: docs-audit
+description: Audit docs/ for accuracy, staleness, and gaps — then fix or flag issues
+user_invocable: true
+---
+
+# Docs Audit Skill
+
+Run this periodically (e.g. after a batch of PRs, a new phase, or when docs feel stale) to keep `docs/` accurate and useful.
+
+## Philosophy
+
+Docs should be **trustworthy or absent**. A wrong doc is worse than no doc — it misleads. Every doc must earn its place by being either:
+- **Accurate reference** for something implemented in code, OR
+- **Clearly marked design spec** for something not yet built
+
+## Audit Checklist
+
+Work through each section. Use parallel agents where possible.
+
+### 1. Inventory
+
+List every file in `docs/`, `docs/design/`, and `docs/system-overviews/`. For each file, note:
+- What system/feature it covers
+- Last meaningful git update (`git log -1 --format='%ci' -- <file>`)
+
+### 2. Constants and numbers check
+
+Cross-reference **every numeric constant** mentioned in docs against `shared/src/constants.ts` and the actual code. Common drift points:
+- `STEPS_PER_DAY`, `STEPS_PER_YEAR` and any derived timing/pacing math
+- `SIM_FLUSH_INTERVAL_MS` and data-loss window claims
+- Decay rates (`FOOD_DECAY_PER_TICK`, etc.)
+- Threshold values (`STRESS_TANTRUM_THRESHOLD`, etc.)
+- Any "~X real seconds" or "~X real minutes" claims
+
+**Action:** Fix wrong numbers in-place. If a doc computes derived values (e.g. "one year = 30 real minutes"), recompute from current constants.
+
+### 3. Phase list accuracy
+
+Read `sim/src/tick.ts` and extract the full ordered phase list from `runTick`. Compare against `docs/design/02-core-game-loop.md` and any other doc listing phases.
+
+**Action:** Update phase lists to match code exactly. Include every phase, in order.
+
+### 4. File/function/type references
+
+Grep for every file path, function name, and type name mentioned in docs. Flag any that no longer exist.
+
+**Action:** Remove or update stale references.
+
+### 5. Implementation status check
+
+For each design doc (`docs/design/*.md`), determine implementation status:
+- **Implemented**: Core functionality exists in code and is tested
+- **Partial**: Some parts built, others not
+- **Design only**: No code exists for this system
+
+**Action:** Add or update a status banner at the top of each design doc:
+
+```markdown
+> **Status:** Implemented | Partial | Design only
+> **Last verified:** YYYY-MM-DD
+```
+
+Use "Design only" — never "planned" or "coming soon" (those go stale silently).
+
+### 6. Gap analysis — undocumented systems
+
+Search for sim phases, major modules, and systems that have NO corresponding doc. Check:
+- Every file in `sim/src/phases/`
+- Every file in `sim/src/` that defines a major system
+- Any `shared/src/` module with complex logic
+
+**Action:** Don't auto-generate docs for these. Instead, list them in a summary and ask the user which ones are worth documenting.
+
+### 7. Removal candidates
+
+Flag docs that are:
+- **Fully superseded** by a more detailed doc covering the same system
+- **Pure brainstorming** with no actionable content and no implementation
+- **So stale** that fixing them would be a full rewrite
+
+**Action:** Don't delete without user approval. List candidates with reasoning.
+
+## Criteria for Adding a New Doc
+
+Only add a doc to `docs/` if ALL of these are true:
+- The system is **complex enough** that reading the code alone is insufficient (>2 files, non-obvious interactions)
+- The information is **not derivable** from code comments, types, or test names
+- Someone (future you, a contributor, the user) would **reasonably search for this**
+- You commit to keeping it accurate (or marking it "Design only")
+
+Do NOT create docs for:
+- Simple CRUD or one-file utilities
+- Things fully covered by CLAUDE.md
+- Anything that `git log` or inline comments explain
+
+## Criteria for Removing a Doc
+
+Remove (with user approval) if ANY of these are true:
+- Every claim in the doc is wrong and fixing it would be a full rewrite
+- The doc duplicates another doc with no unique content
+- The system it describes was removed from the codebase
+- It's a brainstorm/scratchpad with no reference value
+
+## Criteria for Updating a Doc
+
+Update in-place (no approval needed) when:
+- A constant or number changed and the doc references the old value
+- A file/function was renamed and the doc uses the old name
+- A phase was added/removed and the doc lists phases
+- Implementation status changed (design only -> partial -> implemented)
+
+## Output
+
+After the audit, produce a summary with:
+
+1. **Fixed** — list of docs updated with what changed
+2. **Flagged** — issues that need user input (removal candidates, ambiguous status)
+3. **Gaps** — undocumented systems worth considering
+4. **Health score** — X/Y docs are accurate and up-to-date

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ When changing a public API that both `sim/` and `app/` use (e.g. `SimRunner` con
 
 ## Workflow
 
+- **Never commit directly to `main`.** All changes go through pull requests. Create a feature branch, push it, open a PR, and merge via GitHub. No exceptions.
 - **`main` has force-push protection enabled.** Never `git push --force` to main. Force-pushing feature branches after a rebase is fine.
 - **Always `git pull` on main before starting new work.** Create worktrees off the latest main to avoid missing recently merged changes.
 - **Every code change must be made in a worktree, never in the main checkout.** Multiple Claude Code sessions sharing the same working directory will silently overwrite each other's changes. Always use `isolation: "worktree"` for agents or `git worktree add` manually. The main checkout should only be used for read-only operations (browsing, `git log`, etc.).
@@ -119,6 +120,23 @@ Follow these when writing or modifying code to keep the codebase clean:
 ### Sim tick loop
 
 All sim phase ordering lives in `sim/src/tick.ts` (`runTick`, `advanceTime`, `maybeYearRollup`). Runners (`sim-runner.ts`, `headless-runner.ts`, `run-scenario.ts`, `step-mode.ts`) import from `tick.ts` — never duplicate the phase call list. When adding a new phase, add it once in `tick.ts`.
+
+### Design docs
+
+Design docs live in `docs/design/`. **Every new sim system or major update to an existing system must include a corresponding design doc update in the same PR.**
+
+- **New system** (new phase, new mechanic, new entity type): Create a new `docs/design/NN-system-name.md` with a status banner, overview, and key mechanics. Number it sequentially.
+- **Major update** (reworked phase, changed constants, new interactions): Update the existing design doc to reflect the changes. Fix any constants, phase lists, or examples that are now wrong.
+- **Bug fix or minor tuning**: No doc update needed unless the doc explicitly states the old (now wrong) value.
+
+Every design doc must have a status banner at the top:
+
+```markdown
+> **Status:** Implemented | Partial | Design only
+> **Last verified:** YYYY-MM-DD
+```
+
+Run `/docs-audit` periodically to catch drift between docs and code.
 
 ### Types and constants
 

--- a/docs/design/01-world-generation.md
+++ b/docs/design/01-world-generation.md
@@ -1,5 +1,8 @@
 # World Generation
 
+> **Status:** Implemented
+> **Last verified:** 2026-03-25
+
 ## Overview
 
 The game uses a **two-tier world generation** system:

--- a/docs/design/02-core-game-loop.md
+++ b/docs/design/02-core-game-loop.md
@@ -1,5 +1,8 @@
 # Core Game Loop (Simulation Engine)
 
+> **Status:** Implemented
+> **Last verified:** 2026-03-25
+
 ## Overview
 
 The simulation runs as a headless Node.js process on the server — completely separate from the React frontend. It has zero browser dependencies. One `SimRunner` instance drives one civilization's simulation in real time.
@@ -11,6 +14,7 @@ sim/src/
 ├── index.ts           Entry point (reads env, creates Supabase client, starts runner)
 ├── sim-runner.ts      Main loop: start/stop/tick, calls phases in order
 ├── sim-context.ts     SimContext interface (shared state threaded through phases)
+├── tick.ts            Phase ordering: runTick, advanceTime, maybeYearRollup
 └── phases/
     ├── index.ts              Barrel export
     ├── needs-decay.ts        Phase 1: decrement dwarf needs
@@ -18,12 +22,20 @@ sim/src/
     ├── need-satisfaction.ts  Phase 3: consume food/drink/beds
     ├── stress-update.ts      Phase 4: recalculate stress
     ├── tantrum-check.ts      Phase 5: trigger tantrums
-    ├── monster-pathfinding.ts Phase 6: move monsters
-    ├── combat-resolution.ts  Phase 7: resolve fights
-    ├── construction-progress.ts Phase 8: advance builds
-    ├── job-claiming.ts       Phase 9: assign idle dwarves
-    ├── event-firing.ts       Phase 10: write events to DB
-    └── yearly-rollup.ts      Phase 11: annual updates (every 18,000 steps)
+    ├── tantrum-actions.ts    Phase 6: execute tantrum effects
+    ├── monster-spawning.ts   Phase 7: spawn new monsters
+    ├── monster-pathfinding.ts Phase 8: move monsters
+    ├── combat-resolution.ts  Phase 9: resolve fights
+    ├── expedition-tick.ts    Phase 10: advance expeditions
+    ├── haul-assignment.ts    Phase 11: assign haul tasks
+    ├── task-recovery.ts      Phase 12: recover stuck tasks
+    ├── auto-cook.ts          Phase 13: auto-create cook tasks
+    ├── auto-brew.ts          Phase 14: auto-create brew tasks
+    ├── auto-forage.ts        Phase 15: auto-create forage tasks
+    ├── job-claiming.ts       Phase 16: assign idle dwarves
+    ├── event-firing.ts       Phase 17: write events to DB
+    ├── thought-generation.ts Phase 18: generate dwarf thoughts
+    └── yearly-rollup.ts      Annual updates (every 36,000 steps)
 ```
 
 ## Tick Rate & Timing
@@ -33,15 +45,15 @@ All timing constants live in `shared/src/constants.ts`:
 | Constant            | Value  | Meaning                                |
 |--------------------|--------|----------------------------------------|
 | `STEPS_PER_SECOND` | 10     | Ticks per real-time second             |
-| `STEPS_PER_YEAR`   | 18,000 | Ticks per in-game year (30 real min)   |
-| `STEPS_PER_DAY`    | 49     | Ticks per in-game day (~5 real sec)    |
+| `STEPS_PER_YEAR`   | 36,000 | Ticks per in-game year (1 real hour)   |
+| `STEPS_PER_DAY`    | 1,800  | Ticks per in-game day (~3 real min)    |
 
 Derived timings:
 - **Tick interval**: 100ms (1000 / STEPS_PER_SECOND)
-- **1 in-game day** ≈ 5 real seconds
-- **1 in-game year** = 30 real minutes
-- **Dwarf lifespan (~80 years)** ≈ 40 real hours
-- **Average fortress run (20–40 years)** ≈ 10–20 real hours
+- **1 in-game day** ≈ 3 real minutes
+- **1 in-game year** = 1 real hour
+- **Dwarf lifespan (~80 years)** ≈ 80 real hours
+- **Average fortress run (20–40 years)** ≈ 20–40 real hours
 
 ## SimRunner Lifecycle
 
@@ -53,7 +65,7 @@ Derived timings:
 ### `tick()`
 Each tick:
 1. Increments `stepCount` and `currentDay`
-2. Runs all 10 standard phases in deterministic order
+2. Runs all 18 standard phases in deterministic order
 3. If `stepCount % STEPS_PER_YEAR === 0`: increments year, resets day, runs `yearlyRollup`
 
 ### `stop()`
@@ -101,23 +113,39 @@ The phases run in a strict, deterministic order every tick. This ordering matter
 
 2. **Task Execution** — Each dwarf with an assigned job advances it by one work step. Handles pathfinding progress, material hauling, skill-based speed modifiers. Completes jobs when progress hits 100%.
 
-3. **Need Satisfaction** — Dwarves near need-satisfying sources (food stockpile, drink barrel, bed, meeting hall) consume the resource and refill the corresponding need.
+3. **Need Satisfaction** — Dwarves near need-satisfying sources (food stockpile, drink barrel, bed, meeting hall) consume the resource and refill the corresponding need. Creates autonomous eat/drink/sleep tasks when needs fall below interrupt thresholds.
 
 4. **Stress Update** — Recalculates stress from: unmet needs (low food = stress), recent negative memories (witnessed death, slept outside), personality traits (high neuroticism = more stress from same stimuli). Positive memories and fulfilled needs reduce stress.
 
-5. **Tantrum Check** — Dwarves with `stress_level >= STRESS_TANTRUM_THRESHOLD` (80) may enter tantrum. Tantrum severity scales with stress. Effects: destroy nearby items, attack other dwarves, go berserk. Can cascade ("tantrum spiral").
+5. **Tantrum Check** — Dwarves with `stress_level >= STRESS_TANTRUM_THRESHOLD` (80) may enter tantrum. Tantrum severity scales with stress. Can cascade ("tantrum spiral").
 
-6. **Monster Pathfinding** — Active monsters advance one tile toward their target. Behavior determines target selection: `aggressive` → nearest dwarf, `sieging` → fortress entrance, `territorial` → patrol lair area, `hunting` → weakest visible dwarf.
+6. **Tantrum Actions** — Executes tantrum effects: destroy nearby items, attack other dwarves, go berserk. Duration varies by severity (1800–7200 ticks).
 
-7. **Combat Resolution** — Checks for tile overlap between monsters and dwarves (or military squads). Resolves using attack/defense stats, equipment quality, skill levels, and dice rolls. Applies damage to health, generates wound descriptions, awards combat XP.
+7. **Monster Spawning** — Spawns new monsters based on fortress wealth, population, and current year. Higher wealth attracts more dangerous creatures.
 
-8. **Construction Progress** — Active build jobs advance one step. Checks that required materials are available and a builder is assigned. Marks structures as complete at 100%. Incomplete builds without builders stall.
+8. **Monster Pathfinding** — Active monsters advance one tile toward their target. Behavior determines target selection: `aggressive` → nearest dwarf, `sieging` → fortress entrance, `territorial` → patrol lair area, `hunting` → weakest visible dwarf.
 
-9. **Job Claiming** — Finds idle dwarves (no current task) and matches them to unclaimed work orders. Matching considers: enabled labors, skill level, proximity to job site, job priority.
+9. **Combat Resolution** — Checks for tile overlap between monsters and dwarves (or military squads). Resolves using attack/defense stats, equipment quality, skill levels, and dice rolls. Applies damage to health, generates wound descriptions, awards combat XP.
 
-10. **Event Firing** — Collects all notable events from this tick and writes them to `world_events` in Supabase. Events include births, deaths, completions, artifact creation, sieges, discoveries.
+10. **Expedition Tick** — Advances expedition progress for dwarves exploring ruins. Handles travel, exploration events, loot discovery, and return.
 
-### Yearly Rollup (every 18,000 steps)
+11. **Haul Assignment** — Creates haul tasks for loose items on the ground that should be moved to stockpiles.
+
+12. **Task Recovery** — Detects and recovers stuck tasks (e.g., blocked paths, missing materials). Resets failed tasks to pending or cancels invalid ones.
+
+13. **Auto-Cook** — Checks food stock levels and auto-creates cook tasks when supplies are low and raw ingredients are available.
+
+14. **Auto-Brew** — Checks drink stock levels and auto-creates brew tasks when supplies are low and brewable plants are available.
+
+15. **Auto-Forage** — Auto-creates forage tasks when food is scarce and forageable tiles exist nearby.
+
+16. **Job Claiming** — Finds idle dwarves (no current task) and matches them to unclaimed work orders. Matching considers: enabled labors, skill level, proximity to job site, job priority.
+
+17. **Event Firing** — Collects all notable events from this tick and writes them to `world_events` in Supabase. Events include births, deaths, completions, artifact creation, sieges, discoveries.
+
+18. **Thought Generation** — Creates dwarf thoughts and memories based on recent events, surroundings, and need states. These feed into the stress system and activity log.
+
+### Yearly Rollup (every 36,000 steps)
 
 Runs after the standard phases on the tick where `step % STEPS_PER_YEAR === 0`:
 
@@ -222,7 +250,7 @@ async function flushToSupabase(ctx: SimContext) {
 
 ### Data Loss Window
 
-With 1-second batching, a server crash loses at most **1 second** (10 ticks) of progress. This is acceptable — the player won't notice 1 second of lost simulation time, and the previous write-every-tick design was solving a problem that didn't need solving at the cost of massive write amplification.
+With 1-second batching (`WRITE_INTERVAL = 1000ms`) for in-memory snapshots and 2-second DB flushing (`SIM_FLUSH_INTERVAL_MS = 2000ms`), a server crash loses at most **2 seconds** (20 ticks) of progress. This is acceptable — the player won't notice 2 seconds of lost simulation time, and the previous write-every-tick design was solving a problem that didn't need solving at the cost of massive write amplification.
 
 ### Frontend Update Rate
 

--- a/docs/design/03-dwarf-needs-and-stress.md
+++ b/docs/design/03-dwarf-needs-and-stress.md
@@ -1,5 +1,8 @@
 # Dwarf Needs & Stress System
 
+> **Status:** Implemented
+> **Last verified:** 2026-03-25
+
 ## Overview
 
 Every dwarf has six need meters and a stress level. Needs decay over time, stress rises when needs are unmet, and tantrums trigger when stress exceeds a threshold. This is the core behavioral driver — everything a dwarf does flows from their needs.
@@ -19,11 +22,13 @@ Each need is an integer from 0 (critical) to 100 (fully satisfied):
 
 ### Decay Mechanics
 
-Needs decay every sim tick (Phase 1: `needs-decay`). Decay amounts should vary:
-- **Drink** decays fastest (~0.05/tick → runs out in ~2000 ticks ≈ 3.3 min)
-- **Food** decays slightly slower (~0.04/tick)
-- **Sleep** moderate (~0.03/tick)
-- **Social/Purpose/Beauty** very slow (~0.01/tick → takes ~5000 ticks ≈ 8 min to fully deplete)
+Needs decay every sim tick (Phase 1: `needs-decay`). Decay rates per tick:
+- **Drink**: 0.0033/tick (runs out from 80 in ~24,242 ticks, ~40 real min)
+- **Food**: 0.0022/tick (runs out from 80 in ~36,364 ticks, ~60 real min)
+- **Sleep**: 0.0022/tick
+- **Social**: 0.0014/tick
+- **Purpose**: 0.0011/tick
+- **Beauty**: 0.0008/tick (slowest — takes ~100,000 ticks to fully deplete from 80)
 
 These rates are tunable and should be constants, not hardcoded.
 
@@ -63,9 +68,9 @@ When `stress_level >= 80` (the `STRESS_TANTRUM_THRESHOLD` constant), the dwarf m
 ### Tantrum Effects
 
 Tantrums are not instant — they play out over multiple ticks:
-- **Mild (stress 80–89)**: Dwarf throws items, refuses to work for ~50 ticks
-- **Moderate (stress 90–95)**: Dwarf destroys nearby items, may punch another dwarf
-- **Severe (stress 96–100)**: Dwarf goes berserk — attacks others indiscriminately until subdued or killed
+- **Mild (stress 80–89)**: Dwarf throws items, refuses to work for ~1800 ticks (~1 in-game day)
+- **Moderate (stress 90–95)**: Dwarf destroys nearby items, may punch another dwarf. Lasts ~3600 ticks (~2 in-game days)
+- **Severe (stress 96–100)**: Dwarf goes berserk — attacks others indiscriminately until subdued or killed. Lasts ~7200 ticks (~4 in-game days)
 
 ### Tantrum Spirals
 

--- a/docs/design/04-rendering-and-ui.md
+++ b/docs/design/04-rendering-and-ui.md
@@ -1,5 +1,8 @@
 # Rendering & UI System
 
+> **Status:** Implemented
+> **Last verified:** 2026-03-25
+
 ## Overview
 
 The frontend is a React + TypeScript app that renders an ASCII character grid to an HTML5 canvas. It is purely a viewer — zero simulation logic. All game state comes from Supabase Realtime subscriptions.

--- a/docs/design/05-data-flow-and-persistence.md
+++ b/docs/design/05-data-flow-and-persistence.md
@@ -1,5 +1,8 @@
 # Data Flow & Persistence
 
+> **Status:** Implemented
+> **Last verified:** 2026-03-25
+
 ## Overview
 
 The architecture enforces a strict separation: the sim engine writes state to Supabase, and the frontend reads it via Supabase Realtime subscriptions. There is no direct communication between sim and frontend.
@@ -92,7 +95,7 @@ If the sim process crashes and restarts:
 2. Determine the last step from the most recent world event or civilization `updated_at`
 3. Resume the tick loop from that point
 
-Since state is flushed every 1 second, recovery loses at most 10 ticks — imperceptible to the player.
+Since state is flushed every 2 seconds (`SIM_FLUSH_INTERVAL_MS = 2000`), recovery loses at most 20 ticks — imperceptible to the player.
 
 ## Shared Types
 

--- a/docs/design/06-graveyard-and-ruins.md
+++ b/docs/design/06-graveyard-and-ruins.md
@@ -1,5 +1,8 @@
 # Graveyard & Ruins System
 
+> **Status:** Partial
+> **Last verified:** 2026-03-25
+
 ## Overview
 
 When a fortress falls, it becomes a ruin. Ruins can be published to a global graveyard that all players can browse, explore, and loot. This is the only multiplayer interaction — through the ruins left behind by real people.

--- a/docs/design/07-monsters-and-combat.md
+++ b/docs/design/07-monsters-and-combat.md
@@ -1,5 +1,8 @@
 # Monsters & Combat System
 
+> **Status:** Partial
+> **Last verified:** 2026-03-25
+
 ## Monster Types
 
 12 monster types, each with different threat profiles:

--- a/docs/design/08-event-system.md
+++ b/docs/design/08-event-system.md
@@ -1,5 +1,8 @@
 # Event System
 
+> **Status:** Implemented
+> **Last verified:** 2026-03-25
+
 ## Overview
 
 Events are the narrative backbone of the game. Every notable thing that happens in the world is recorded as a `world_event` in the database and as a typed `SimEvent` flowing through the sim. Events feed the activity log, the legends screen, ruin histories, and dwarf memories.

--- a/docs/design/09-ui-screens-and-interaction.md
+++ b/docs/design/09-ui-screens-and-interaction.md
@@ -1,5 +1,8 @@
 # UI Screens & Interaction Design
 
+> **Status:** Partial
+> **Last verified:** 2026-03-25
+
 ## Overview
 
 This document describes the player-facing UI: what the player sees, how screens flow together, and how they interact with the game. For technical rendering details (canvas, grid snapping, DPR), see `04-rendering-and-ui.md`.

--- a/docs/design/10-dwarf-task-dispatch.md
+++ b/docs/design/10-dwarf-task-dispatch.md
@@ -1,5 +1,8 @@
 # Dwarf Task Dispatch
 
+> **Status:** Implemented
+> **Last verified:** 2026-03-25
+
 ## Overview
 
 This document specifies how dwarves receive, claim, execute, and complete tasks — the system that connects player intent (dig designations, farm plots) to dwarf behavior. Without this, dwarves exist and get hungry but never do anything about it.
@@ -59,7 +62,7 @@ These are the only task types needed for the core game loop:
 | `farm_harvest` | Crop reaches maturity | Dwarf with `farming` skill | 30 base | Food item created at plot |
 | `eat` | Dwarf need_food < threshold | Self only (autonomous) | 10 (quick action) | Food item consumed, need_food += restore amount |
 | `drink` | Dwarf need_drink < threshold | Self only (autonomous) | 10 | Drink item consumed, need_drink += restore amount |
-| `sleep` | Dwarf need_sleep < threshold | Self only (autonomous) | 50 (takes a while) | need_sleep fully restored |
+| `sleep` | Dwarf need_sleep < threshold | Self only (autonomous) | 600 (~8 in-game hours) | need_sleep restored by 60 |
 
 ### Material Hardness Modifiers (Mining)
 
@@ -176,9 +179,9 @@ for each dwarf with status='alive' and current_task_id != null:
 | `farm_till` | Mark tile as tilled (tile property). Award farming XP. |
 | `farm_plant` | Consume seed item. Set crop growth timer on tile. Award farming XP. |
 | `farm_harvest` | Create food `Item` at tile position. Reset tile for next planting. Award farming XP. |
-| `eat` | Remove food item from stockpile. Restore `need_food` by item's restore amount (40 for basic food). |
-| `drink` | Remove drink item from stockpile. Restore `need_drink` by item's restore amount (50 for basic drink). |
-| `sleep` | Restore `need_sleep` to 100. If sleeping in a bed: no stress. If sleeping on the floor: +5 stress. |
+| `eat` | Remove food item from stockpile. Restore `need_food` by `FOOD_RESTORE_AMOUNT` (60). |
+| `drink` | Remove drink item from stockpile. Restore `need_drink` by `DRINK_RESTORE_AMOUNT` (70). |
+| `sleep` | Restore `need_sleep` by `SLEEP_RESTORE_AMOUNT` (60). If sleeping in a bed: no stress. If sleeping on the floor: +5 stress. |
 
 ### XP Awards
 
@@ -229,8 +232,8 @@ Dwarves interrupt work to survive. This is what makes them feel alive rather tha
 
 | Need | Interrupt Threshold | Behavior |
 |------|-------------------|----------|
-| `need_food` | < 25 | Drop task, create `eat` task targeting nearest food item |
-| `need_drink` | < 25 | Drop task, create `drink` task targeting nearest drink item |
+| `need_food` | < 30 | Drop task, create `eat` task targeting nearest food item |
+| `need_drink` | < 30 | Drop task, create `drink` task targeting nearest drink item |
 | `need_sleep` | < 20 | Drop task, create `sleep` task targeting nearest bed (or current tile if no bed) |
 
 These thresholds are constants in `shared/src/constants.ts`.
@@ -301,8 +304,8 @@ At 10 ticks/second, a dwarf with zero food climbs from 0 to tantrum threshold (8
 ## Death
 
 A dwarf dies when:
-- `need_food` reaches 0 and stays there for `STARVATION_TICKS` (490 ticks = ~10 in-game days)
-- `need_drink` reaches 0 and stays there for `DEHYDRATION_TICKS` (245 ticks = ~5 in-game days)
+- `need_food` reaches 0 and stays there for `STARVATION_TICKS` (18,000 ticks = ~10 in-game days)
+- `need_drink` reaches 0 and stays there for `DEHYDRATION_TICKS` (9,000 ticks = ~5 in-game days)
 - `health` reaches 0 (combat, not in Phase 0)
 
 Death is handled in the task-execution phase:
@@ -376,7 +379,7 @@ All 7 dwarves spawn at the fortress center on the surface (z=0). The exact start
 | Plump helmet seed | raw_material | 10 | For first farm |
 | Stone pickaxe | tool | 2 | Mining (not consumed, just required) |
 
-With 30 food and 7 dwarves eating, food lasts about 15 in-game days (~75 real seconds). Drink lasts about 10 days (~50 real seconds). The player must have farming going before supplies run out.
+With 30 food and 7 dwarves eating, food lasts many in-game days (~38 real minutes per dwarf before the food need hits the interrupt threshold). Drink runs out faster due to the higher decay rate. The player must have farming going before supplies run out.
 
 ---
 

--- a/docs/design/11-autonomous-behavior.md
+++ b/docs/design/11-autonomous-behavior.md
@@ -1,5 +1,8 @@
 # 11 — Autonomous Dwarf Behavior
 
+> **Status:** Design only
+> **Last verified:** 2026-03-25
+
 ## Problem
 
 When dwarves have no player-designated tasks and no urgent needs, they stand still doing nothing. The fortress feels dead. Cooking, brewing, and foraging happen automatically via hidden auto-systems, but the player has no visibility into or control over them. Dwarves should feel alive — doing useful things, socializing, and expressing their personalities.

--- a/docs/design/12-tile-variety.md
+++ b/docs/design/12-tile-variety.md
@@ -1,5 +1,8 @@
 # 12 — Tile Variety and Points of Interest
 
+> **Status:** Design only
+> **Last verified:** 2026-03-25
+
 ## Problem
 
 The fortress map feels empty and repetitive. The surface is mostly base terrain (grass/sand/mud) with scattered trees, rocks, bushes, and ponds. Underground caves are cavern_floor and cavern_wall with occasional ore/gem. There's nothing to discover, interact with, or build around. The map doesn't reward exploration or create interesting decisions about where to build.

--- a/docs/design/13-workshops.md
+++ b/docs/design/13-workshops.md
@@ -1,5 +1,8 @@
 # 13 — Workshop System
 
+> **Status:** Design only
+> **Last verified:** 2026-03-25
+
 ## Problem
 
 Crafting tasks (brew, cook, smith) happen anywhere — there's no physical structure requirement. This removes spatial gameplay, hauling logistics, and placement decisions. In Dwarf Fortress, workshop placement and stockpile proximity are the core optimization puzzle. We have none of that.

--- a/docs/system-overviews/data-flow.md
+++ b/docs/system-overviews/data-flow.md
@@ -8,16 +8,26 @@ Monorepo with three workspaces: **app/** (React/Vite), **sim/** (simulation engi
 
 ## Sim Engine
 
-The sim runs a **tick loop at 10 Hz** (100ms per tick). Each tick executes ~12 phases in order:
+The sim runs a **tick loop at 10 Hz** (100ms per tick). Each tick executes 18 phases in order:
 
 1. Needs decay (food, drink, sleep drain per tick)
 2. Task execution (dwarves move to tasks, do work)
 3. Need satisfaction (eat/drink/sleep if critical)
-4. Stress update, tantrum check
-5. Monster pathfinding, combat
-6. Construction progress
-7. Idle wandering, job claiming
-8. Event firing, thought generation
+4. Stress update
+5. Tantrum check
+6. Tantrum actions
+7. Monster spawning
+8. Monster pathfinding
+9. Combat resolution
+10. Expedition tick
+11. Haul assignment
+12. Task recovery
+13. Auto-cook
+14. Auto-brew
+15. Auto-forage
+16. Job claiming (assign idle dwarves to tasks)
+17. Event firing
+18. Thought generation
 
 All state lives in a **`CachedState` object in memory** with dirty-tracking sets (`dirtyDwarfIds`, `dirtyTaskIds`, etc.). Phases mutate this directly.
 
@@ -29,7 +39,7 @@ Key files:
 ## State Persistence (Flush/Load)
 
 - **Load** (`sim/src/load-state.ts`): On start, parallel-fetches dwarves, items, structures, monsters, tasks, and skills from Supabase into `CachedState`.
-- **Flush** (`sim/src/flush-state.ts`): Every **15 seconds**, upserts only dirty entities to Supabase, inserts pending events, polls for new player-created tasks, then clears dirty sets.
+- **Flush** (`sim/src/flush-state.ts`): Every **2 seconds** (`SIM_FLUSH_INTERVAL_MS = 2000`), upserts only dirty entities to Supabase, inserts pending events, polls for new player-created tasks, then clears dirty sets.
 
 The sim is the source of truth while running; the DB is the durable store.
 
@@ -51,7 +61,7 @@ When a player designates an area (e.g., "mine here"):
 
 1. **Optimistic UI** — blueprints show immediately
 2. **Insert to DB** — tasks written directly to Supabase `tasks` table
-3. **Sim polls** — next flush cycle (<=15s), sim picks up new pending tasks
+3. **Sim polls** — next flush cycle (<=2s), sim picks up new pending tasks
 4. **Job claiming phase** — dwarves score and claim tasks
 5. **Task execution** — dwarf pathfinds, does work, completes it
 6. **Flush** — results (mined tiles, moved items) written back to DB
@@ -79,7 +89,7 @@ Sim tick loop (10 Hz, in-memory)
   -> Phases mutate CachedState
   -> Dirty-track changed entities
 
-Every 15s: Flush
+Every 2s: Flush
   -> Upsert dirty entities to Supabase
   -> Poll for new player tasks
   -> Clear dirty sets
@@ -95,8 +105,8 @@ Frontend polling (2-3s intervals)
 | Constant | Value | Notes |
 |---|---|---|
 | `STEPS_PER_SECOND` | 10 | Tick rate |
-| `STEPS_PER_YEAR` | 18,000 | ~30 real-time minutes per in-game year |
-| `SIM_FLUSH_INTERVAL_MS` | 15,000 | How often dirty state writes to DB |
+| `STEPS_PER_YEAR` | 36,000 | ~1 real-time hour per in-game year |
+| `SIM_FLUSH_INTERVAL_MS` | 2,000 | How often dirty state writes to DB |
 | `POLL_DWARVES_MS` | 2,000 | Frontend polling interval |
 | `POLL_TASKS_MS` | 2,000 | Frontend polling interval |
 | `POLL_EVENTS_MS` | 3,000 | Frontend polling interval |

--- a/docs/system-overviews/dwarf-decision-making.md
+++ b/docs/system-overviews/dwarf-decision-making.md
@@ -4,13 +4,26 @@ This document explains how dwarves decide what to do each simulation tick.
 
 ## Overview
 
-Every simulation tick runs these phases in order:
+Every simulation tick runs 18 phases in order (see `sim/src/tick.ts`). The decision-relevant phases are:
 
 1. **needsDecay** — all needs (food, drink, sleep, etc.) tick down
 2. **taskExecution** — dwarves with a task make progress on it
-3. **needsSatisfaction** — dwarves check if a completed eat/drink/sleep task restored needs
-4. **idleWandering** — dwarves with no task are given a wander task
-5. **jobClaiming** — idle dwarves claim the highest-scoring pending task
+3. **needSatisfaction** — creates autonomous eat/drink/sleep tasks when needs fall below interrupt thresholds
+4. **stressUpdate** — recalculates stress from unmet needs and memories
+5. **tantrumCheck** — dwarves with stress >= 80 may enter tantrum
+6. **tantrumActions** — executes tantrum effects (item destruction, attacks)
+7. **monsterSpawning** — spawns new monsters based on fortress wealth
+8. **monsterPathfinding** — monsters advance toward targets
+9. **combatResolution** — resolves fights between monsters and dwarves
+10. **expeditionTick** — advances expedition progress
+11. **haulAssignment** — creates haul tasks for loose items
+12. **taskRecovery** — recovers stuck/failed tasks
+13. **autoCookPhase** — auto-creates cook tasks when food is low
+14. **autoBrew** — auto-creates brew tasks when drinks are low
+15. **autoForage** — auto-creates forage tasks when food is scarce
+16. **jobClaiming** — idle dwarves claim the highest-scoring pending task
+17. **eventFiring** — writes notable events to the database
+18. **thoughtGeneration** — creates dwarf thoughts and memories
 
 ---
 


### PR DESCRIPTION
## Summary
- Fix timing constants across all docs: `STEPS_PER_DAY` 49→1800, `STEPS_PER_YEAR` 18000→36000, derived timings (1 day = 3 min, 1 year = 1 hour)
- Update phase lists from 10-11 phases to all 18 actual phases matching `tick.ts`
- Fix `SIM_FLUSH_INTERVAL_MS` from 15s→2s in data-flow docs
- Fix need interrupt thresholds (25→30), restore amounts (food 40→60, drink 50→70), deprivation ticks (490→18000/245→9000), sleep work (50→600)
- Add status banners (`Implemented` / `Partial` / `Design only`) to all 13 design docs
- Mark 11-autonomous-behavior, 12-tile-variety, 13-workshops as **Design only**
- Add `/docs-audit` skill for periodic doc health checks
- Add CLAUDE.md rules: never commit directly to main; design doc maintenance requirements

Closes #683

## Files changed (17)
- 13 design docs (status banners + fixes)
- 2 system-overview docs (phase lists + constants)
- CLAUDE.md (workflow + design doc rules)
- `.claude/skills/docs-audit/skill.md` (new skill)

## Test plan
- [ ] Docs are markdown-only — no code changes, no tests needed
- [ ] Verify status banners render correctly on GitHub
- [ ] Spot-check constants against `shared/src/constants.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)