### PR TITLE
docs: add design docs for undocumented sim systems

### DIFF
--- a/docs/design/14-dwarf-inner-life.md
+++ b/docs/design/14-dwarf-inner-life.md
@@ -1,0 +1,204 @@
+# 14 — Dwarf Inner Life
+
+> **Status:** Implemented
+> **Last verified:** 2026-03-25
+
+## Overview
+
+Three tightly coupled systems give dwarves an inner emotional life: **memories**, **relationships**, and **thought generation**. Together they create emergent narrative — a dwarf witnesses a friend's death, grieves, accumulates stress, throws a tantrum, and potentially kills another dwarf, triggering a cascade.
+
+## Files
+
+| File | Role |
+|---|---|
+| `sim/src/dwarf-memory.ts` | Memory CRUD, factory functions for each memory type |
+| `sim/src/phases/relationship-formation.ts` | Yearly phase: acquaintance, friend, and spouse progression |
+| `sim/src/phases/thought-generation.ts` | Per-tick personality-influenced thought generation |
+
+## Memory System
+
+Memories are stored as a JSONB array in the `dwarves.memories` column. Each memory has:
+
+| Field | Type | Description |
+|---|---|---|
+| `type` | string | One of the memory types below |
+| `intensity` | number | Positive = stress-inducing, negative = stress-relieving |
+| `year` | number | Year the memory was formed |
+| `expires_year` | number | Year after which the memory is stripped |
+
+### Memory Types
+
+| Type | Intensity | Duration (years) | Trigger |
+|---|---|---|---|
+| `witnessed_death` | 15 | 3 | Alive dwarf within radius 5 of a death |
+| `created_artifact` | -20 | 5 | Dwarf completes an artifact |
+| `created_masterwork` | -10 | 2 | Dwarf creates a masterwork/exceptional item |
+| `married_joy` | -20 | 5 | Both spouses on marriage |
+| `grief_friend` | 25 | 5 | Friend dies (+ immediate 20 stress spike) |
+| `grief_spouse` | 40 | 10 | Spouse dies (+ immediate 35 stress spike) |
+
+### Memory Lifecycle
+
+1. **Creation** — Factory functions (`createWitnessDeathMemories`, `createGriefFriendMemories`, etc.) add memories via `addMemory()`, which appends to the JSONB array and marks the dwarf dirty.
+2. **Active filtering** — `activeMemories(dwarf, currentYear)` returns only non-expired memories. Used by the stress-update phase.
+3. **Decay** — `decayMemories(dwarf, currentYear, state)` strips expired memories during the yearly rollup.
+4. **Stress contribution** — Each active memory contributes `MEMORY_STRESS_PER_TICK (0.00027) * intensity` to the dwarf's stress every tick. Positive intensity increases stress; negative intensity relieves it.
+
+### Witness Death Mechanics
+
+When any dwarf dies (from any cause — deprivation, combat, tantrum), `createWitnessDeathMemories` is called:
+
+- All alive dwarves on the same z-level within `WITNESS_DEATH_RADIUS = 5` Manhattan distance receive a `witnessed_death` memory.
+- The deceased dwarf is excluded.
+
+### Grief Mechanics
+
+After witness memories are applied, relationship-based grief is processed:
+
+- **Friend death** (`createGriefFriendMemories`): Every alive dwarf with a `friend` relationship to the deceased receives an immediate `GRIEF_FRIEND_STRESS = 20` stress spike plus a `grief_friend` memory (intensity 25, 5-year duration).
+- **Spouse death** (`createGriefSpouseMemories`): The surviving spouse receives an immediate `GRIEF_SPOUSE_STRESS = 35` stress spike plus a `grief_spouse` memory (intensity 40, 10-year duration).
+
+## Relationship System
+
+Relationships are stored in the `dwarfRelationships` array on `CachedState`, typed as `DwarfRelationship`.
+
+### Canonical Ordering
+
+To prevent duplicate relationships, IDs are stored in lexicographic order: `dwarf_a_id < dwarf_b_id`. The `sortedIds()` helper enforces this, and `canonicalKey()` builds a lookup key from any pair.
+
+### Yearly Progression
+
+The `relationshipFormationPhase` runs once per year during the yearly rollup. For every pair of alive dwarves:
+
+```
+nothing ──(30% chance)──> acquaintance
+                              │
+                    (after 2 years as acquaintance)
+                              │
+                              v
+                           friend
+                              │
+                    (after 3 years as friend, 5% chance)
+                              │
+                              v
+                           spouse
+```
+
+| Transition | Constant | Value |
+|---|---|---|
+| Nothing to acquaintance | `FRIENDSHIP_FORMATION_CHANCE` | 0.3 (30%) |
+| Acquaintance to friend | `FRIEND_UPGRADE_YEARS` | 2 years |
+| Friend to spouse | `MARRIAGE_FRIEND_MIN_YEARS` | 3 years as friend |
+| Friend to spouse (probability) | `MARRIAGE_CHANCE` | 0.05 (5%) |
+
+Key details:
+- When an acquaintance upgrades to friend, `formed_year` is reset to the current year so the marriage timer counts from friendship, not from first meeting.
+- Marriage triggers `createMarriageMemories` (joy memories for both) and a world event.
+- Strength increases on each upgrade (capped at 10).
+
+## Thought Generation
+
+The `thoughtGeneration` phase runs every tick but only processes every `THOUGHT_INTERVAL = 10` ticks (1 game-second).
+
+### Storage
+
+Thoughts are stored in the same `dwarf.memories` JSONB column as memories, but as `Thought` objects with a different shape:
+
+| Field | Type | Description |
+|---|---|---|
+| `text` | string | Human-readable thought text |
+| `tick` | number | Tick when the thought was generated |
+| `sentiment` | `"positive" \| "negative" \| "neutral"` | Emotional valence |
+
+Maximum `MAX_THOUGHTS = 10` thoughts per dwarf. When the cap is exceeded, the oldest thoughts are trimmed.
+
+### Generators
+
+Four generators run for each alive dwarf:
+
+1. **Need thoughts** — Hunger, thirst, sleep, morale. Thresholds adjusted by neuroticism (`adjustedThreshold(base, trait)`). Each personality point shifts the threshold by 5, so a neurotic dwarf (neuroticism +3) starts worrying at need level 45 instead of 30.
+2. **Work thoughts** — Idle dwarves generate boredom (conscientiousness amplifies distress). Working dwarves with decent morale feel productive.
+3. **Stress thoughts** — High stress triggers worry; neuroticism lowers the threshold. Tantrum state generates its own thought.
+4. **Health thoughts** — Wounded dwarves generate pain thoughts at health < 50.
+
+### Deduplication
+
+`hasRecentThought(dwarf, text, currentTick)` prevents the same thought from appearing within 50 ticks. This stops thought spam when a dwarf stays in the same state for extended periods.
+
+### Personality Influence
+
+Personality traits (Big Five: openness, conscientiousness, extraversion, agreeableness, neuroticism) range from -3 to +3. The `adjustedThreshold(base, traitValue)` function shifts base thresholds by `traitValue * 5`:
+
+- **Neuroticism** affects hunger/thirst/sleep worry thresholds and stress awareness.
+- **Conscientiousness** affects idle-boredom threshold.
+
+## System Interactions
+
+The three systems form a feedback loop that creates emergent narrative:
+
+```
+Relationship Formation (yearly)
+       │
+       ├── creates bonds between dwarves
+       │
+Dwarf Death (any cause)
+       │
+       ├── createWitnessDeathMemories (proximity-based)
+       ├── createGriefFriendMemories (relationship-based, +20 stress spike)
+       └── createGriefSpouseMemories (relationship-based, +35 stress spike)
+                │
+                v
+       Stress Update Phase (per-tick)
+                │
+                ├── MEMORY_STRESS_PER_TICK * intensity per active memory
+                │
+                v
+       Tantrum Check Phase
+                │
+                ├── high stress → tantrum → potential dwarf death
+                │                                    │
+                └────────────────────────────────────┘
+                         (cascade loop)
+
+Thought Generation (every 10 ticks)
+       │
+       └── surfaces the dwarf's inner state as readable text
+```
+
+The tantrum spiral is the key emergent behavior: one death can cascade through grief and stress into more deaths, especially in small fortresses with dense relationships. Long-duration grief memories (spouse grief lasts 10 years) ensure the effects persist across multiple game years.
+
+## Constants
+
+```typescript
+// Memory intensities (positive = stress, negative = relief)
+MEMORY_WITNESSED_DEATH_INTENSITY = 15
+MEMORY_ARTIFACT_INTENSITY = -20
+MEMORY_MASTERWORK_INTENSITY = -10
+MEMORY_MARRIAGE_JOY_INTENSITY = -20
+MEMORY_GRIEF_FRIEND_INTENSITY = 25
+MEMORY_SPOUSE_GRIEF_INTENSITY = 40
+
+// Memory durations
+MEMORY_WITNESSED_DEATH_DURATION_YEARS = 3
+MEMORY_ARTIFACT_DURATION_YEARS = 5
+MEMORY_MASTERWORK_DURATION_YEARS = 2
+MEMORY_GRIEF_FRIEND_DURATION_YEARS = 5
+MEMORY_MARRIAGE_JOY_DURATION_YEARS = 5
+MEMORY_SPOUSE_GRIEF_DURATION_YEARS = 10
+
+// Stress
+WITNESS_DEATH_RADIUS = 5
+GRIEF_FRIEND_STRESS = 20
+GRIEF_SPOUSE_STRESS = 35
+MEMORY_STRESS_PER_TICK = 0.00027
+
+// Relationships
+FRIENDSHIP_FORMATION_CHANCE = 0.3
+FRIEND_UPGRADE_YEARS = 2
+MARRIAGE_CHANCE = 0.05
+MARRIAGE_FRIEND_MIN_YEARS = 3
+
+// Thoughts
+THOUGHT_INTERVAL = 10  (local constant)
+MAX_THOUGHTS = 10      (local constant)
+```

--- a/docs/design/15-hauling-and-stockpiles.md
+++ b/docs/design/15-hauling-and-stockpiles.md
@@ -1,0 +1,115 @@
+# 15 — Hauling and Stockpiles
+
+> **Status:** Implemented
+> **Last verified:** 2026-03-25
+
+## Overview
+
+The hauling system moves loose items from the ground into organized stockpiles. It works alongside the inventory system (item carrying/dropping) and the resource check system (material consumption for building). Together they form the item logistics layer of the sim.
+
+## Files
+
+| File | Role |
+|---|---|
+| `sim/src/phases/haul-assignment.ts` | Creates haul tasks for loose items and carrying dwarves |
+| `sim/src/inventory.ts` | Item pickup, drop, carry weight helpers |
+| `sim/src/resource-check.ts` | Resource availability checks and consumption for build tasks |
+
+## Haul Assignment Phase
+
+The `haulAssignment` phase runs every tick and operates in two passes.
+
+### Phase 1: Dwarves Already Carrying Items
+
+For each idle dwarf currently holding items:
+
+1. If no stockpiles exist at all, drop items on the ground (dwarf is not stuck).
+2. Find the best stockpile tile for the first carried item.
+3. If a valid stockpile is found, create a `haul` task targeting that tile.
+4. If no valid stockpile accepts the item, drop all carried items.
+
+### Phase 2: Ground Items Not on Stockpiles
+
+For each item on the ground that is not already on a stockpile tile:
+
+1. Skip items already targeted by a pending/active haul task (prevents duplicate hauling).
+2. Find the best stockpile tile for the item.
+3. If found, create a `haul` task.
+
+### Duplicate Prevention
+
+A `Set<string>` tracks all item IDs that already have a non-completed haul task. Both phases check this set before creating new tasks. Items added during the current tick's Phase 1 are also tracked so Phase 2 does not duplicate them.
+
+## Stockpile Selection
+
+`findBestStockpile` selects the optimal tile using a priority cascade:
+
+1. **Category filter** — Only tiles whose `accepts_categories` includes the item's category (or `null`/undefined, meaning accept all).
+2. **Capacity check** — Skip tiles at `STOCKPILE_TILE_CAPACITY = 3` items. Capacity counts both items physically on the tile and items targeted by pending haul tasks.
+3. **Priority** — Among valid tiles, prefer the highest `priority` value.
+4. **Distance** — Break ties by nearest Manhattan distance from the item/dwarf.
+
+Returns `null` if no valid tile exists.
+
+## Inventory System
+
+The inventory module provides low-level item manipulation:
+
+| Function | Purpose |
+|---|---|
+| `getCarriedItems(dwarfId, items)` | Returns all items held by a dwarf |
+| `getCarriedWeight(dwarfId, items)` | Sum of `weight` for held items |
+| `canPickUp(dwarfId, item, items)` | Check against `DWARF_CARRY_CAPACITY = 50` |
+| `pickUpItem(dwarf, item, state)` | Set `held_by_dwarf_id`, clear world position, mark dirty |
+| `dropItem(dwarf, item, state)` | Clear `held_by_dwarf_id`, set position to dwarf's location, mark dirty |
+
+Items exist in one of two states:
+- **On ground**: `held_by_dwarf_id = null`, `position_x/y/z` set
+- **Carried**: `held_by_dwarf_id` set, `position_x/y/z = null`
+
+## Resource Check
+
+The `resource-check` module verifies and consumes materials for build tasks. It uses `BUILDING_COSTS` (defined in `shared/src/constants.ts`) which maps task types to arrays of `{ category, material, count }` requirements.
+
+### Two-Pass Verify-Then-Consume
+
+`consumeResources(taskType, ctx, builderId?)`:
+
+1. **Verify pass** — Count available items matching each cost's category and material. If any cost cannot be met, return `false` (nothing consumed).
+2. **Consume pass** — Remove items from `state.items`. Prefers ground items first, then falls back to the builder's held items.
+
+The `builderId` parameter solves a deadlock: when a dwarf mines stone and immediately needs it to build a wall, the stone is in their inventory, not on the ground. Without `builderId`, the resource check would fail.
+
+### Availability Check
+
+`hasResources(taskType, items, civId, includeDwarfId?)` is a read-only check used by the UI and task creation to show whether a build is affordable. Same logic as the verify pass but does not consume.
+
+`countAvailableItems(items, civId, category, material, includeDwarfId?)` counts matching items in a civilization. Items must not be held by another dwarf (unless that dwarf is `includeDwarfId`).
+
+## Constants
+
+```typescript
+WORK_HAUL = 10
+STOCKPILE_TILE_CAPACITY = 3
+DWARF_CARRY_CAPACITY = 50
+```
+
+## Item Flow
+
+```
+Mining / Foraging / Crafting
+         │
+         v
+   Item on ground
+         │
+    ┌────┴─────────────────────┐
+    │                          │
+    v                          v
+ Haul Assignment          Build Task
+ (idle dwarf picks up,    (consumeResources
+  carries to stockpile)    removes from ground
+    │                      or builder inventory)
+    v
+ Stockpile tile
+ (organized, up to 3 per tile)
+```

--- a/docs/design/16-expeditions.md
+++ b/docs/design/16-expeditions.md
@@ -1,0 +1,131 @@
+# 16 — Expeditions
+
+> **Status:** Implemented
+> **Last verified:** 2026-03-25
+
+## Overview
+
+Expeditions send a party of dwarves to explore ancient ruins. Dwarves travel to the ruin, face dangers, loot treasure, and return home. The system is split into a pure resolution function and a per-tick state machine that drives the lifecycle.
+
+## Files
+
+| File | Role |
+|---|---|
+| `sim/src/expedition-resolution.ts` | Pure function: danger calculation, survival rolls, loot generation |
+| `sim/src/phases/expedition-tick.ts` | Per-tick state machine advancing expedition status |
+
+## Expedition Status Flow
+
+```
+traveling ──(arrival)──> resolve ──> retreating ──(arrival)──> complete
+```
+
+1. **Traveling** — Each tick, `travel_ticks_remaining` is decremented. Travel duration is calculated by `calculateTravelTicks(distance, terrain)` at expedition creation.
+2. **Resolution** — When `travel_ticks_remaining` reaches 0, the expedition arrives at the ruin. `resolveExpedition()` is called to determine casualties and loot. The expedition transitions to `retreating`.
+3. **Retreating** — Each tick, `return_ticks_remaining` is decremented. Return distance uses the same Manhattan distance but always assumes `plains` terrain.
+4. **Complete** — When `return_ticks_remaining` reaches 0, surviving dwarves are placed at fortress center (256, 256, 0), loot items are created, and a world event fires.
+
+## Resolution (`resolveExpedition`)
+
+A pure, deterministic function (given a seeded RNG) with no side effects. The caller applies the outcome to state.
+
+### Danger Calculation
+
+```
+effectiveDanger = ruin.danger_level
+                + 20  (if resident_monster_id exists)
+                + 15  (if is_trapped)
+                + 10  (if is_contaminated)
+```
+
+### Survival Rolls
+
+For each dwarf in the party:
+
+```
+survivalRoll = rng.random()        // 0.0 to 1.0
+deathThreshold = effectiveDanger / 200
+```
+
+If `survivalRoll > deathThreshold`, the dwarf survives. Otherwise, they are lost.
+
+Example: a ruin with `danger_level = 50` and a monster (`+20`) has `effectiveDanger = 70`. Death threshold = 70/200 = 0.35, so each dwarf has a 35% chance of death.
+
+### Loot Generation
+
+Loot is only generated if survivors exist and the ruin has `remaining_wealth > 0`.
+
+**Loot count:** `max(1, min(5, floor(remaining_wealth / 500)))` — between 1 and 5 items.
+
+For each item:
+- **Category** — Random from `LOOT_CATEGORIES`: gem, weapon, armor, crafted, raw_material
+- **Material** — Random from `LOOT_MATERIALS`: iron, bronze, gold, silver, obsidian, crystal, bone, jade
+- **Quality** — Scales with ruin wealth. Index = `min(4, floor((remaining_wealth / 10000) * 5 * rng.random()))`. Tiers from `QUALITY_TIERS`: standard, fine, superior, exceptional, masterwork. Wealthier ruins produce higher quality loot on average.
+- **Value** — `floor(50 + rng.random() * (remaining_wealth / lootCount))`, clamped so total `wealthExtracted` does not exceed `remaining_wealth`.
+
+### Outcome Object
+
+```typescript
+interface ExpeditionOutcome {
+  survivingDwarfIds: string[];
+  lostDwarfIds: string[];
+  lootedItems: Array<{ category: ItemCategory; material: string; quality: ItemQuality }>;
+  wealthExtracted: number;
+  log: string;  // narrative summary
+}
+```
+
+## Expedition Tick Phase
+
+The `expeditionTick` phase processes all active expeditions each tick.
+
+### Traveling Phase
+
+- Decrement `travel_ticks_remaining`, mark expedition dirty.
+- On arrival (`<= 0`):
+  - Look up the target ruin.
+  - Gather party dwarves and their skills.
+  - Call `resolveExpedition()`.
+  - Deduct `wealthExtracted` from `ruin.remaining_wealth`.
+  - Mark dead dwarves (`status = 'dead'`, `cause_of_death = 'expedition'`), release their tasks.
+  - Store outcome fields on the expedition object (`dwarves_lost`, `expedition_log`, `items_looted`).
+  - Transition to `retreating` status.
+  - Calculate return trip ticks using Manhattan distance with `plains` terrain.
+  - Stash loot details in `state._pendingExpeditionLoot` map for item creation on return.
+
+### Retreating Phase
+
+- Decrement `return_ticks_remaining`, mark expedition dirty.
+- On arrival (`<= 0`):
+  - Identify surviving dwarves (not dead).
+  - Return survivors to fortress center (256, 256, 0), set `status = 'alive'`, release tasks.
+  - Create loot items from `_pendingExpeditionLoot` at fortress center (only if survivors exist to carry them back).
+  - Clean up pending loot map entry.
+  - Set expedition `status = 'complete'`, record `completed_at`.
+  - Fire a `discovery` world event with expedition outcome details.
+
+## Integration
+
+Expeditions tie into several other systems:
+
+- **Death processing** — Lost dwarves trigger the standard death path (witness memories, grief, stress).
+- **Item system** — Loot items are created at fortress center and enter the normal hauling pipeline.
+- **World events** — Expedition return fires a `discovery` event visible in the event log.
+- **Ruins** — `remaining_wealth` is permanently reduced, making repeated expeditions to the same ruin yield diminishing returns.
+
+## Constants
+
+```typescript
+// Loot categories and materials (local to expedition-resolution.ts)
+LOOT_CATEGORIES = ['gem', 'weapon', 'armor', 'crafted', 'raw_material']
+LOOT_MATERIALS = ['iron', 'bronze', 'gold', 'silver', 'obsidian', 'crystal', 'bone', 'jade']
+QUALITY_TIERS = ['standard', 'fine', 'superior', 'exceptional', 'masterwork']
+
+// Danger modifiers
++20 for resident monster
++15 for traps
++10 for contamination
+
+// Death threshold
+deathThreshold = effectiveDanger / 200
+```


### PR DESCRIPTION
## Summary
- Add `docs/design/14-dwarf-inner-life.md` — documents the memory system, relationship formation (acquaintance→friend→spouse), thought generation, and how they chain into tantrum spirals
- Add `docs/design/15-hauling-and-stockpiles.md` — documents haul assignment (two-phase: carrying dwarves + ground items), stockpile selection (category→priority→distance), and resource consumption
- Add `docs/design/16-expeditions.md` — documents the expedition state machine, danger calculation, survival rolls, and wealth-scaled loot generation

**Skipped** (single-file, self-documenting): task-recovery, monster-spawning, auto-brew, auto-cook, auto-forage

Closes #686

## Test plan
- [ ] Markdown only — no code changes
- [ ] Verify constants referenced in docs match `shared/src/constants.ts`
- [ ] Status banners present on all 3 docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)