### PR TITLE
fix: mud and sand tiles should be buildable (closes #583)

### DIFF
--- a/app/src/hooks/useDesignation.ts
+++ b/app/src/hooks/useDesignation.ts
@@ -42,6 +42,8 @@ const DECONSTRUCTIBLE: ReadonlySet<string> = new Set([
 const FARMABLE: ReadonlySet<string> = new Set([
   'grass',
   'soil',
+  'mud',
+  'sand',
 ]);
 
 export function useDesignation(opts: {
@@ -115,7 +117,7 @@ export function useDesignation(opts: {
     }
 
     const mineable: string[] = ['stone', 'ore', 'gem', 'soil', 'cavern_wall', 'tree', 'rock', 'bush'];
-    const buildable: string[] = ['open_air', 'grass', 'constructed_floor', 'cavern_floor'];
+    const buildable: string[] = ['open_air', 'grass', 'constructed_floor', 'cavern_floor', 'mud', 'sand'];
     const isMine = designationMode === 'mine';
     const isDeconstruct = designationMode === 'deconstruct';
     const isFarm = designationMode === 'farm_till';


### PR DESCRIPTION
## Summary
- Add `mud` and `sand` to the `buildable` array in `useDesignation.ts` so players can place build tasks on these tiles
- Add `mud` and `sand` to the `FARMABLE` set so farm plots can be designated on these ground tiles
- Fixes swamp and desert biomes being unplayable since no structures could be built

## Test plan
- [x] `npm run build` passes (typecheck)
- [x] `npm test` passes (all 1050 tests)
- No new tests needed -- this is a minor constant addition with no new logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Claude Cost
**Claude cost:** $0.74 (687k tokens)