### PR TITLE
feat: in-game bug report with state snapshot for test generation

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -24,6 +24,7 @@ import TaskPriorities from "./components/TaskPriorities";
 import { DwarfModal } from "./components/DwarfModal";
 import { InventoryModal } from "./components/InventoryModal";
 import { CaveScoutModal } from "./components/CaveScoutModal";
+import { BugReportModal } from "./components/BugReportModal";
 import { EpitaphScreen } from "./components/EpitaphScreen";
 import { TutorialOverlay } from "./components/TutorialOverlay";
 import { useTutorial } from "./hooks/useTutorial";
@@ -64,7 +65,7 @@ export default function App() {
   });
 
   // Sim runner — provides live in-memory state
-  const { snapshot, isPaused, togglePause, speed, setSpeed } = useSimRunner(world.civId, world.worldId);
+  const { runnerRef, snapshot, isPaused, togglePause, speed, setSpeed } = useSimRunner(world.civId, world.worldId);
 
   const getFortressTileResult = useFortressTiles({
     civId: world.civId,
@@ -480,6 +481,12 @@ export default function App() {
   // Inventory modal
   const [inventoryOpen, setInventoryOpen] = useState(false);
 
+  // Bug report modal
+  const [bugReportOpen, setBugReportOpen] = useState(false);
+  const getBugReportSnapshot = useCallback(() => {
+    return runnerRef.current?.getBugReportSnapshot() ?? null;
+  }, [runnerRef]);
+
   const handleDwarfClick = useCallback((x: number, y: number) => {
     const dwarf = liveDwarves.find(d => d.position_x === x && d.position_y === y && d.position_z === zLevel);
     if (dwarf) {
@@ -584,6 +591,7 @@ export default function App() {
         dwarves={liveDwarves}
         onTutorial={tutorial.start}
         onInventory={world.civId ? () => setInventoryOpen(true) : undefined}
+        onBugReport={world.civId ? () => setBugReportOpen(true) : undefined}
         soundMuted={soundMuted}
         onToggleMute={toggleMute}
       />
@@ -694,6 +702,16 @@ export default function App() {
             items={liveItems}
             dwarves={liveDwarves}
             onClose={() => setInventoryOpen(false)}
+          />
+        )}
+
+        {bugReportOpen && world.civId && world.worldId && user && (
+          <BugReportModal
+            onClose={() => setBugReportOpen(false)}
+            getSnapshot={getBugReportSnapshot}
+            civId={world.civId}
+            worldId={world.worldId}
+            playerId={user.id}
           />
         )}
 

--- a/app/src/components/BugReportModal.tsx
+++ b/app/src/components/BugReportModal.tsx
@@ -1,0 +1,132 @@
+import { useState, useEffect, useCallback } from "react";
+import type { BugReportSnapshot } from "../hooks/useSimRunner";
+import { supabase } from "../lib/supabase";
+
+interface BugReportModalProps {
+  onClose: () => void;
+  getSnapshot: () => BugReportSnapshot | null;
+  civId: string;
+  worldId: string;
+  playerId: string;
+}
+
+export function BugReportModal({ onClose, getSnapshot, civId, worldId, playerId }: BugReportModalProps) {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  const handleSubmit = useCallback(async () => {
+    if (!title.trim() || submitting) return;
+    setSubmitting(true);
+    setError(null);
+
+    const snapshot = getSnapshot();
+
+    const { error: insertError } = await supabase.from("bug_reports").insert({
+      world_id: worldId,
+      civilization_id: civId,
+      player_id: playerId,
+      title: title.trim(),
+      description: description.trim(),
+      game_state: snapshot ?? {},
+    });
+
+    if (insertError) {
+      setError(insertError.message);
+      setSubmitting(false);
+    } else {
+      setSubmitted(true);
+    }
+  }, [title, description, submitting, getSnapshot, civId, worldId, playerId]);
+
+  return (
+    <div
+      className="absolute inset-0 z-50 flex items-center justify-center"
+      onClick={onClose}
+    >
+      <div
+        className="bg-[var(--bg-panel)] border border-[var(--amber)] p-4 min-w-[340px] max-w-[480px] text-xs"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="text-[var(--green)] font-bold text-sm mb-3">
+          Report Bug
+        </h2>
+
+        {submitted ? (
+          <>
+            <p className="text-[var(--text)] mb-3">
+              Bug report submitted. Game state was captured automatically.
+            </p>
+            <div className="flex justify-end">
+              <button
+                onClick={onClose}
+                className="px-3 py-1 border border-[var(--green)] text-[var(--green)] hover:bg-[var(--green)] hover:text-[var(--bg-panel)] cursor-pointer"
+              >
+                OK
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="mb-2">
+              <label className="block text-[var(--text)] mb-1">Title</label>
+              <input
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="e.g. Dwarf stuck in corridor"
+                className="w-full px-2 py-1 bg-[var(--bg-main,#1a1a2e)] border border-[var(--border)] text-[var(--text)] text-xs outline-none focus:border-[var(--amber)]"
+                autoFocus
+              />
+            </div>
+
+            <div className="mb-3">
+              <label className="block text-[var(--text)] mb-1">What happened?</label>
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Describe what you saw..."
+                rows={4}
+                className="w-full px-2 py-1 bg-[var(--bg-main,#1a1a2e)] border border-[var(--border)] text-[var(--text)] text-xs outline-none focus:border-[var(--amber)] resize-vertical"
+              />
+            </div>
+
+            <p className="text-[var(--border)] mb-3">
+              Full game state will be captured automatically.
+            </p>
+
+            {error && (
+              <p className="text-[var(--red,#f87171)] mb-2">{error}</p>
+            )}
+
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={handleSubmit}
+                disabled={!title.trim() || submitting}
+                className="px-3 py-1 border border-[var(--green)] text-[var(--green)] hover:bg-[var(--green)] hover:text-[var(--bg-panel)] cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                {submitting ? "Submitting..." : "Submit"}
+              </button>
+              <button
+                onClick={onClose}
+                className="px-3 py-1 border border-[var(--text)] text-[var(--text)] hover:text-[var(--amber)] hover:border-[var(--amber)] cursor-pointer"
+              >
+                Cancel
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/Toolbar.tsx
+++ b/app/src/components/Toolbar.tsx
@@ -20,11 +20,12 @@ interface ToolbarProps {
   dwarves?: LiveDwarf[];
   onTutorial?: () => void;
   onInventory?: () => void;
+  onBugReport?: () => void;
   soundMuted?: boolean;
   onToggleMute?: () => void;
 }
 
-export default function Toolbar({ mode, onSignOut, onRestart, onTogglePause, isPaused = false, speed = 1, onSetSpeed, population = 0, year = 1, civName, items = [], wealth = 0, dwarves = [], onTutorial, onInventory, soundMuted = false, onToggleMute }: ToolbarProps) {
+export default function Toolbar({ mode, onSignOut, onRestart, onTogglePause, isPaused = false, speed = 1, onSetSpeed, population = 0, year = 1, civName, items = [], wealth = 0, dwarves = [], onTutorial, onInventory, onBugReport, soundMuted = false, onToggleMute }: ToolbarProps) {
   const alert = mode === "fortress" ? deriveAlert(dwarves) : null;
 
   return (
@@ -96,6 +97,15 @@ export default function Toolbar({ mode, onSignOut, onRestart, onTogglePause, isP
             title={soundMuted ? "Unmute soundtrack" : "Mute soundtrack"}
           >
             {soundMuted ? "Muted" : "Sound"}
+          </button>
+        )}
+        {onBugReport && (
+          <button
+            onClick={onBugReport}
+            className="px-2 py-0.5 border border-[var(--border)] text-[var(--text)] hover:text-[var(--red,#f87171)] hover:border-[var(--red,#f87171)] cursor-pointer"
+            title="Report a bug"
+          >
+            Bug
           </button>
         )}
         {onRestart && (

--- a/app/src/hooks/useSimRunner.ts
+++ b/app/src/hooks/useSimRunner.ts
@@ -1,9 +1,9 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { SimRunner, SupabaseStateAdapter } from '@pwarf/sim';
-import type { SimSnapshot } from '@pwarf/sim';
+import type { SimSnapshot, BugReportSnapshot } from '@pwarf/sim';
 import { supabase } from '../lib/supabase';
 
-export type { SimSnapshot };
+export type { SimSnapshot, BugReportSnapshot };
 
 export function useSimRunner(civId: string | null, worldId: string | null) {
   const runnerRef = useRef<SimRunner | null>(null);

--- a/scripts/bug-to-test.mjs
+++ b/scripts/bug-to-test.mjs
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+
+/**
+ * Generate a scenario test skeleton from a bug report stored in Supabase.
+ *
+ * Usage:
+ *   node scripts/bug-to-test.mjs <bug-report-id>
+ *   node scripts/bug-to-test.mjs --list          # list recent bug reports
+ *
+ * The script reads the bug report's game_state JSONB and generates a
+ * runScenario() test file that reconstructs the exact world state.
+ */
+
+import { createClient } from "@supabase/supabase-js";
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+
+// Load env from app/.env.local
+function loadEnv() {
+  const envPath = resolve(ROOT, "app", ".env.local");
+  if (!existsSync(envPath)) {
+    console.error("Missing app/.env.local — needed for Supabase credentials");
+    process.exit(1);
+  }
+  const lines = readFileSync(envPath, "utf-8").split("\n");
+  const env = {};
+  for (const line of lines) {
+    const match = line.match(/^([^#=]+)=(.*)$/);
+    if (match) env[match[1].trim()] = match[2].trim();
+  }
+  return env;
+}
+
+const env = loadEnv();
+const supabaseUrl = env.VITE_SUPABASE_URL;
+const supabaseKey = env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+  console.error("VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY must be set in app/.env.local");
+  process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+async function listReports() {
+  const { data, error } = await supabase
+    .from("bug_reports")
+    .select("id, title, created_at")
+    .order("created_at", { ascending: false })
+    .limit(20);
+
+  if (error) {
+    console.error("Failed to fetch bug reports:", error.message);
+    process.exit(1);
+  }
+
+  if (!data || data.length === 0) {
+    console.log("No bug reports found.");
+    return;
+  }
+
+  console.log("Recent bug reports:\n");
+  for (const r of data) {
+    const date = new Date(r.created_at).toLocaleDateString();
+    console.log(`  ${r.id}  ${date}  ${r.title}`);
+  }
+  console.log(`\nRun: node scripts/bug-to-test.mjs <id>`);
+}
+
+function slugify(title) {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 50);
+}
+
+function generateTest(report) {
+  const { title, description, game_state: state } = report;
+  const slug = slugify(title);
+  const hasDwarves = state.dwarves?.length > 0;
+  const hasTasks = state.tasks?.length > 0;
+  const hasItems = state.items?.length > 0;
+  const hasStructures = state.structures?.length > 0;
+  const hasTiles = state.fortressTileOverrides?.length > 0;
+  const hasStockpiles = state.stockpileTiles?.length > 0;
+  const hasMonsters = state.monsters?.length > 0;
+  const hasSkills = state.dwarfSkills?.length > 0;
+
+  const lines = [];
+  lines.push(`import { describe, it, expect } from "vitest";`);
+  lines.push(`import { runScenario } from "../run-scenario.js";`);
+  lines.push(`import type { ScenarioConfig } from "../run-scenario.js";`);
+
+  // Import types we need
+  const types = ["Dwarf"];
+  if (hasTasks) types.push("Task");
+  if (hasItems) types.push("Item");
+  if (hasStructures) types.push("Structure");
+  if (hasTiles) types.push("FortressTile");
+  if (hasStockpiles) types.push("StockpileTile");
+  if (hasMonsters) types.push("Monster");
+  if (hasSkills) types.push("DwarfSkill");
+  lines.push(`import type { ${types.join(", ")} } from "@pwarf/shared";`);
+  lines.push(``);
+
+  // Emit state as JSON constants
+  lines.push(`// State captured from bug report: ${title}`);
+  lines.push(`// ${description.replace(/\n/g, "\n// ")}`);
+  lines.push(``);
+
+  if (hasDwarves) {
+    lines.push(`const dwarves: Dwarf[] = ${JSON.stringify(state.dwarves, null, 2)} as Dwarf[];`);
+    lines.push(``);
+  }
+  if (hasSkills) {
+    lines.push(`const dwarfSkills: DwarfSkill[] = ${JSON.stringify(state.dwarfSkills, null, 2)} as DwarfSkill[];`);
+    lines.push(``);
+  }
+  if (hasTasks) {
+    // Only include non-completed tasks for the scenario
+    const activeTasks = state.tasks.filter(t => t.status !== "completed");
+    lines.push(`const tasks: Task[] = ${JSON.stringify(activeTasks, null, 2)} as Task[];`);
+    lines.push(``);
+  }
+  if (hasItems) {
+    lines.push(`const items: Item[] = ${JSON.stringify(state.items, null, 2)} as Item[];`);
+    lines.push(``);
+  }
+  if (hasStructures) {
+    lines.push(`const structures: Structure[] = ${JSON.stringify(state.structures, null, 2)} as Structure[];`);
+    lines.push(``);
+  }
+  if (hasTiles) {
+    lines.push(`const fortressTileOverrides: FortressTile[] = ${JSON.stringify(state.fortressTileOverrides, null, 2)} as FortressTile[];`);
+    lines.push(``);
+  }
+  if (hasStockpiles) {
+    lines.push(`const stockpileTiles: StockpileTile[] = ${JSON.stringify(state.stockpileTiles, null, 2)} as StockpileTile[];`);
+    lines.push(``);
+  }
+  if (hasMonsters) {
+    lines.push(`const monsters: Monster[] = ${JSON.stringify(state.monsters, null, 2)} as Monster[];`);
+    lines.push(``);
+  }
+
+  // Build the test
+  lines.push(`describe("bug report: ${title.replace(/"/g, '\\"')}", () => {`);
+  lines.push(`  it("should reproduce and verify the fix", async () => {`);
+  lines.push(`    const config: ScenarioConfig = {`);
+  if (hasDwarves) lines.push(`      dwarves,`);
+  if (hasSkills) lines.push(`      dwarfSkills,`);
+  if (hasTasks) lines.push(`      tasks,`);
+  if (hasItems) lines.push(`      items,`);
+  if (hasStructures) lines.push(`      structures,`);
+  if (hasTiles) lines.push(`      fortressTileOverrides,`);
+  if (hasStockpiles) lines.push(`      stockpileTiles,`);
+  if (hasMonsters) lines.push(`      monsters,`);
+  lines.push(`      ticks: 200,`);
+  lines.push(`      seed: 42,`);
+  lines.push(`    };`);
+  lines.push(``);
+  lines.push(`    const result = await runScenario(config);`);
+  lines.push(``);
+  lines.push(`    // TODO: Add assertions for the expected behavior.`);
+  lines.push(`    // Examples:`);
+  lines.push(`    // - Verify no dwarf is stuck idle with pending tasks`);
+  lines.push(`    // - Verify a specific task completed`);
+  lines.push(`    // - Verify no dwarf died unexpectedly`);
+  lines.push(`    const aliveDwarves = result.dwarves.filter(d => d.status === "alive");`);
+  lines.push(`    expect(aliveDwarves.length).toBeGreaterThan(0);`);
+  lines.push(``);
+  lines.push(`    // Stuck detection: no alive dwarf should be idle if there are pending tasks`);
+  lines.push(`    const pendingTasks = result.tasks.filter(t => t.status === "pending");`);
+  lines.push(`    const idleDwarves = aliveDwarves.filter(d => d.current_task_id === null);`);
+  lines.push(`    if (pendingTasks.length > 0) {`);
+  lines.push(`      expect(idleDwarves.length, "dwarves idle with pending tasks").toBeLessThan(aliveDwarves.length);`);
+  lines.push(`    }`);
+  lines.push(`  });`);
+  lines.push(`});`);
+  lines.push(``);
+
+  return { slug, content: lines.join("\n") };
+}
+
+async function generateFromReport(reportId) {
+  const { data, error } = await supabase
+    .from("bug_reports")
+    .select("*")
+    .eq("id", reportId)
+    .single();
+
+  if (error || !data) {
+    console.error("Failed to fetch bug report:", error?.message ?? "not found");
+    process.exit(1);
+  }
+
+  if (!data.game_state || Object.keys(data.game_state).length === 0) {
+    console.error("Bug report has no game state snapshot.");
+    process.exit(1);
+  }
+
+  const { slug, content } = generateTest(data);
+  const filename = `bug-${slug}.test.ts`;
+  const outPath = resolve(ROOT, "sim", "src", "__tests__", filename);
+
+  writeFileSync(outPath, content, "utf-8");
+  console.log(`Generated: sim/src/__tests__/${filename}`);
+  console.log(`\nNext steps:`);
+  console.log(`  1. Add specific assertions for the bug`);
+  console.log(`  2. Run: npm test --workspace=sim -- --run ${filename}`);
+  console.log(`  3. Verify it fails (red), then fix the bug, then verify it passes (green)`);
+}
+
+// Main
+const arg = process.argv[2];
+if (!arg) {
+  console.log("Usage:");
+  console.log("  node scripts/bug-to-test.mjs <bug-report-id>");
+  console.log("  node scripts/bug-to-test.mjs --list");
+  process.exit(0);
+}
+
+if (arg === "--list") {
+  await listReports();
+} else {
+  await generateFromReport(arg);
+}

--- a/sim/src/index.ts
+++ b/sim/src/index.ts
@@ -1,5 +1,5 @@
 export { SimRunner } from "./sim-runner.js";
-export type { SimSnapshot } from "./sim-runner.js";
+export type { SimSnapshot, BugReportSnapshot } from "./sim-runner.js";
 export { loadStateFromSupabase } from "./load-state.js";
 export { flushToSupabase } from "./flush-state.js";
 export type { StateAdapter } from "./state-adapter.js";

--- a/sim/src/sim-runner.ts
+++ b/sim/src/sim-runner.ts
@@ -1,5 +1,5 @@
 import { STEPS_PER_SECOND, STEPS_PER_YEAR, STEPS_PER_DAY, SIM_FLUSH_INTERVAL_MS, createFortressDeriver } from "@pwarf/shared";
-import type { Dwarf, Item, Task, WorldEvent, FortressTile, Monster } from "@pwarf/shared";
+import type { Dwarf, DwarfSkill, Item, Structure, StockpileTile, Task, WorldEvent, FortressTile, Monster } from "@pwarf/shared";
 import type { SimContext } from "./sim-context.js";
 import { createEmptyCachedState } from "./sim-context.js";
 import { createRng } from "./rng.js";
@@ -19,6 +19,21 @@ export interface SimSnapshot {
   monsters: Monster[];
   year: number;
   civFallen: boolean;
+}
+
+/** Full state snapshot for bug reports — includes everything needed to reconstruct a ScenarioConfig. */
+export interface BugReportSnapshot {
+  dwarves: Dwarf[];
+  dwarfSkills: DwarfSkill[];
+  items: Item[];
+  structures: Structure[];
+  tasks: Task[];
+  fortressTileOverrides: FortressTile[];
+  stockpileTiles: StockpileTile[];
+  monsters: Monster[];
+  events: WorldEvent[];
+  year: number;
+  step: number;
 }
 
 /**
@@ -160,6 +175,25 @@ export class SimRunner {
     }
 
     console.log(`[sim] stopped at step ${this.stepCount}`);
+  }
+
+  /** Capture full sim state for a bug report. Returns null if the sim isn't running. */
+  getBugReportSnapshot(): BugReportSnapshot | null {
+    if (!this.ctx) return null;
+    const { state } = this.ctx;
+    return {
+      dwarves: state.dwarves.map(d => ({ ...d })),
+      dwarfSkills: state.dwarfSkills.map(s => ({ ...s })),
+      items: state.items.map(i => ({ ...i })),
+      structures: state.structures.map(s => ({ ...s })),
+      tasks: state.tasks.map(t => ({ ...t })),
+      fortressTileOverrides: [...state.fortressTileOverrides.values()].map(t => ({ ...t })),
+      stockpileTiles: [...state.stockpileTiles.values()].map(t => ({ ...t })),
+      monsters: state.monsters.map(m => ({ ...m })),
+      events: state.worldEvents.map(e => ({ ...e })),
+      year: this.currentYear,
+      step: this.stepCount,
+    };
   }
 
   private async pollNewTasks(): Promise<void> {

--- a/supabase/migrations/00028_bug_reports.sql
+++ b/supabase/migrations/00028_bug_reports.sql
@@ -1,0 +1,22 @@
+-- Bug reports with full game state snapshot for scenario test generation
+CREATE TABLE bug_reports (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  world_id UUID NOT NULL REFERENCES worlds(id),
+  civilization_id UUID NOT NULL REFERENCES civilizations(id),
+  player_id UUID NOT NULL REFERENCES players(id),
+  title TEXT NOT NULL,
+  description TEXT NOT NULL,
+  game_state JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- RLS: players can insert their own reports and read all reports
+ALTER TABLE bug_reports ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Players can insert their own bug reports"
+  ON bug_reports FOR INSERT
+  WITH CHECK (auth.uid() = player_id);
+
+CREATE POLICY "Players can read all bug reports"
+  ON bug_reports FOR SELECT
+  USING (true);


### PR DESCRIPTION
Closes #695

## Summary

- Adds a **Bug** button to the toolbar that opens a modal for players to report bugs
- Auto-captures the **full sim state** (dwarves, skills, tasks, items, structures, tiles, stockpiles, monsters) as JSONB at the moment of report
- Stores reports in a new `bug_reports` Supabase table
- Includes `scripts/bug-to-test.mjs` — a script that reads a bug report and generates a `runScenario()` test skeleton with the captured state pre-loaded

### How it works

1. Player clicks **Bug** in the toolbar → modal opens
2. They type a title and description
3. On submit, `SimRunner.getBugReportSnapshot()` captures all in-memory state
4. Report + snapshot saved to Supabase
5. To create a test: `node scripts/bug-to-test.mjs --list` then `node scripts/bug-to-test.mjs <id>`
6. Generated test starts from the exact world state — just add assertions

### Files changed

| File | Change |
|---|---|
| `supabase/migrations/00028_bug_reports.sql` | New table with JSONB snapshot column |
| `sim/src/sim-runner.ts` | `BugReportSnapshot` type + `getBugReportSnapshot()` method |
| `sim/src/index.ts` | Export new type |
| `app/src/components/BugReportModal.tsx` | New modal component |
| `app/src/components/Toolbar.tsx` | Bug report button |
| `app/src/App.tsx` | Wire up modal + snapshot getter |
| `app/src/hooks/useSimRunner.ts` | Export `BugReportSnapshot` type |
| `scripts/bug-to-test.mjs` | CLI to generate scenario tests from reports |

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] Existing tests still pass (pre-existing flaky tests in chaos/long-run unrelated)
- [ ] Migration file matches applied schema
- [ ] Bug button appears in toolbar during fortress mode
- [ ] Modal opens, accepts title + description, submits to Supabase
- [ ] `bug-to-test.mjs --list` shows reports, `bug-to-test.mjs <id>` generates test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)