### PR TITLE
fix: swap dirty sets before flush RPC to prevent zombie task duplicates

### DIFF
--- a/sim/src/__tests__/flush-dirty-race.test.ts
+++ b/sim/src/__tests__/flush-dirty-race.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { SimContext } from "../sim-context.js";
+import { createEmptyCachedState, createRng } from "../sim-context.js";
+import { DEFAULT_TEST_SEED } from "../rng.js";
+import { flushToSupabase } from "../flush-state.js";
+import { makeTask, makeDwarf, makeItem } from "./test-helpers.js";
+
+/**
+ * Creates a fake Supabase client where the rpc() call returns a
+ * manually-controllable promise. This lets us simulate the race
+ * between the async RPC and concurrent state modifications.
+ */
+function createControllableSupabase() {
+  let resolveRpc!: () => void;
+  const rpcPromise = new Promise<{ error: null }>((resolve) => {
+    resolveRpc = () => resolve({ error: null });
+  });
+
+  const flushedPayloads: Record<string, unknown>[] = [];
+
+  const client = {
+    rpc(_name: string, params: Record<string, unknown>) {
+      flushedPayloads.push(params);
+      return rpcPromise;
+    },
+  } as unknown as SupabaseClient;
+
+  return { client, resolveRpc, flushedPayloads };
+}
+
+function createTestCtx(supabase: SupabaseClient): SimContext {
+  return {
+    supabase,
+    civilizationId: "test-civ",
+    worldId: "test-world",
+    civName: "Test Fortress",
+    civTileX: 0,
+    civTileY: 0,
+    fortressDeriver: null,
+    step: 0,
+    year: 1,
+    day: 1,
+    rng: createRng(DEFAULT_TEST_SEED),
+    state: createEmptyCachedState(),
+  };
+}
+
+describe("flush dirty tracking race condition", () => {
+  it("preserves dirty flags for tasks modified during the RPC await", async () => {
+    const { client, resolveRpc } = createControllableSupabase();
+    const ctx = createTestCtx(client);
+    const { state } = ctx;
+
+    // Task T1: created before flush starts, will be included in the flush
+    const t1 = makeTask("haul", {
+      status: "pending",
+      target_x: 5,
+      target_y: 5,
+      target_z: 0,
+    });
+    state.tasks.push(t1);
+    state.taskById.set(t1.id, t1);
+    state.newTasks.push(t1);
+
+    // Start flush — collects T1, then awaits RPC
+    const flushPromise = flushToSupabase(ctx);
+
+    // While RPC is in-flight, simulate a tick creating T2
+    const t2 = makeTask("haul", {
+      status: "pending",
+      target_x: 6,
+      target_y: 6,
+      target_z: 0,
+    });
+    state.tasks.push(t2);
+    state.taskById.set(t2.id, t2);
+    state.newTasks.push(t2);
+
+    // Also simulate T1 getting claimed during the await
+    t1.status = "claimed";
+    t1.assigned_dwarf_id = "some-dwarf";
+    state.dirtyTaskIds.add(t1.id);
+
+    // Resolve the RPC — flush clearing happens
+    resolveRpc();
+    await flushPromise;
+
+    // T2 must still be tracked as new — it was NOT in the flush
+    expect(state.newTasks.some(t => t.id === t2.id)).toBe(true);
+
+    // T1's status change (pending→claimed) must still be dirty
+    // because the flush sent T1 as 'pending', but it's now 'claimed'
+    expect(state.dirtyTaskIds.has(t1.id)).toBe(true);
+  });
+
+  it("preserves dirty flags for dwarves modified during the RPC await", async () => {
+    const { client, resolveRpc } = createControllableSupabase();
+    const ctx = createTestCtx(client);
+    const { state } = ctx;
+
+    // Dwarf D1: dirty before flush
+    const d1 = makeDwarf({ need_food: 90 });
+    state.dwarves.push(d1);
+    state.dirtyDwarfIds.add(d1.id);
+
+    const flushPromise = flushToSupabase(ctx);
+
+    // During RPC await, D1's food decays further
+    d1.need_food = 85;
+    state.dirtyDwarfIds.add(d1.id);
+
+    // Also a new dwarf D2 becomes dirty
+    const d2 = makeDwarf({ need_food: 70 });
+    state.dwarves.push(d2);
+    state.dirtyDwarfIds.add(d2.id);
+
+    resolveRpc();
+    await flushPromise;
+
+    // D1 was re-dirtied after collection — must stay dirty
+    expect(state.dirtyDwarfIds.has(d1.id)).toBe(true);
+
+    // D2 was added during await — must stay dirty
+    expect(state.dirtyDwarfIds.has(d2.id)).toBe(true);
+  });
+
+  it("preserves dirty flags for items modified during the RPC await", async () => {
+    const { client, resolveRpc } = createControllableSupabase();
+    const ctx = createTestCtx(client);
+    const { state } = ctx;
+
+    // Item I1: dirty before flush
+    const i1 = makeItem({ position_x: 5, position_y: 5, position_z: 0 });
+    state.items.push(i1);
+    state.dirtyItemIds.add(i1.id);
+
+    const flushPromise = flushToSupabase(ctx);
+
+    // During await, I1 is picked up (position changes)
+    i1.held_by_dwarf_id = "some-dwarf";
+    state.dirtyItemIds.add(i1.id);
+
+    resolveRpc();
+    await flushPromise;
+
+    // I1 was re-dirtied — must stay dirty
+    expect(state.dirtyItemIds.has(i1.id)).toBe(true);
+  });
+
+  it("clears dirty flags for entities that were NOT modified during await", async () => {
+    const { client, resolveRpc } = createControllableSupabase();
+    const ctx = createTestCtx(client);
+    const { state } = ctx;
+
+    // Task T1: dirty before flush, NOT modified during await
+    const t1 = makeTask("mine", {
+      status: "pending",
+      target_x: 5,
+      target_y: 5,
+      target_z: 0,
+    });
+    state.tasks.push(t1);
+    state.taskById.set(t1.id, t1);
+    state.newTasks.push(t1);
+
+    const flushPromise = flushToSupabase(ctx);
+
+    // Don't modify anything during the await
+
+    resolveRpc();
+    await flushPromise;
+
+    // T1 was flushed and not re-dirtied — should be cleared
+    expect(state.newTasks.some(t => t.id === t1.id)).toBe(false);
+    expect(state.dirtyTaskIds.has(t1.id)).toBe(false);
+  });
+});

--- a/sim/src/flush-state.ts
+++ b/sim/src/flush-state.ts
@@ -106,6 +106,39 @@ async function doFlush(ctx: SimContext): Promise<void> {
 
   if (!hasDirty) return;
 
+  // ── Swap dirty sets before the async RPC ──────────────────────────────
+  // Ticks continue running during the RPC call below. By swapping the
+  // dirty sets for fresh empty ones NOW, any entities dirtied during the
+  // await window will land in the new sets and survive for the next flush.
+  // On RPC failure, the old IDs are merged back into the live sets.
+  const prevDirtyDwarfIds = state.dirtyDwarfIds;
+  const prevDirtyItemIds = state.dirtyItemIds;
+  const prevDirtyStructureIds = state.dirtyStructureIds;
+  const prevDirtyMonsterIds = state.dirtyMonsterIds;
+  const prevDirtyTaskIds = state.dirtyTaskIds;
+  const prevDirtySkillIds = state.dirtyDwarfSkillIds;
+  const prevDirtyTileKeys = state.dirtyFortressTileKeys;
+  const prevDirtyRelIds = state.dirtyDwarfRelationshipIds;
+  const prevDirtyRuinIds = state.dirtyRuinIds;
+  const prevNewTasks = state.newTasks;
+  const prevNewRels = state.newDwarfRelationships;
+  const prevEvents = state.pendingEvents;
+  const prevCivDirty = state.civDirty;
+
+  state.dirtyDwarfIds = new Set();
+  state.dirtyItemIds = new Set();
+  state.dirtyStructureIds = new Set();
+  state.dirtyMonsterIds = new Set();
+  state.dirtyTaskIds = new Set();
+  state.dirtyDwarfSkillIds = new Set();
+  state.dirtyFortressTileKeys = new Set();
+  state.dirtyDwarfRelationshipIds = new Set();
+  state.dirtyRuinIds = new Set();
+  state.newTasks = [];
+  state.newDwarfRelationships = [];
+  state.pendingEvents = [];
+  state.civDirty = false;
+
   // ── Single RPC call ─────────────────────────────────────────────────────
 
   // Build ruin payload for civ-fall
@@ -147,23 +180,26 @@ async function doFlush(ctx: SimContext): Promise<void> {
 
   if (error) {
     console.warn(`[flush] rpc flush_state failed: ${error.message}`);
-    return; // Don't clear dirty tracking on failure — retry next cycle
+    // Merge the pre-swap dirty IDs back so they're retried next cycle.
+    for (const id of prevDirtyDwarfIds) state.dirtyDwarfIds.add(id);
+    for (const id of prevDirtyItemIds) state.dirtyItemIds.add(id);
+    for (const id of prevDirtyStructureIds) state.dirtyStructureIds.add(id);
+    for (const id of prevDirtyMonsterIds) state.dirtyMonsterIds.add(id);
+    for (const id of prevDirtyTaskIds) state.dirtyTaskIds.add(id);
+    for (const id of prevDirtySkillIds) state.dirtyDwarfSkillIds.add(id);
+    for (const key of prevDirtyTileKeys) state.dirtyFortressTileKeys.add(key);
+    for (const id of prevDirtyRelIds) state.dirtyDwarfRelationshipIds.add(id);
+    for (const id of prevDirtyRuinIds) state.dirtyRuinIds.add(id);
+    state.newTasks.push(...prevNewTasks);
+    state.newDwarfRelationships.push(...prevNewRels);
+    state.pendingEvents.push(...prevEvents);
+    state.civDirty = state.civDirty || prevCivDirty;
+    return;
   }
 
-  // Clear dirty tracking after successful flush
-  state.dirtyDwarfIds.clear();
-  state.dirtyItemIds.clear();
-  state.dirtyStructureIds.clear();
-  state.dirtyMonsterIds.clear();
-  state.dirtyTaskIds.clear();
-  state.dirtyDwarfSkillIds.clear();
-  state.dirtyFortressTileKeys.clear();
-  state.dirtyDwarfRelationshipIds.clear();
-  state.dirtyRuinIds.clear();
-  state.newTasks = [];
-  state.newDwarfRelationships = [];
-  state.pendingEvents = [];
-  state.civDirty = false;
+  // No clearing needed here — dirty sets were swapped for fresh empties
+  // before the RPC. Any modifications during the await landed in the new
+  // sets and will be picked up by the next flush cycle.
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixes race condition where `flushToSupabase` cleared ALL dirty tracking after the async RPC, losing changes made by ticks running during the await
- Cancelled tasks never reached the DB, then `pollNewTasks` re-loaded stale versions as zombie duplicates — one per flush cycle (~2s)
- Fix: swap dirty sets for fresh empties **before** the RPC. Modifications during the await land in the new sets. On RPC failure, old IDs merge back for retry.

Closes #705

## Test plan
- [x] New unit test `flush-dirty-race.test.ts` (4 cases) — verifies dirty flags survive for tasks, dwarves, and items modified during the RPC await
- [x] Verifies dirty flags are cleared for entities NOT modified during the await
- [x] Full sim test suite passes (917 tests)
- [x] TypeScript build clean

## Claude Cost
```
TODO: /review-pr will fill this in
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)