### PR TITLE
feat: clickable monsters — inspect any entity on the map (closes #597)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -22,6 +22,7 @@ import { usePublishedRuins } from "./hooks/usePublishedRuins";
 import BuildMenu, { BUILD_OPTIONS } from "./components/BuildMenu";
 import TaskPriorities from "./components/TaskPriorities";
 import { DwarfModal } from "./components/DwarfModal";
+import { MonsterModal } from "./components/MonsterModal";
 import { InventoryModal } from "./components/InventoryModal";
 import { CaveScoutModal } from "./components/CaveScoutModal";
 import { BugReportModal } from "./components/BugReportModal";
@@ -30,7 +31,7 @@ import { TutorialOverlay } from "./components/TutorialOverlay";
 import { useTutorial } from "./hooks/useTutorial";
 import { useSoundtrack } from "./hooks/useSoundtrack";
 import { SURFACE_Z, CAVE_OFFSET, CAVE_SIZE, BUILDING_COSTS, WORK_SCOUT_CAVE } from "@pwarf/shared";
-import type { Item } from "@pwarf/shared";
+import type { Item, Monster } from "@pwarf/shared";
 import type { LiveDwarf } from "./hooks/useDwarves";
 
 export default function App() {
@@ -478,6 +479,11 @@ export default function App() {
   const [modalDwarfId, setModalDwarfId] = useState<string | null>(null);
   const modalDwarf = modalDwarfId ? liveDwarves.find(d => d.id === modalDwarfId) ?? null : null;
 
+  // Monster info modal
+  const [modalMonsterId, setModalMonsterId] = useState<string | null>(null);
+  const liveMonsters = useMemo(() => snapshot?.monsters ?? [], [snapshot]);
+  const modalMonster = modalMonsterId ? liveMonsters.find(m => m.id === modalMonsterId) ?? null : null;
+
   // Inventory modal
   const [inventoryOpen, setInventoryOpen] = useState(false);
 
@@ -494,6 +500,23 @@ export default function App() {
       setFollowedDwarfId(dwarf.id);
     }
   }, [liveDwarves, zLevel]);
+
+  const handleMonsterClick = useCallback((x: number, y: number) => {
+    const monster = liveMonsters.find(m => m.current_tile_x === x && m.current_tile_y === y && m.status === 'active');
+    if (monster) {
+      setModalMonsterId(monster.id);
+    }
+  }, [liveMonsters]);
+
+  const handleGoToMonster = useCallback((monster: Monster) => {
+    if (monster.current_tile_x !== null && monster.current_tile_y !== null) {
+      setFollowedDwarfId(null);
+      viewport.setOffset(
+        monster.current_tile_x - Math.floor(vpCols / 2),
+        monster.current_tile_y - Math.floor(vpRows / 2),
+      );
+    }
+  }, [viewport, vpCols, vpRows]);
 
   // Keyboard shortcuts for build menu items when the menu is open
   useEffect(() => {
@@ -669,6 +692,7 @@ export default function App() {
               ? handleFortressTileClick
               : undefined}
           onDwarfClick={world.mode === "fortress" ? handleDwarfClick : undefined}
+          onMonsterClick={world.mode === "fortress" ? handleMonsterClick : undefined}
           selectedTile={world.mode === "world" ? selectedWorldTile : undefined}
           stockpileTiles={world.mode === "fortress" ? stockpileTiles : undefined}
           groundItems={world.mode === "fortress" ? groundItems : undefined}
@@ -685,6 +709,14 @@ export default function App() {
             onGoTo={handleGoToDwarf}
             items={liveItems}
             tasks={liveTasks}
+          />
+        )}
+
+        {modalMonster && (
+          <MonsterModal
+            monster={modalMonster}
+            onClose={() => setModalMonsterId(null)}
+            onGoTo={handleGoToMonster}
           />
         )}
 

--- a/app/src/components/DwarfModal.tsx
+++ b/app/src/components/DwarfModal.tsx
@@ -1,10 +1,12 @@
-import { useEffect, useState } from "react";
+import { useState, useEffect } from "react";
 import type { DwarfSkill, Item } from "@pwarf/shared";
 import { DWARF_CARRY_CAPACITY, AUTONOMOUS_TASK_TYPES, IDLE_TASK_TYPES } from "@pwarf/shared";
 import { supabase } from "../lib/supabase";
 import type { LiveDwarf, DwarfThought } from "../hooks/useDwarves";
 import type { ActiveTask } from "../hooks/useTasks";
 import { skillStars } from "../utils/skillStars";
+import { EntityModal } from "./EntityModal";
+import { needBar } from "./needBar";
 
 interface DwarfModalProps {
   dwarf: LiveDwarf;
@@ -32,37 +34,8 @@ function dwarfJobLabel(d: LiveDwarf, tasks?: ActiveTask[]): string {
   return `${label} (${pct}%)`;
 }
 
-function needBar(label: string, value: number, color: string) {
-  const pct = Math.round(value);
-  const barColor = value < 25 ? "var(--red, #f87171)" : color;
-  return (
-    <div className="flex items-center gap-1">
-      <span className="w-14 text-[var(--text)]">{label}</span>
-      <div className="flex-1 h-2 bg-[#333] rounded overflow-hidden">
-        <div
-          className="h-full rounded"
-          style={{ width: `${pct}%`, backgroundColor: barColor }}
-        />
-      </div>
-      <span className="w-8 text-right" style={{ color: barColor }}>{pct}</span>
-    </div>
-  );
-}
-
 export function DwarfModal({ dwarf, onClose, onGoTo, items = [], tasks }: DwarfModalProps) {
   const [skills, setSkills] = useState<DwarfSkill[]>([]);
-
-  useEffect(() => {
-    function handleKey(e: KeyboardEvent) {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        e.stopPropagation();
-        onClose();
-      }
-    }
-    window.addEventListener("keydown", handleKey, true);
-    return () => window.removeEventListener("keydown", handleKey, true);
-  }, [onClose]);
 
   useEffect(() => {
     supabase
@@ -79,27 +52,10 @@ export function DwarfModal({ dwarf, onClose, onGoTo, items = [], tasks }: DwarfM
   const carried = items.filter(i => i.held_by_dwarf_id === dwarf.id);
   const totalWeight = carried.reduce((sum, i) => sum + (i.weight ?? 0), 0);
 
-  return (
-    <div
-      className="absolute inset-0 z-50 flex items-center justify-center"
-      onClick={onClose}
-    >
-      <div
-        className="bg-[var(--bg-panel)] border border-[var(--amber)] p-4 min-w-[280px] max-w-[360px] text-xs"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex items-center justify-between mb-2">
-          <h2 className="text-[var(--green)] font-bold text-sm">
-            {dwarf.name}{dwarf.surname ? ` ${dwarf.surname}` : ""}
-          </h2>
-          <button
-            onClick={onClose}
-            className="text-[var(--text)] hover:text-[var(--amber)] cursor-pointer"
-          >
-            [Esc]
-          </button>
-        </div>
+  const title = dwarf.name + (dwarf.surname ? ` ${dwarf.surname}` : "");
 
+  return (
+    <EntityModal title={title} onClose={onClose}>
         <div className="text-[var(--text)] mb-1 flex gap-3">
           <span>Status: <span className="text-[var(--green)]">{dwarfJobLabel(dwarf, tasks)}</span></span>
           {dwarf.age != null && (
@@ -205,7 +161,6 @@ export function DwarfModal({ dwarf, onClose, onGoTo, items = [], tasks }: DwarfM
             </ul>
           </div>
         )}
-      </div>
-    </div>
+    </EntityModal>
   );
 }

--- a/app/src/components/EntityModal.tsx
+++ b/app/src/components/EntityModal.tsx
@@ -1,0 +1,47 @@
+import { useEffect, type ReactNode } from "react";
+
+interface EntityModalProps {
+  title: string;
+  titleColor?: string;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+export function EntityModal({ title, titleColor = "var(--green)", onClose, children }: EntityModalProps) {
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        onClose();
+      }
+    }
+    window.addEventListener("keydown", handleKey, true);
+    return () => window.removeEventListener("keydown", handleKey, true);
+  }, [onClose]);
+
+  return (
+    <div
+      className="absolute inset-0 z-50 flex items-center justify-center"
+      onClick={onClose}
+    >
+      <div
+        className="bg-[var(--bg-panel)] border border-[var(--amber)] p-4 min-w-[280px] max-w-[360px] text-xs"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-2">
+          <h2 className="font-bold text-sm" style={{ color: titleColor }}>
+            {title}
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-[var(--text)] hover:text-[var(--amber)] cursor-pointer"
+          >
+            [Esc]
+          </button>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/MainViewport.tsx
+++ b/app/src/components/MainViewport.tsx
@@ -30,6 +30,8 @@ interface MainViewportProps {
   onTileClick?: (x: number, y: number) => void;
   /** Click handler for clicking a dwarf on the map */
   onDwarfClick?: (x: number, y: number) => void;
+  /** Click handler for clicking a monster on the map */
+  onMonsterClick?: (x: number, y: number) => void;
   /** Selected world tile position */
   selectedTile?: { x: number; y: number } | null;
   /** Stockpile tile positions keyed by "x,y,z" */
@@ -83,6 +85,7 @@ export default function MainViewport({
   onCancelArea,
   onTileClick,
   onDwarfClick,
+  onMonsterClick,
   selectedTile,
   stockpileTiles,
   groundItems,
@@ -447,6 +450,8 @@ export default function MainViewport({
         const cursorKey = `${cursorX},${cursorY}`;
         if (onDwarfClick && dwarfPositions?.has(cursorKey)) {
           onDwarfClick(cursorX, cursorY);
+        } else if (onMonsterClick && monsterPositions?.has(cursorKey)) {
+          onMonsterClick(cursorX, cursorY);
         } else if (onTileClick) {
           onTileClick(cursorX, cursorY);
         }
@@ -461,7 +466,7 @@ export default function MainViewport({
         onDragEnd();
       }
     },
-    [onDragEnd, onDesignateArea, onCancelArea, onTileClick, onDwarfClick, dwarfPositions, isDesignating, selStart, selEnd, cursorX, cursorY],
+    [onDragEnd, onDesignateArea, onCancelArea, onTileClick, onDwarfClick, onMonsterClick, dwarfPositions, monsterPositions, isDesignating, selStart, selEnd, cursorX, cursorY],
   );
 
   return (

--- a/app/src/components/MonsterModal.tsx
+++ b/app/src/components/MonsterModal.tsx
@@ -1,0 +1,84 @@
+import type { Monster } from "@pwarf/shared";
+import { EntityModal } from "./EntityModal";
+import { needBar } from "./needBar";
+
+interface MonsterModalProps {
+  monster: Monster;
+  onClose: () => void;
+  onGoTo: (monster: Monster) => void;
+}
+
+function threatColor(level: number): string {
+  if (level >= 8) return "#ff2222";
+  if (level >= 5) return "#ff6600";
+  if (level >= 3) return "var(--amber)";
+  return "var(--green)";
+}
+
+export function MonsterModal({ monster, onClose, onGoTo }: MonsterModalProps) {
+  const displayName = monster.epithet
+    ? `${monster.name} "${monster.epithet}"`
+    : monster.name;
+
+  return (
+    <EntityModal title={displayName} titleColor="#ff2222" onClose={onClose}>
+      <div className="text-[var(--text)] mb-1 flex gap-3">
+        <span>Type: <span className="text-[var(--green)] capitalize">{monster.type}</span></span>
+        <span>Size: <span className="text-[var(--green)] capitalize">{monster.size_category}</span></span>
+      </div>
+
+      <div className="text-[var(--text)] mb-1 flex gap-3">
+        <span>Behavior: <span className="text-[var(--green)] capitalize">{monster.behavior}</span></span>
+        <span>Status: <span className={monster.status === "active" ? "text-[var(--green)]" : "text-[#f87171]"} >{monster.status}</span></span>
+      </div>
+
+      {monster.current_tile_x !== null && monster.current_tile_y !== null && (
+        <div className="text-[var(--text)] flex items-center justify-between mb-2">
+          <span>
+            Pos: <span className="text-[var(--green)]">({monster.current_tile_x}, {monster.current_tile_y})</span>
+          </span>
+          <button
+            onClick={() => onGoTo(monster)}
+            className="text-[var(--amber)] hover:text-[var(--green)] cursor-pointer"
+          >
+            Go to
+          </button>
+        </div>
+      )}
+
+      <div className="border-t border-[var(--border)] pt-2 mt-2 space-y-1">
+        <div className="text-[var(--amber)] font-bold mb-0.5">Health</div>
+        {needBar("HP", monster.health, "var(--green)")}
+      </div>
+
+      <div className="border-t border-[var(--border)] pt-2 mt-2">
+        <div className="text-[var(--amber)] font-bold mb-0.5">Threat</div>
+        <div className="flex items-center gap-1">
+          <span className="w-14 text-[var(--text)]">Level</span>
+          <span className="font-bold" style={{ color: threatColor(monster.threat_level) }}>
+            {monster.threat_level}
+          </span>
+        </div>
+      </div>
+
+      {monster.lore && (
+        <div className="border-t border-[var(--border)] pt-2 mt-2">
+          <div className="text-[var(--amber)] font-bold mb-0.5">Lore</div>
+          <p className="text-[var(--text)] italic">{monster.lore}</p>
+        </div>
+      )}
+
+      {monster.first_seen_year !== null && (
+        <div className="border-t border-[var(--border)] pt-2 mt-2 text-[var(--text)]">
+          First seen: year {monster.first_seen_year}
+        </div>
+      )}
+
+      {monster.slain_year !== null && (
+        <div className="text-[#f87171] mt-1">
+          Slain in year {monster.slain_year}
+        </div>
+      )}
+    </EntityModal>
+  );
+}

--- a/app/src/components/needBar.tsx
+++ b/app/src/components/needBar.tsx
@@ -1,0 +1,16 @@
+export function needBar(label: string, value: number, color: string) {
+  const pct = Math.round(value);
+  const barColor = value < 25 ? "var(--red, #f87171)" : color;
+  return (
+    <div className="flex items-center gap-1">
+      <span className="w-14 text-[var(--text)]">{label}</span>
+      <div className="flex-1 h-2 bg-[#333] rounded overflow-hidden">
+        <div
+          className="h-full rounded"
+          style={{ width: `${pct}%`, backgroundColor: barColor }}
+        />
+      </div>
+      <span className="w-8 text-right" style={{ color: barColor }}>{pct}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Extract `EntityModal` wrapper from `DwarfModal` — shared modal shell with backdrop, Escape key, and header
- Extract `needBar` helper to its own module for reuse across modals
- Add `MonsterModal` showing name/epithet, type, behavior, size, health bar, threat level (color-coded), lore, first seen year, slain status, and "Go to" button
- Wire up monster clicking in `MainViewport` (checks monster positions after dwarf positions on click)
- Add modal state and handlers in `App.tsx`

Closes #597

## Test plan
- [ ] Click a monster on the map — MonsterModal opens with correct stats
- [ ] Click backdrop or press Escape — modal closes
- [ ] "Go to" button centers viewport on monster
- [ ] Click a dwarf — DwarfModal still works correctly (regression check after EntityModal refactor)
- [ ] Build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Claude Cost
**Claude cost:** $11.96 (18.2M tokens)