### PR TITLE
feat: add Locations tab to RightPanel for discovered caves

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -32,6 +32,7 @@ import { useSoundtrack } from "./hooks/useSoundtrack";
 import { SURFACE_Z, CAVE_OFFSET, CAVE_SIZE, BUILDING_COSTS, WORK_SCOUT_CAVE } from "@pwarf/shared";
 import type { Item } from "@pwarf/shared";
 import type { LiveDwarf } from "./hooks/useDwarves";
+import type { DiscoveredLocation } from "./components/RightPanel";
 
 export default function App() {
   const { session, user, loading, signIn, signUp, signInAsGuest, signOut } = useAuth();
@@ -274,6 +275,21 @@ export default function App() {
     return map;
   }, [liveItems, zLevel]);
 
+  // Discovered cave locations for the Locations tab
+  const discoveredLocations: DiscoveredLocation[] = useMemo(() => {
+    const deriver = getFortressTileResult.deriver;
+    if (!deriver) return [];
+    const overrides = snapshot?.fortressTileOverrides ?? [];
+    return deriver.entrances
+      .filter(e => overrides.some(t => t.z === e.z))
+      .map(e => ({
+        name: deriver.getCaveName(e.z) ?? 'Unknown Cave',
+        entranceX: e.x,
+        entranceY: e.y,
+        caveZ: e.z,
+      }));
+  }, [getFortressTileResult.deriver, snapshot?.fortressTileOverrides]);
+
   // Selected fortress tile (for stockpile inspection)
   const [selectedFortressTile, setSelectedFortressTile] = useState<{ x: number; y: number } | null>(null);
 
@@ -407,6 +423,16 @@ export default function App() {
   const handleGoToDwarf = useCallback((dwarf: LiveDwarf) => {
     setFollowedDwarfId(dwarf.id);
   }, []);
+
+  const handleGoToLocation = useCallback((loc: DiscoveredLocation) => {
+    setFollowedDwarfId(null);
+    setZLevel(loc.caveZ);
+    const center = CAVE_OFFSET + Math.floor(CAVE_SIZE / 2);
+    viewport.setOffset(
+      center - Math.floor(vpCols / 2),
+      center - Math.floor(vpRows / 2),
+    );
+  }, [viewport, vpCols, vpRows]);
 
   // Cave scout modal state
   const [caveScoutModal, setCaveScoutModal] = useState<{
@@ -721,6 +747,8 @@ export default function App() {
           events={events}
           mode={world.mode}
           publishedRuins={publishedRuins}
+          locations={discoveredLocations}
+          onLocationClick={handleGoToLocation}
         />
       </div>
 

--- a/app/src/components/RightPanel.tsx
+++ b/app/src/components/RightPanel.tsx
@@ -2,15 +2,24 @@ import { useState, useEffect, useRef } from "react";
 import type { LiveEvent } from "../hooks/useEvents";
 import type { Ruin } from "@pwarf/shared";
 
+export interface DiscoveredLocation {
+  name: string;
+  entranceX: number;
+  entranceY: number;
+  caveZ: number;
+}
+
 interface RightPanelProps {
   collapsed: boolean;
   onToggle: () => void;
   events: LiveEvent[];
   mode: "world" | "fortress";
   publishedRuins?: Ruin[];
+  locations?: DiscoveredLocation[];
+  onLocationClick?: (loc: DiscoveredLocation) => void;
 }
 
-type FortressTab = "Log" | "Legends";
+type FortressTab = "Log" | "Legends" | "Locations";
 type WorldTab = "Log" | "Legends" | "Graveyard";
 type Tab = FortressTab | WorldTab;
 
@@ -88,8 +97,8 @@ export function causeLabel(cause: string): string {
   }
 }
 
-export default function RightPanel({ collapsed, onToggle, events, mode, publishedRuins = [] }: RightPanelProps) {
-  const tabs: Tab[] = mode === "world" ? ["Log", "Legends", "Graveyard"] : ["Log", "Legends"];
+export default function RightPanel({ collapsed, onToggle, events, mode, publishedRuins = [], locations = [], onLocationClick }: RightPanelProps) {
+  const tabs: Tab[] = mode === "world" ? ["Log", "Legends", "Graveyard"] : ["Log", "Legends", "Locations"];
   const [tab, setTab] = useState<Tab>("Log");
   const logRef = useRef<HTMLDivElement>(null);
   const prevCountRef = useRef(0);
@@ -174,6 +183,25 @@ export default function RightPanel({ collapsed, onToggle, events, mode, publishe
                     </div>
                   ))}
                 </div>
+              )
+            ) : tab === "Locations" ? (
+              locations.length === 0 ? (
+                <p className="text-[var(--text)] opacity-50 italic">No locations discovered.</p>
+              ) : (
+                <ul className="space-y-0.5">
+                  {locations.map((loc) => (
+                    <li key={loc.caveZ}>
+                      <button
+                        onClick={() => onLocationClick?.(loc)}
+                        className="text-left w-full cursor-pointer hover:bg-[var(--bg-hover)] px-1 py-0.5 rounded"
+                        style={{ color: 'var(--green)' }}
+                      >
+                        <span className="mr-1">*</span>
+                        {loc.name}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
               )
             ) : (
               /* Graveyard tab */


### PR DESCRIPTION
Closes #709

## Summary
- Adds a **Locations** tab to the RightPanel in fortress mode, listing all discovered caves
- Each cave entry is clickable and navigates the viewport to that cave (sets z-level + centers camera)
- Exports a `DiscoveredLocation` interface from `RightPanel.tsx`
- Computes discovered locations in `App.tsx` via `useMemo` from the fortress deriver's entrances filtered by snapshot overrides
- Shows "No locations discovered." placeholder when no caves have been scouted yet

## Files changed
- `app/src/components/RightPanel.tsx` — new `DiscoveredLocation` interface, `Locations` tab type, tab rendering with clickable cave list
- `app/src/App.tsx` — `discoveredLocations` memo, `handleGoToLocation` callback, props wired to RightPanel

## Test plan
- [ ] Build passes (`npm run build`) -- verified locally
- [ ] Fortress mode shows Log, Legends, Locations tabs
- [ ] Before any caves are scouted, Locations tab shows italic placeholder
- [ ] After discovering a cave, it appears in the Locations tab with green styling
- [ ] Clicking a location navigates to the cave z-level and centers the viewport

## Claude Cost
**Claude cost:** $0.92 (523k tokens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)