### PR TITLE
feat: make STEPS_PER_YEAR/STEPS_PER_DAY configurable in scenarios

### DIFF
--- a/sim/src/__tests__/relationship-formation-scenario.test.ts
+++ b/sim/src/__tests__/relationship-formation-scenario.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { runScenario } from "../run-scenario.js";
 import { makeRealisticScenario } from "./test-helpers.js";
-import { STEPS_PER_YEAR } from "@pwarf/shared";
 
 /**
  * Relationship Formation scenario tests.
@@ -12,7 +11,13 @@ import { STEPS_PER_YEAR } from "@pwarf/shared";
  *
  * Uses makeRealisticScenario with the fortress deriver so pathfinding,
  * movement, and tile lookup all exercise the full BFS + simplex pipeline.
+ *
+ * Uses a small stepsPerYear override so the year rollup fires after ~20
+ * ticks instead of 36,000, keeping the test fast.
  */
+
+const FAST_YEAR = 20;
+const FAST_DAY = 5;
 
 describe("relationship formation", () => {
   it("forms acquaintances after the first yearly rollup", async () => {
@@ -23,7 +28,9 @@ describe("relationship formation", () => {
       drinkCount: 200,
     });
 
-    config.ticks = STEPS_PER_YEAR + 1;
+    config.stepsPerYear = FAST_YEAR;
+    config.stepsPerDay = FAST_DAY;
+    config.ticks = FAST_YEAR + 1;
 
     const result = await runScenario(config);
 
@@ -57,5 +64,5 @@ describe("relationship formation", () => {
         e.description.includes("ends"),
     );
     expect(yearEndEvents.length).toBeGreaterThanOrEqual(1);
-  }, 600_000);
+  }, 60_000);
 });

--- a/sim/src/run-scenario.test.ts
+++ b/sim/src/run-scenario.test.ts
@@ -11,7 +11,6 @@ function woodLog() {
 import {
   FOOD_DECAY_PER_TICK,
   NEED_INTERRUPT_FOOD,
-  STEPS_PER_YEAR,
   WORK_BUILD_WALL,
   WORK_BUILD_FLOOR,
   WORK_BUILD_BED,
@@ -29,8 +28,8 @@ describe("runScenario", () => {
     expect(result.year).toBe(1);
   });
 
-  it("advances year after STEPS_PER_YEAR ticks", async () => {
-    const result = await runScenario({ dwarves: [makeDwarf()], ticks: STEPS_PER_YEAR });
+  it("advances year after stepsPerYear ticks", async () => {
+    const result = await runScenario({ dwarves: [makeDwarf()], ticks: 200, stepsPerYear: 200, stepsPerDay: 10 });
     expect(result.year).toBe(2);
   });
 

--- a/sim/src/run-scenario.ts
+++ b/sim/src/run-scenario.ts
@@ -23,6 +23,10 @@ export interface ScenarioConfig {
   fortressDeriver?: FortressDeriver;
   ticks: number;
   seed?: number;
+  /** Override STEPS_PER_YEAR for faster year rollups in tests. */
+  stepsPerYear?: number;
+  /** Override STEPS_PER_DAY for faster day progression in tests. */
+  stepsPerDay?: number;
 }
 
 /** Full final state returned after a scenario run — suitable for test assertions. */
@@ -94,6 +98,8 @@ export async function runScenario(config: ScenarioConfig): Promise<ScenarioResul
     day: 1,
     rng: createRng(seed),
     state,
+    stepsPerYear: config.stepsPerYear,
+    stepsPerDay: config.stepsPerDay,
   };
 
   // Accumulate all events fired across the run

--- a/sim/src/sim-context.ts
+++ b/sim/src/sim-context.ts
@@ -205,6 +205,11 @@ export interface SimContext {
 
   /** Mutable cached world state, loaded at start and patched each tick. */
   state: CachedState;
+
+  /** Override for STEPS_PER_YEAR — used in tests to speed up year rollups. */
+  stepsPerYear?: number;
+  /** Override for STEPS_PER_DAY — used in tests to speed up day progression. */
+  stepsPerDay?: number;
 }
 
 /** Creates a SimContext with a default test seed. Used in tests. */

--- a/sim/src/tick.ts
+++ b/sim/src/tick.ts
@@ -44,7 +44,9 @@ export async function runTick(ctx: SimContext): Promise<void> {
 
 /** Advance day/year counters on a SimContext for the given step number. */
 export function advanceTime(ctx: SimContext, step: number, currentYear: number): void {
-  const day = Math.floor((step % STEPS_PER_YEAR) / STEPS_PER_DAY) + 1;
+  const spy = ctx.stepsPerYear ?? STEPS_PER_YEAR;
+  const spd = ctx.stepsPerDay ?? STEPS_PER_DAY;
+  const day = Math.floor((step % spy) / spd) + 1;
   ctx.step = step;
   ctx.day = day;
   ctx.year = currentYear;
@@ -52,7 +54,8 @@ export function advanceTime(ctx: SimContext, step: number, currentYear: number):
 
 /** Run yearly rollup if the step lands on a year boundary, updating ctx. Returns the new year. */
 export async function maybeYearRollup(ctx: SimContext, step: number, currentYear: number): Promise<number> {
-  if (step % STEPS_PER_YEAR === 0) {
+  const spy = ctx.stepsPerYear ?? STEPS_PER_YEAR;
+  if (step % spy === 0) {
     const newYear = currentYear + 1;
     ctx.year = newYear;
     ctx.day = 1;


### PR DESCRIPTION
## Summary
- Add optional `stepsPerYear`/`stepsPerDay` overrides to `SimContext` and `ScenarioConfig` so tests can trigger year rollups without running 36,000+ ticks
- `advanceTime` and `maybeYearRollup` in `tick.ts` now read from `ctx.stepsPerYear`/`ctx.stepsPerDay`, falling back to the shared constants when not set
- The `relationship-formation-scenario` test drops from ~7.7 min to ~1.6s by using `stepsPerYear=20`
- The `run-scenario.test.ts` year-advance test uses the override (200 ticks instead of 36,000)
- Production code paths (`sim-runner.ts`) are unaffected — they never set overrides

Closes #707

## Test plan
- [x] `npm run build` passes (types verified)
- [x] `relationship-formation-scenario.test.ts` passes in ~1.6s (was ~7.7 min)
- [x] `run-scenario.test.ts` passes (year advance test uses override)
- [x] `chaos-test-deep.test.ts` passes (unchanged, uses real constants)
- [x] All 3 modified test files pass together

🤖 Generated with [Claude Code](https://claude.com/claude-code)