### PR TITLE
fix: mark monsters dirty so they flush to DB (closes #710)

### DIFF
--- a/sim/src/phases/combat-resolution.ts
+++ b/sim/src/phases/combat-resolution.ts
@@ -114,6 +114,7 @@ export async function combatResolution(ctx: SimContext): Promise<void> {
     const skillBonus = fightingSkill ? Math.floor(fightingSkill.level / 2) : 0;
     const dwarfDmg = rollDamage(rng, DWARF_ATTACK_BASE + skillBonus, COMBAT_DAMAGE_SPREAD);
     monster.health = Math.max(0, monster.health - dwarfDmg);
+    state.dirtyMonsterIds.add(monster.id);
 
     if (monster.health <= 0) {
       slayMonster(monster, target, ctx);
@@ -143,6 +144,7 @@ function slayMonster(monster: Monster, killer: Dwarf, ctx: SimContext): void {
   monster.slain_year = ctx.year;
   monster.slain_by_dwarf_id = killer.id;
   monster.slain_in_civ_id = ctx.civilizationId;
+  state.dirtyMonsterIds.add(monster.id);
 
   // Award XP to the killer — create/update fighting skill record
   const existing = state.dwarfSkills.find(

--- a/sim/src/phases/monster-pathfinding.ts
+++ b/sim/src/phases/monster-pathfinding.ts
@@ -44,6 +44,7 @@ export async function monsterPathfinding(ctx: SimContext): Promise<void> {
 
     monster.current_tile_x = newX;
     monster.current_tile_y = newY;
+    state.dirtyMonsterIds.add(monster.id);
   }
 }
 

--- a/sim/src/phases/monster-spawning.ts
+++ b/sim/src/phases/monster-spawning.ts
@@ -70,6 +70,7 @@ export async function monsterSpawning(ctx: SimContext): Promise<void> {
   };
 
   state.monsters.push(monster);
+  state.dirtyMonsterIds.add(monster.id);
 
   state.pendingEvents.push({
     id: rng.uuid(),


### PR DESCRIPTION
## Summary
- Monsters were never added to `state.dirtyMonsterIds`, so they were never flushed to the database
- World events referencing those monster IDs *were* flushed, causing FK constraint violations on `world_events_monster_id_fkey`
- Added `state.dirtyMonsterIds.add(monster.id)` in all four mutation sites: monster spawning, combat damage, monster slaying, and monster pathfinding

## Test plan
- [x] `npm run build` passes (typecheck)
- [x] `npm test` — all failures are pre-existing timeouts on main, unrelated to this change
- [ ] Verify in a live session that monsters now persist to DB and world_events no longer cause FK violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Claude Cost
**Claude cost:** $0.84 (741k tokens)