### PR TITLE
fix: shove/swap idle dwarves in narrow corridors to prevent deadlock (closes #714)

### DIFF
--- a/sim/src/__tests__/stockpile-corridor-deadlock.test.ts
+++ b/sim/src/__tests__/stockpile-corridor-deadlock.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import { runScenario } from "../run-scenario.js";
+import { makeDwarf, makeSkill, makeItem, makeMapTile } from "./test-helpers.js";
+import { SKILL_NAMES } from "@pwarf/shared";
+import type { FortressDeriver, StockpileTile } from "@pwarf/shared";
+
+/** Wall-only deriver — only explicit tile overrides are walkable, keeping pathfinding fast. */
+const wallDeriver: FortressDeriver = {
+  deriveTile: () => ({ tileType: 'constructed_wall' as const, material: 'stone', isMined: false }),
+  baseTileType: 'constructed_wall' as any,
+  getZForEntrance: () => null,
+  getEntranceForZ: () => null,
+  getCaveName: () => null,
+} as any;
+
+/**
+ * Deadlock scenario: dwarves in a narrow corridor can't reach a dead-end stockpile.
+ *
+ * Layout (z=0):
+ *   x: 5   6   7
+ * y=0: wall wall wall       <- dead end
+ * y=1: wall [SP] wall       <- stockpile
+ * y=2: wall  .  wall        <- corridor
+ * y=3: wall  .  wall        <- corridor
+ * y=4: wall  .  wall        <- corridor
+ * y=5: floor floor floor    <- open area
+ * y=6: floor floor floor
+ */
+describe("stockpile corridor deadlock", () => {
+  function makeCorridorTiles() {
+    return [
+      makeMapTile(5, 0, 0, "stone"),
+      makeMapTile(6, 0, 0, "stone"),
+      makeMapTile(7, 0, 0, "stone"),
+      ...[1, 2, 3, 4].flatMap(y => [
+        makeMapTile(5, y, 0, "stone"),
+        makeMapTile(6, y, 0, "constructed_floor"),
+        makeMapTile(7, y, 0, "stone"),
+      ]),
+      ...[5, 6, 7, 8].flatMap(x => [
+        makeMapTile(x, 5, 0, "constructed_floor"),
+        makeMapTile(x, 6, 0, "constructed_floor"),
+      ]),
+    ];
+  }
+
+  function makeStockpile(): StockpileTile[] {
+    return [{
+      id: "sp-deadend",
+      civilization_id: "test-civ",
+      x: 6, y: 1, z: 0,
+      accepts_categories: null,
+      priority: 1,
+      created_at: new Date().toISOString(),
+    }];
+  }
+
+  it("dwarves in a narrow corridor can deposit items at a dead-end stockpile", async () => {
+    const dwarves = [
+      makeDwarf({ name: "A", civilization_id: "test-civ", position_x: 6, position_y: 2, position_z: 0, need_food: 100, need_drink: 100, need_sleep: 100 }),
+      makeDwarf({ name: "B", civilization_id: "test-civ", position_x: 6, position_y: 3, position_z: 0, need_food: 100, need_drink: 100, need_sleep: 100 }),
+      makeDwarf({ name: "C", civilization_id: "test-civ", position_x: 6, position_y: 4, position_z: 0, need_food: 100, need_drink: 100, need_sleep: 100 }),
+    ];
+
+    const items = dwarves.map(d => makeItem({
+      name: "Stone block",
+      category: "raw_material",
+      material: "stone",
+      located_in_civ_id: "test-civ",
+      held_by_dwarf_id: d.id,
+      position_x: d.position_x,
+      position_y: d.position_y,
+      position_z: d.position_z,
+    }));
+
+    const dwarfSkills = dwarves.flatMap(d =>
+      SKILL_NAMES.map(skill => makeSkill(d.id, skill, 2))
+    );
+
+    const supplies = [];
+    for (let i = 0; i < 10; i++) {
+      supplies.push(makeItem({ name: "Plump helmet", category: "food", material: "plant", located_in_civ_id: "test-civ", position_x: 8, position_y: 6, position_z: 0 }));
+      supplies.push(makeItem({ name: "Dwarven ale", category: "drink", material: "plant", located_in_civ_id: "test-civ", position_x: 8, position_y: 6, position_z: 0 }));
+    }
+
+    const result = await runScenario({
+      dwarves,
+      dwarfSkills,
+      items: [...items, ...supplies],
+      fortressTileOverrides: makeCorridorTiles(),
+      stockpileTiles: makeStockpile(),
+      fortressDeriver: wallDeriver,
+      ticks: 400,
+      seed: 42,
+    });
+
+    const stoneBlocks = result.items.filter(i => i.name === "Stone block");
+    const deposited = stoneBlocks.filter(i =>
+      i.held_by_dwarf_id === null &&
+      i.position_x === 6 && i.position_y === 1 && i.position_z === 0
+    );
+    expect(deposited.length).toBe(3);
+  });
+
+  it("dwarf blocked by two idle dwarves can still deposit at stockpile", async () => {
+    const blocker1 = makeDwarf({ name: "B1", civilization_id: "test-civ", position_x: 6, position_y: 2, position_z: 0, need_food: 100, need_drink: 100, need_sleep: 100 });
+    const blocker2 = makeDwarf({ name: "B2", civilization_id: "test-civ", position_x: 6, position_y: 3, position_z: 0, need_food: 100, need_drink: 100, need_sleep: 100 });
+    const hauler = makeDwarf({ name: "A", civilization_id: "test-civ", position_x: 6, position_y: 4, position_z: 0, need_food: 100, need_drink: 100, need_sleep: 100 });
+
+    const item = makeItem({
+      name: "Stone block",
+      category: "raw_material",
+      material: "stone",
+      located_in_civ_id: "test-civ",
+      held_by_dwarf_id: hauler.id,
+      position_x: hauler.position_x,
+      position_y: hauler.position_y,
+      position_z: hauler.position_z,
+    });
+
+    const allDwarves = [blocker1, blocker2, hauler];
+    const dwarfSkills = allDwarves.flatMap(d =>
+      SKILL_NAMES.map(skill => makeSkill(d.id, skill, 2))
+    );
+
+    const supplies = [];
+    for (let i = 0; i < 10; i++) {
+      supplies.push(makeItem({ name: "Plump helmet", category: "food", material: "plant", located_in_civ_id: "test-civ", position_x: 8, position_y: 6, position_z: 0 }));
+      supplies.push(makeItem({ name: "Dwarven ale", category: "drink", material: "plant", located_in_civ_id: "test-civ", position_x: 8, position_y: 6, position_z: 0 }));
+    }
+
+    const result = await runScenario({
+      dwarves: allDwarves,
+      dwarfSkills,
+      items: [item, ...supplies],
+      fortressTileOverrides: makeCorridorTiles(),
+      stockpileTiles: makeStockpile(),
+      fortressDeriver: wallDeriver,
+      ticks: 100,
+      seed: 42,
+    });
+
+    const stoneBlock = result.items.find(i => i.name === "Stone block");
+    expect(stoneBlock?.held_by_dwarf_id).toBeNull();
+    expect(stoneBlock?.position_x).toBe(6);
+    expect(stoneBlock?.position_y).toBe(1);
+    expect(stoneBlock?.position_z).toBe(0);
+  });
+});

--- a/sim/src/phases/task-execution.test.ts
+++ b/sim/src/phases/task-execution.test.ts
@@ -573,12 +573,10 @@ describe("taskExecution", () => {
 
       await taskExecution(ctx);
 
-      // The dwarf should NOT have moved back to (0,0) — should stay at (1,0)
-      expect(dwarf.position_x).toBe(1);
+      // The idle blocker should be shoved to (3,0) and the dwarf proceeds to (2,0)
+      expect(blocker.position_x).toBe(3);
+      expect(dwarf.position_x).toBe(2);
       expect(dwarf.position_y).toBe(0);
-
-      // Occupancy wait counter should have incremented
-      expect(ctx.state._occupancyWaitTicks?.get(dwarf.id)).toBe(1);
     });
 
     it("records previous position on successful movement", async () => {

--- a/sim/src/phases/task-execution.ts
+++ b/sim/src/phases/task-execution.ts
@@ -48,11 +48,14 @@ export async function taskExecution(ctx: SimContext): Promise<void> {
       }
     : undefined;
 
-  // Build a set of occupied tiles so dwarves don't stack on each other
+  // Build a set of occupied tiles and a position-to-dwarf map for shove logic
   const occupiedTiles = new Set<string>();
+  const dwarfAtPos = new Map<string, Dwarf>();
   for (const d of state.dwarves) {
     if (d.status === 'alive') {
-      occupiedTiles.add(`${d.position_x},${d.position_y},${d.position_z}`);
+      const key = `${d.position_x},${d.position_y},${d.position_z}`;
+      occupiedTiles.add(key);
+      dwarfAtPos.set(key, d);
     }
   }
 
@@ -113,15 +116,33 @@ export async function taskExecution(ctx: SimContext): Promise<void> {
                   ctx.state._previousPositions.set(dwarf.id, `${dwarf.position_x},${dwarf.position_y},${dwarf.position_z}`);
                   const prevKey = `${dwarf.position_x},${dwarf.position_y},${dwarf.position_z}`;
                   occupiedTiles.delete(prevKey);
+                  dwarfAtPos.delete(prevKey);
                   occupiedTiles.add(finalKey);
+                  dwarfAtPos.set(finalKey, dwarf);
                   dwarf.position_x = haulNext.x;
                   dwarf.position_y = haulNext.y;
                   dwarf.position_z = haulNext.z;
                   state.dirtyDwarfIds.add(dwarf.id);
                 }
               } else {
-                // Blocked by occupancy — track wait and fail after threshold
-                if (!incrementOccupancyWait(dwarf, ctx)) {
+                // All paths blocked — try shove, then swap, then wait
+                if (tryShoveBlocker(haulNext, haulStart, ctx, occupiedTiles, dwarfAtPos, zResolver)) {
+                  ctx.state._occupancyWaitTicks?.delete(dwarf.id);
+                  if (!ctx.state._previousPositions) ctx.state._previousPositions = new Map();
+                  ctx.state._previousPositions.set(dwarf.id, `${dwarf.position_x},${dwarf.position_y},${dwarf.position_z}`);
+                  const prevKey = `${dwarf.position_x},${dwarf.position_y},${dwarf.position_z}`;
+                  occupiedTiles.delete(prevKey);
+                  dwarfAtPos.delete(prevKey);
+                  const fk = `${haulNext.x},${haulNext.y},${haulNext.z}`;
+                  occupiedTiles.add(fk);
+                  dwarfAtPos.set(fk, dwarf);
+                  dwarf.position_x = haulNext.x;
+                  dwarf.position_y = haulNext.y;
+                  dwarf.position_z = haulNext.z;
+                  state.dirtyDwarfIds.add(dwarf.id);
+                } else if (trySwapWithBlocker(dwarf, haulNext, ctx, occupiedTiles, dwarfAtPos)) {
+                  // Swapped — dwarf already moved
+                } else if (!incrementOccupancyWait(dwarf, ctx)) {
                   failTask(dwarf, task, state);
                 }
               }
@@ -157,7 +178,7 @@ export async function taskExecution(ctx: SimContext): Promise<void> {
       }
 
       if (!atSite) {
-        const moved = moveTowardTarget(dwarf, task, ctx, occupiedTiles, zResolver);
+        const moved = moveTowardTarget(dwarf, task, ctx, occupiedTiles, dwarfAtPos, zResolver);
         if (!moved) {
           failTask(dwarf, task, state);
         }
@@ -208,7 +229,7 @@ function isAdjacentToTarget(dwarf: Dwarf, task: Task): boolean {
   return (dx + dy) === 1;
 }
 
-function moveTowardTarget(dwarf: Dwarf, task: Task, ctx: SimContext, occupiedTiles: Set<string>, zResolver?: ZResolver): boolean {
+function moveTowardTarget(dwarf: Dwarf, task: Task, ctx: SimContext, occupiedTiles: Set<string>, dwarfAtPos: Map<string, Dwarf>, zResolver?: ZResolver): boolean {
   if (task.target_x === null || task.target_y === null || task.target_z === null) return true;
 
   // Already at the task site — no movement needed
@@ -239,9 +260,15 @@ function moveTowardTarget(dwarf: Dwarf, task: Task, ctx: SimContext, occupiedTil
       nextStep = altStep;
       usedAltPath = true;
     } else {
-      // All paths blocked by occupancy — track wait ticks and fail after threshold
-      // so the task gets released and can be reclaimed when the area clears.
-      return incrementOccupancyWait(dwarf, ctx);
+      // All paths blocked — try to shove the blocking dwarf aside, then swap
+      if (tryShoveBlocker(nextStep, start, ctx, occupiedTiles, dwarfAtPos, zResolver)) {
+        // Blocker moved — proceed with the original step
+      } else if (trySwapWithBlocker(dwarf, nextStep, ctx, occupiedTiles, dwarfAtPos)) {
+        // Swapped positions with idle blocker — dwarf is already at nextStep
+        return true;
+      } else {
+        return incrementOccupancyWait(dwarf, ctx);
+      }
     }
   }
 
@@ -264,7 +291,9 @@ function moveTowardTarget(dwarf: Dwarf, task: Task, ctx: SimContext, occupiedTil
   // Update occupancy tracking
   const prevKey = `${dwarf.position_x},${dwarf.position_y},${dwarf.position_z}`;
   occupiedTiles.delete(prevKey);
+  dwarfAtPos.delete(prevKey);
   occupiedTiles.add(finalKey);
+  dwarfAtPos.set(finalKey, dwarf);
 
   dwarf.position_x = nextStep.x;
   dwarf.position_y = nextStep.y;
@@ -319,6 +348,110 @@ export function getTileHardness(tileType: string | null): number {
     case 'cavern_wall': return HARDNESS_IGNITE; // 1.5 — slow
     default:           return HARDNESS_STONE;   // 1.0 — rock, open_air, etc.
   }
+}
+
+/**
+ * Atomically swap a task-bearing dwarf with an idle blocker.
+ * Used when shove fails (e.g. dead-end corridor where the blocker has nowhere to go).
+ */
+function trySwapWithBlocker(
+  requester: Dwarf,
+  blockerPos: { x: number; y: number; z: number },
+  ctx: SimContext,
+  occupiedTiles: Set<string>,
+  dwarfAtPos: Map<string, Dwarf>,
+): boolean {
+  const blockerKey = `${blockerPos.x},${blockerPos.y},${blockerPos.z}`;
+  const blocker = dwarfAtPos.get(blockerKey);
+  if (!blocker || blocker.status !== 'alive') return false;
+  if (blocker.current_task_id !== null) return false;
+
+  const requesterKey = `${requester.position_x},${requester.position_y},${requester.position_z}`;
+
+  blocker.position_x = requester.position_x;
+  blocker.position_y = requester.position_y;
+  blocker.position_z = requester.position_z;
+
+  requester.position_x = blockerPos.x;
+  requester.position_y = blockerPos.y;
+  requester.position_z = blockerPos.z;
+
+  dwarfAtPos.set(requesterKey, blocker);
+  dwarfAtPos.set(blockerKey, requester);
+
+  ctx.state.dirtyDwarfIds.add(blocker.id);
+  ctx.state.dirtyDwarfIds.add(requester.id);
+
+  ctx.state._occupancyWaitTicks?.delete(requester.id);
+  if (!ctx.state._previousPositions) ctx.state._previousPositions = new Map();
+  ctx.state._previousPositions.set(requester.id, requesterKey);
+
+  return true;
+}
+
+/** Max recursive depth for shoving chains of idle dwarves. */
+const MAX_SHOVE_DEPTH = 5;
+
+/**
+ * Try to shove an idle blocking dwarf out of the way so a task-bearing dwarf can pass.
+ * Recursively shoves chains of idle dwarves (depth-limited).
+ * Only shoves idle dwarves (no current task) — busy dwarves keep their position.
+ */
+function tryShoveBlocker(
+  blockerPos: { x: number; y: number; z: number },
+  requesterPos: { x: number; y: number; z: number },
+  ctx: SimContext,
+  occupiedTiles: Set<string>,
+  dwarfAtPos: Map<string, Dwarf>,
+  zResolver?: ZResolver,
+  depth = 0,
+): boolean {
+  if (depth >= MAX_SHOVE_DEPTH) return false;
+
+  const blockerKey = `${blockerPos.x},${blockerPos.y},${blockerPos.z}`;
+  const blocker = dwarfAtPos.get(blockerKey);
+  if (!blocker || blocker.status !== 'alive') return false;
+  if (blocker.current_task_id !== null) return false;
+
+  const getTile = buildTileLookup(ctx);
+  const neighbors = getNeighbors(blockerPos, getTile, zResolver);
+  const requesterKey = `${requesterPos.x},${requesterPos.y},${requesterPos.z}`;
+
+  for (const neighbor of neighbors) {
+    const key = `${neighbor.x},${neighbor.y},${neighbor.z}`;
+    if (key === requesterKey) continue;
+    if (occupiedTiles.has(key)) continue;
+
+    occupiedTiles.delete(blockerKey);
+    dwarfAtPos.delete(blockerKey);
+    occupiedTiles.add(key);
+    dwarfAtPos.set(key, blocker);
+    blocker.position_x = neighbor.x;
+    blocker.position_y = neighbor.y;
+    blocker.position_z = neighbor.z;
+    ctx.state.dirtyDwarfIds.add(blocker.id);
+    return true;
+  }
+
+  for (const neighbor of neighbors) {
+    const key = `${neighbor.x},${neighbor.y},${neighbor.z}`;
+    if (key === requesterKey) continue;
+    if (!occupiedTiles.has(key)) continue;
+
+    if (tryShoveBlocker(neighbor, blockerPos, ctx, occupiedTiles, dwarfAtPos, zResolver, depth + 1)) {
+      occupiedTiles.delete(blockerKey);
+      dwarfAtPos.delete(blockerKey);
+      occupiedTiles.add(key);
+      dwarfAtPos.set(key, blocker);
+      blocker.position_x = neighbor.x;
+      blocker.position_y = neighbor.y;
+      blocker.position_z = neighbor.z;
+      ctx.state.dirtyDwarfIds.add(blocker.id);
+      return true;
+    }
+  }
+
+  return false;
 }
 
 /** Increment the occupancy wait counter for a dwarf. Returns false (= fail task) when threshold is reached. */


### PR DESCRIPTION
## Summary

- Adds `tryShoveBlocker` — recursively pushes idle dwarves to adjacent free tiles (depth-limited to 5) when a task-bearing dwarf is blocked in a narrow corridor
- Adds `trySwapWithBlocker` — atomically swaps positions with an idle blocker when shove fails (dead-end corridors where there's nowhere to push)
- Only idle dwarves (no current task) are shoved/swapped — busy dwarves keep their position
- Integrated at both movement code paths: general `moveTowardTarget` and haul-specific pickup movement

## Test plan

- [x] New scenario test: 3 hauling dwarves in a 1-wide corridor all deposit at dead-end stockpile
- [x] New scenario test: 1 hauler blocked by 2 idle dwarves in dead-end corridor deposits successfully
- [x] Updated oscillation test to expect shove behavior instead of wait
- [x] All 113 movement/hauling/collision tests pass
- [x] Typecheck clean (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)