### PR TITLE
fix: prevent caves from spawning in water and increase cave count

### DIFF
--- a/shared/src/fortress-gen-helpers.ts
+++ b/shared/src/fortress-gen-helpers.ts
@@ -214,6 +214,10 @@ function combineSeed(worldSeed: bigint, civId: string): bigint {
 
 function pickCaveEntrances(
   entranceNoise: NoiseFunction2D,
+  treeNoise: NoiseFunction2D,
+  rockNoise: NoiseFunction2D,
+  pondNoise: NoiseFunction2D,
+  terrain: TerrainType,
 ): Array<{ x: number; y: number }> {
   const candidates: Array<{ x: number; y: number; val: number }> = [];
   const step = 32;
@@ -221,7 +225,9 @@ function pickCaveEntrances(
   for (let sy = step; sy < FORTRESS_SIZE - step; sy += step) {
     for (let sx = step; sx < FORTRESS_SIZE - step; sx += step) {
       const val = (entranceNoise(sx * 0.01, sy * 0.01) + 1) / 2;
-      if (val > 0.7) {
+      if (val > 0.6) {
+        const surface = deriveSurfaceTile(sx, sy, treeNoise, rockNoise, pondNoise, terrain);
+        if (surface.tileType === "pond" || surface.tileType === "water" || surface.tileType === "ice" || surface.tileType === "magma") continue;
         candidates.push({ x: sx, y: sy, val });
       }
     }
@@ -233,7 +239,7 @@ function pickCaveEntrances(
   const minDist = 80;
 
   for (const c of candidates) {
-    if (positions.length >= 5) break;
+    if (positions.length >= 8) break;
     const tooClose = positions.some(
       (p) => Math.abs(p.x - c.x) + Math.abs(p.y - c.y) < minDist,
     );
@@ -448,7 +454,7 @@ export function createFortressDeriver(
   const surfacePondNoise = createNoise2D(rng);
   CAVE_MATERIALS.forEach(() => createNoise2D(rng));
 
-  const entrancePositions = pickCaveEntrances(entranceNoise);
+  const entrancePositions = pickCaveEntrances(entranceNoise, surfaceTreeNoise, surfaceRockNoise, surfacePondNoise, terrain);
 
   const entrances: CaveEntrance[] = entrancePositions.map((p, i) => ({
     x: p.x, y: p.y, z: -(i + 1),

--- a/sim/src/__tests__/cave-scout-distance.test.ts
+++ b/sim/src/__tests__/cave-scout-distance.test.ts
@@ -119,10 +119,10 @@ describe("cave scouting at long distance", () => {
     expect(marker?.tile_type).toBe("cavern_floor");
   });
 
-  it("dwarf reaches entrance 288 tiles away (entrance 4)", async () => {
-    const { entrance, config } = makeScoutScenario(4, 2000);
+  it("dwarf reaches entrance 288 tiles away (entrance 7)", async () => {
+    const { entrance, config } = makeScoutScenario(7, 2000);
 
-    // Entrance 4 at (384, 416) is 288 Manhattan from spawn
+    // Entrance 7 at (384, 416) is 288 Manhattan from spawn
     expect(Math.abs(entrance.x - 256) + Math.abs(entrance.y - 256)).toBeGreaterThanOrEqual(200);
 
     const result = await runScenario(config);


### PR DESCRIPTION
## Summary
- Filter water-like tiles (pond, water, ice, magma) from cave entrance candidates in `pickCaveEntrances()` by checking `deriveSurfaceTile()` before accepting a position
- Lower entrance noise threshold from 0.7 to 0.6 so more candidate positions are evaluated
- Raise max cave count from 5 to 8 entrances per map
- Update `cave-scout-distance.test.ts` to reference entrance index 7 (was 4) since positions shifted

Closes #719

## Test plan
- [x] `npm run build` passes (types check)
- [x] `fortress-gen-helpers.test.ts` — 21 tests pass
- [x] `cave-scout-distance.test.ts` — 2 tests pass (updated for new entrance positions)
- [x] Verified new deriver produces 8 entrances with seed 42, none on water tiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)