### PR TITLE
feat: headless playtest reports AI actions taken

### DIFF
--- a/.claude/skills/headless-playtest/skill.md
+++ b/.claude/skills/headless-playtest/skill.md
@@ -25,6 +25,10 @@ node scripts/playtest-all.mjs --pretty
 
 This runs: `starvation`, `idle-fortress`, `long-run-stability`, `overcrowding`
 
+### Action timeline
+
+The headless run result includes an `actionLog` field — a chronological list of all AI actions and world events that occurred during the run. Each entry has `tick`, `category`, `description`, and optional `details`. The `action_log` field is also available in every `StateSnapshot` (capped to the last 200 entries). Use this to understand *what happened* during the run, not just the final state.
+
 ### Phase 2: Interactive investigation
 
 If batch results show issues, use step mode to investigate:

--- a/sim/src/headless-runner.test.ts
+++ b/sim/src/headless-runner.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import type { WorldEvent } from "@pwarf/shared";
+import { createEmptyCachedState } from "./sim-context.js";
+import { runHeadless } from "./headless-runner.js";
+
+function makeWorldEvent(overrides?: Partial<WorldEvent>): WorldEvent {
+  return {
+    id: "evt-1",
+    world_id: "test-world",
+    year: 1,
+    category: "death",
+    civilization_id: null,
+    ruin_id: null,
+    dwarf_id: null,
+    item_id: null,
+    faction_id: null,
+    monster_id: null,
+    description: "Something happened",
+    event_data: {},
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("runHeadless", () => {
+  it("flushes pendingEvents into worldEvents and returns actionLog", async () => {
+    const state = createEmptyCachedState();
+    // Simulate events that would be placed in pendingEvents by phases
+    // We pre-load pendingEvents so after the first tick they get flushed
+    state.pendingEvents.push(
+      makeWorldEvent({ id: "e1", description: "A dwarf arrived" }),
+    );
+
+    const result = await runHeadless({
+      initialState: state,
+      ticks: 1,
+    });
+
+    // pendingEvents should have been flushed to worldEvents
+    expect(state.worldEvents.length).toBeGreaterThanOrEqual(1);
+    expect(state.pendingEvents).toHaveLength(0);
+
+    // actionLog should contain the flushed event
+    expect(result.actionLog.length).toBeGreaterThanOrEqual(1);
+    const arrival = result.actionLog.find(e => e.description === "A dwarf arrived");
+    expect(arrival).toBeDefined();
+    expect(arrival!.category).toBe("death");
+  });
+
+  it("returns empty actionLog when no events occur", async () => {
+    const result = await runHeadless({
+      ticks: 1,
+    });
+
+    expect(result.actionLog).toBeDefined();
+    expect(Array.isArray(result.actionLog)).toBe(true);
+  });
+
+  it("includes actionLog in finalSnapshot as action_log", async () => {
+    const state = createEmptyCachedState();
+    state.pendingEvents.push(
+      makeWorldEvent({ id: "e1", description: "Test event", category: "battle" }),
+    );
+
+    const result = await runHeadless({
+      initialState: state,
+      ticks: 1,
+    });
+
+    const snapshotEntry = result.finalSnapshot.action_log.find(
+      e => e.description === "Test event",
+    );
+    expect(snapshotEntry).toBeDefined();
+    expect(snapshotEntry!.category).toBe("battle");
+  });
+});

--- a/sim/src/headless-runner.ts
+++ b/sim/src/headless-runner.ts
@@ -5,7 +5,7 @@ import { createRng } from "./rng.js";
 import { runTick, advanceTime, maybeYearRollup } from "./tick.js";
 import { SCENARIOS, buildScenarioState, buildEatDrinkTasks } from "./scenarios.js";
 import { serializeState } from "./state-serializer.js";
-import type { StateSnapshot } from "./state-serializer.js";
+import type { StateSnapshot, ActionLogEntry } from "./state-serializer.js";
 import type { ScenarioDefinition } from "./scenarios.js";
 import type { CachedState } from "./sim-context.js";
 
@@ -29,6 +29,8 @@ export interface HeadlessRunResult {
   tasksCompleted: number;
   /** Total ticks executed. */
   ticks: number;
+  /** Chronological log of AI actions/events that occurred during the run. */
+  actionLog: ActionLogEntry[];
 }
 
 /**
@@ -92,6 +94,12 @@ export async function runHeadless(opts: HeadlessRunOptions): Promise<HeadlessRun
 
     currentYear = await maybeYearRollup(ctx, stepCount, currentYear);
 
+    // Flush pendingEvents → worldEvents (mirrors what run-scenario does)
+    if (state.pendingEvents.length > 0) {
+      state.worldEvents.push(...state.pendingEvents);
+      state.pendingEvents = [];
+    }
+
     if (snapshotEvery > 0 && stepCount % snapshotEvery === 0) {
       snapshots.push(serializeState(ctx, tasksCompleted));
     }
@@ -99,5 +107,12 @@ export async function runHeadless(opts: HeadlessRunOptions): Promise<HeadlessRun
 
   const finalSnapshot = serializeState(ctx, tasksCompleted);
 
-  return { finalSnapshot, snapshots, tasksCompleted, ticks: stepCount };
+  const actionLog: ActionLogEntry[] = state.worldEvents.map(e => ({
+    tick: e.year,
+    category: e.category,
+    description: e.description,
+    ...(Object.keys(e.event_data).length > 0 ? { details: e.event_data } : {}),
+  }));
+
+  return { finalSnapshot, snapshots, tasksCompleted, ticks: stepCount, actionLog };
 }

--- a/sim/src/state-serializer.test.ts
+++ b/sim/src/state-serializer.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import type { WorldEvent } from "@pwarf/shared";
+import { createTestContext } from "./sim-context.js";
+import { serializeState } from "./state-serializer.js";
+
+function makeWorldEvent(overrides?: Partial<WorldEvent>): WorldEvent {
+  return {
+    id: "evt-1",
+    world_id: "test-world",
+    year: 1,
+    category: "death",
+    civilization_id: null,
+    ruin_id: null,
+    dwarf_id: null,
+    item_id: null,
+    faction_id: null,
+    monster_id: null,
+    description: "Something happened",
+    event_data: {},
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("serializeState", () => {
+  it("populates action_log from worldEvents", () => {
+    const ctx = createTestContext();
+    ctx.state.worldEvents = [
+      makeWorldEvent({ id: "e1", category: "death", description: "Urist died", event_data: { cause: "thirst" } }),
+      makeWorldEvent({ id: "e2", category: "battle", description: "A goblin attacked", event_data: {} }),
+    ];
+
+    const snapshot = serializeState(ctx);
+
+    expect(snapshot.action_log).toHaveLength(2);
+    expect(snapshot.action_log[0]).toEqual({
+      tick: 1,
+      category: "death",
+      description: "Urist died",
+      details: { cause: "thirst" },
+    });
+    expect(snapshot.action_log[1]).toEqual({
+      tick: 1,
+      category: "battle",
+      description: "A goblin attacked",
+    });
+  });
+
+  it("caps action_log to 200 entries", () => {
+    const ctx = createTestContext();
+    ctx.state.worldEvents = Array.from({ length: 300 }, (_, i) =>
+      makeWorldEvent({ id: `e${i}`, description: `Event ${i}` }),
+    );
+
+    const snapshot = serializeState(ctx);
+
+    expect(snapshot.action_log).toHaveLength(200);
+    // Should contain the last 200 (indices 100-299)
+    expect(snapshot.action_log[0].description).toBe("Event 100");
+    expect(snapshot.action_log[199].description).toBe("Event 299");
+  });
+
+  it("returns empty action_log when no worldEvents exist", () => {
+    const ctx = createTestContext();
+    const snapshot = serializeState(ctx);
+    expect(snapshot.action_log).toEqual([]);
+  });
+});

--- a/sim/src/state-serializer.ts
+++ b/sim/src/state-serializer.ts
@@ -53,12 +53,20 @@ export interface TileSnapshot {
   tile_type: string;
 }
 
+export interface ActionLogEntry {
+  tick: number;
+  category: string;
+  description: string;
+  details?: Record<string, unknown>;
+}
+
 export interface StateSnapshot {
   summary: Summary;
   dwarves: DwarfSnapshot[];
   tasks: TaskSnapshot[];
   tiles: TileSnapshot[];
   recent_events: Array<{ tick: number; text: string }>;
+  action_log: ActionLogEntry[];
 }
 
 function needLabel(value: number, name: string): string {
@@ -120,6 +128,8 @@ function buildAlerts(dwarves: Dwarf[]): string[] {
   return alerts;
 }
 
+const ACTION_LOG_CAP = 200;
+
 /** Serialize sim context into an LLM-friendly JSON snapshot. */
 export function serializeState(ctx: SimContext, tasksCompleted = 0): StateSnapshot {
   const { state, step, year, day } = ctx;
@@ -170,6 +180,15 @@ export function serializeState(ctx: SimContext, tasksCompleted = 0): StateSnapsh
     tile_type: t.tile_type,
   }));
 
+  const actionLog: ActionLogEntry[] = state.worldEvents
+    .slice(-ACTION_LOG_CAP)
+    .map(e => ({
+      tick: e.year,
+      category: e.category,
+      description: e.description,
+      ...(Object.keys(e.event_data).length > 0 ? { details: e.event_data } : {}),
+    }));
+
   return {
     summary: {
       tick: step,
@@ -185,5 +204,6 @@ export function serializeState(ctx: SimContext, tasksCompleted = 0): StateSnapsh
     tasks: taskSnapshots,
     tiles: tileSnapshots,
     recent_events: recentEvents,
+    action_log: actionLog,
   };
 }


### PR DESCRIPTION
## Summary
- Flush `pendingEvents` to `worldEvents` in `headless-runner.ts` tick loop (matching `run-scenario.ts` pattern) so events are no longer silently lost
- Add `ActionLogEntry` interface and `action_log` field to `StateSnapshot` in `state-serializer.ts`, capped to last 200 entries
- Add `actionLog` field to `HeadlessRunResult` with the full event list
- Update headless playtest skill docs to mention the action timeline

Closes #592

## Test plan
- [x] `state-serializer.test.ts`: verifies action_log populated from worldEvents, caps at 200 entries, empty when no events
- [x] `headless-runner.test.ts`: verifies pendingEvents flushed, actionLog populated in result, action_log present in finalSnapshot
- [x] `npm run build` passes
- [x] All new tests pass (6/6); pre-existing perf test failures unrelated

## Claude Cost
(will be filled by /review-pr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)