### PR TITLE
fix: prevent duplicate scout_cave tasks from multiple clicks

### DIFF
--- a/.claude/skills/review-bugs/skill.md
+++ b/.claude/skills/review-bugs/skill.md
@@ -32,7 +32,41 @@ LIMIT 10;
 
 If no bug reports exist, report that and stop.
 
-**Step 2: For each bug report, analyze the game state.**
+**Step 2: Reconstruct the world and fortress terrain.**
+
+Terrain is procedurally generated from the world seed and civ ID. To reproduce bugs accurately (especially pathfinding/movement bugs), you **must** reconstruct the exact fortress terrain.
+
+For each bug report, extract the `civilization_id` from the game state, then query the database:
+
+```sql
+SELECT
+  c.id AS civ_id,
+  c.world_id,
+  c.tile_x,
+  c.tile_y,
+  w.seed AS world_seed
+FROM civilizations c
+JOIN worlds w ON w.id = c.world_id
+WHERE c.id = '<civilization_id from game_state>';
+```
+
+Then derive the terrain type using the world deriver:
+
+```typescript
+import { createWorldDeriver, createFortressDeriver } from "@pwarf/shared";
+
+const wd = createWorldDeriver(BigInt(worldSeed));
+const worldTile = wd.deriveTile(tile_x, tile_y);
+// worldTile.terrain is the biome (e.g. "forest", "plains", "desert")
+
+const fd = createFortressDeriver(BigInt(worldSeed), civId, worldTile.terrain);
+// fd.entrances — cave entrance positions
+// fd.deriveTile(x, y, z) — exact tile at any position
+```
+
+Include this deriver as `fortressDeriver` in the ScenarioConfig so pathfinding uses the real terrain (ponds, trees, rocks) instead of defaulting to open_air. This is critical — bugs that involve dwarves failing to reach distant targets are often caused by terrain obstacles (e.g. pond regions blocking A* pathfinding).
+
+**Step 3: Analyze the game state.**
 
 Read these files to understand the sim systems:
 - `sim/src/run-scenario.ts` — how to write scenario tests and the ScenarioConfig shape
@@ -45,13 +79,16 @@ For each bug report:
 2. Examine the `game_state` JSONB snapshot — look at dwarf statuses, pending tasks, items, etc.
 3. Identify what looks wrong: stuck dwarves, unfulfilled tasks, unexpected deaths, missing items, etc.
 4. Check if the bug matches any recently fixed issues by reading recent git history: `git log --oneline -20`
+5. If the bug involves movement/pathfinding, sample tiles along the path using the fortress deriver to check for unwalkable terrain (ponds, water, magma)
 
-**Step 3: Attempt to reproduce each bug.**
+**Step 4: Attempt to reproduce each bug.**
 
 For each bug report, write a minimal scenario test that tries to reproduce the issue. Create the test file at `sim/src/__tests__/bug-repro-temp.test.ts`.
 
 The test should:
-- Set up the game state from the bug report snapshot (dwarves, tasks, items, structures, tiles)
+- Reconstruct the fortress deriver from the world seed + civ ID + terrain type (see Step 2)
+- Pass the deriver as `fortressDeriver` in the ScenarioConfig
+- Set up dwarves, tasks, items, and structures from the bug report snapshot
 - Run for enough ticks to see if the bug manifests
 - Assert on the specific behavior the player reported as broken
 
@@ -62,7 +99,7 @@ Run the test:
 npm run build --workspace=shared --workspace=sim && npm test --workspace=sim -- --run src/__tests__/bug-repro-temp.test.ts
 ```
 
-**Step 4: Classify each bug report.**
+**Step 5: Classify each bug report.**
 
 For each bug report, classify it as one of:
 - **REPRODUCED** — the scenario test demonstrates the bug (test fails as expected)
@@ -72,7 +109,7 @@ For each bug report, classify it as one of:
 - **INSUFFICIENT INFO** — the game state snapshot doesn't contain enough information to understand the bug
 - **DUPLICATE** — matches a known/recently-fixed issue
 
-**Step 5: Mark each bug report as reviewed.**
+**Step 6: Mark each bug report as reviewed.**
 
 After classifying a bug report, mark it as reviewed in the database so it won't appear in future runs:
 
@@ -84,7 +121,7 @@ WHERE id = '<bug-report-id>';
 
 Replace `<CLASSIFICATION>` with the classification from Step 4 (e.g. `ALREADY FIXED`, `WORKING AS INTENDED`, etc.).
 
-**Step 6: Clean up and report.**
+**Step 7: Clean up and report.**
 
 Delete the temporary test file when done:
 ```bash

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -457,6 +457,8 @@ export default function App() {
 
   const handleConfirmScout = useCallback(async () => {
     if (!caveScoutModal || caveScoutModal.alreadyScouting || !world.civId) return;
+    // Optimistically mark as scouting to prevent duplicate clicks
+    setCaveScoutModal({ ...caveScoutModal, alreadyScouting: true });
     const { error } = await supabase.from('tasks').insert({
       civilization_id: world.civId,
       task_type: 'scout_cave',

--- a/sim/src/__tests__/bug-scout-unreachable.test.ts
+++ b/sim/src/__tests__/bug-scout-unreachable.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import { runScenario } from "../run-scenario.js";
+import { makeDwarf, makeTask, makeSkill, makeItem, makeStructure } from "./test-helpers.js";
+import { createWorldDeriver, createFortressDeriver, WORK_SCOUT_CAVE, SKILL_NAMES } from "@pwarf/shared";
+
+/**
+ * Bug reproduction for bug report 51020ece — "dwarf didnt scout cave"
+ *
+ * The player's fortress is in a **forest** biome with ~8% pond coverage.
+ * Cave entrance #7 at (32, 448) is 438 Manhattan tiles from spawn (272, 250).
+ * The direct path crosses ~89 pond tiles, forcing A* into massive detours
+ * that exhaust the 20k node limit. The dwarf claims the task but pathfinding
+ * returns null every tick, leaving work_progress stuck at 0.
+ *
+ * World seed: 5837771263264388, Civ ID: 14f577a0-d787-4633-b01e-dfdb7879c4ff
+ * World tile (30, 8) → forest terrain
+ */
+
+const WORLD_SEED = 5837771263264388n;
+const CIV_ID = "14f577a0-d787-4633-b01e-dfdb7879c4ff";
+
+function makeBugReproScenario(ticks: number) {
+  // Derive the same terrain as the bug report
+  const wd = createWorldDeriver(WORLD_SEED);
+  const worldTile = wd.deriveTile(30, 8);
+  // worldTile.terrain === "forest"
+
+  const deriver = createFortressDeriver(WORLD_SEED, CIV_ID, worldTile.terrain);
+  const entrance = deriver.entrances[7]!; // (32, 448) at z=-8
+
+  const dwarf = makeDwarf({
+    civilization_id: CIV_ID,
+    position_x: 272,
+    position_y: 250,
+    position_z: 0,
+    need_food: 100,
+    need_drink: 100,
+    need_sleep: 100,
+  });
+
+  const skills = SKILL_NAMES.map(s => makeSkill(dwarf.id, s, 2));
+
+  // Place food/drink near spawn so needs don't interfere
+  const items = [];
+  for (let i = 0; i < 20; i++) {
+    items.push(makeItem({
+      name: "Plump helmet", category: "food", material: "plant",
+      located_in_civ_id: CIV_ID, position_x: 270, position_y: 252, position_z: 0,
+    }));
+    items.push(makeItem({
+      name: "Dwarven ale", category: "drink", material: "plant",
+      located_in_civ_id: CIV_ID, position_x: 271, position_y: 252, position_z: 0,
+    }));
+  }
+
+  const stockpileTiles = [];
+  for (let sx = 269; sx <= 272; sx++) {
+    for (let sy = 252; sy <= 254; sy++) {
+      stockpileTiles.push({
+        id: `sp-${sx}-${sy}`,
+        civilization_id: CIV_ID,
+        x: sx, y: sy, z: 0,
+        priority: 1,
+        accepts_categories: null,
+        created_at: new Date().toISOString(),
+      });
+    }
+  }
+
+  const structures = [
+    makeStructure({
+      civilization_id: CIV_ID, type: "bed", completion_pct: 100,
+      position_x: 268, position_y: 252, position_z: 0,
+    }),
+    makeStructure({
+      civilization_id: CIV_ID, type: "well", completion_pct: 100,
+      position_x: 274, position_y: 252, position_z: 0,
+    }),
+  ];
+
+  const scoutTask = makeTask("scout_cave", {
+    civilization_id: CIV_ID,
+    status: "pending",
+    target_x: entrance.x,
+    target_y: entrance.y,
+    target_z: 0,
+    work_progress: 0,
+    work_required: WORK_SCOUT_CAVE,
+  });
+
+  return {
+    deriver,
+    entrance,
+    terrain: worldTile.terrain,
+    config: {
+      dwarves: [dwarf],
+      dwarfSkills: skills,
+      items,
+      structures,
+      stockpileTiles,
+      fortressDeriver: deriver,
+      tasks: [scoutTask],
+      ticks,
+      seed: 42,
+    },
+  };
+}
+
+describe("bug: scout cave unreachable due to pond-heavy terrain", () => {
+  it("confirms forest terrain with ponds blocking the path", () => {
+    const { deriver, entrance, terrain } = makeBugReproScenario(1);
+
+    expect(terrain).toBe("forest");
+
+    // Entrance #7 is far from spawn — distance should be 300+ Manhattan
+    const dist = Math.abs(entrance.x - 272) + Math.abs(entrance.y - 250);
+    expect(dist).toBeGreaterThan(300);
+
+    // Count ponds along the straight-line path from dwarf to entrance
+    let pondCount = 0;
+    const steps = 500;
+    for (let i = 0; i <= steps; i++) {
+      const t = i / steps;
+      const x = Math.round(272 + (entrance.x - 272) * t);
+      const y = Math.round(250 + (entrance.y - 250) * t);
+      const tile = deriver.deriveTile(x, y, 0);
+      if (tile.tileType === "pond") pondCount++;
+    }
+
+    // Significant pond coverage blocks the direct path
+    expect(pondCount).toBeGreaterThan(50);
+  });
+
+  it("dwarf fails to reach distant cave entrance through pond-heavy forest", async () => {
+    const { config } = makeBugReproScenario(1000);
+
+    const result = await runScenario(config);
+
+    const task = result.tasks.find(t => t.task_type === "scout_cave");
+    expect(task).toBeDefined();
+
+    // BUG: the dwarf never completes (or even makes progress on) the scout task
+    // because A* exhausts its 20k node limit navigating around pond regions.
+    // The task stays claimed with 0 work progress.
+    expect(task!.status).not.toBe("completed");
+    expect(task!.work_progress).toBe(0);
+  }, 180_000);
+});

--- a/supabase/migrations/00031_unique_scout_cave_task.sql
+++ b/supabase/migrations/00031_unique_scout_cave_task.sql
@@ -1,0 +1,6 @@
+-- Prevent duplicate scout_cave tasks for the same cave entrance.
+-- Only one active (pending/claimed/in_progress) scout task per entrance per civilization.
+CREATE UNIQUE INDEX IF NOT EXISTS unique_active_scout_cave
+  ON tasks (civilization_id, target_x, target_y)
+  WHERE task_type = 'scout_cave'
+    AND status IN ('pending', 'claimed', 'in_progress');


### PR DESCRIPTION
## Summary
- Add optimistic UI guard in `handleConfirmScout` — sets `alreadyScouting: true` immediately to prevent duplicate clicks before the DB round-trip completes
- Add partial unique index `unique_active_scout_cave` on `tasks(civilization_id, target_x, target_y)` for active scout_cave tasks as a DB-level safety net
- Add scenario test reproducing the A* pathfinding failure on pond-heavy forest terrain (bug report 51020ece)
- Update review-bugs skill to reconstruct world/fortress terrain from DB for accurate bug reproduction

## Test plan
- [x] `bug-scout-unreachable.test.ts` passes — confirms pathfinding bug reproduction
- [x] `npm run build` passes
- [x] DB constraint applied to production, duplicate tasks cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)