### PR TITLE
feat: food/drink subtypes with varying nutrition and hydration

### DIFF
--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -371,11 +371,43 @@ export const STARVATION_TICKS = 18_000;
 /** Ticks at need_drink=0 before dehydration death (~5 in-game days) */
 export const DEHYDRATION_TICKS = 9_000;
 
-/** Amount need_food is restored when eating basic food */
+/** Default need_food restored when eating (fallback if item has no nutrition_value) */
 export const FOOD_RESTORE_AMOUNT = 60;
 
-/** Amount need_drink is restored when drinking basic drink */
+/** Default need_drink restored when drinking (fallback if item has no hydration_value) */
 export const DRINK_RESTORE_AMOUNT = 70;
+
+// ============================================================
+// Food/drink subtype nutrition values
+// ============================================================
+
+/** Nutrition values by food name. Used when creating food items. */
+export const FOOD_NUTRITION: Record<string, number> = {
+  'Wild mushroom': 35,
+  'Berries': 40,
+  'Cave mushroom': 35,
+  'Cave fungus': 30,
+  'Plump helmet': 45,
+  'Dried meat': 50,
+  'Prepared meal': 75,
+};
+
+/** Hydration values by drink name. Used when creating drink items. */
+export const DRINK_HYDRATION: Record<string, number> = {
+  'Plump helmet brew': 70,
+  'Dwarven ale': 65,
+  'Water': 80,
+};
+
+/** Quality multiplier for food/drink restoration. Better quality = more nutrition. */
+export const QUALITY_NUTRITION_MULTIPLIER: Record<string, number> = {
+  standard: 1.0,
+  fine: 1.1,
+  superior: 1.25,
+  exceptional: 1.4,
+  masterwork: 1.5,
+  artifact: 2.0,
+};
 
 /** Total amount need_sleep is restored over the course of one sleep task */
 export const SLEEP_RESTORE_AMOUNT = 60;

--- a/sim/src/__tests__/task-completion.test.ts
+++ b/sim/src/__tests__/task-completion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { FOOD_RESTORE_AMOUNT, DRINK_RESTORE_AMOUNT, FLOOR_SLEEP_STRESS, MAX_NEED } from "@pwarf/shared";
+import { FOOD_RESTORE_AMOUNT, DRINK_RESTORE_AMOUNT, FLOOR_SLEEP_STRESS, MAX_NEED, FOOD_NUTRITION } from "@pwarf/shared";
 import { completeTask } from "../phases/task-completion.js";
 import { createTask } from "../task-helpers.js";
 import { makeDwarf, makeSkill, makeItem, makeContext, makeStructure } from "./test-helpers.js";
@@ -87,7 +87,9 @@ describe("completeTask", () => {
 
     completeTask(dwarf, task, ctx);
 
-    expect(dwarf.need_food).toBe(Math.min(MAX_NEED, 20 + FOOD_RESTORE_AMOUNT));
+    // Default test item is "Plump helmet" — uses FOOD_NUTRITION value
+    const expectedRestore = FOOD_NUTRITION['Plump helmet'] ?? FOOD_RESTORE_AMOUNT;
+    expect(dwarf.need_food).toBe(Math.min(MAX_NEED, 20 + expectedRestore));
     expect(ctx.state.items.find(i => i.id === food.id)).toBeUndefined();
   });
 

--- a/sim/src/nutrition.test.ts
+++ b/sim/src/nutrition.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { getNutritionValue, getHydrationValue } from './nutrition.js';
+import { makeItem } from './__tests__/test-helpers.js';
+import { FOOD_RESTORE_AMOUNT, DRINK_RESTORE_AMOUNT } from '@pwarf/shared';
+
+describe('getNutritionValue', () => {
+  it('returns properties.nutrition_value when set', () => {
+    const item = makeItem({ name: 'Custom food', properties: { nutrition_value: 42 } });
+    expect(getNutritionValue(item)).toBe(42);
+  });
+
+  it('falls back to FOOD_NUTRITION by name', () => {
+    const item = makeItem({ name: 'Prepared meal', properties: {} });
+    expect(getNutritionValue(item)).toBe(75); // FOOD_NUTRITION['Prepared meal']
+  });
+
+  it('falls back to FOOD_RESTORE_AMOUNT for unknown names', () => {
+    const item = makeItem({ name: 'Unknown grub', properties: {} });
+    expect(getNutritionValue(item)).toBe(FOOD_RESTORE_AMOUNT);
+  });
+
+  it('applies quality multiplier', () => {
+    const standard = makeItem({ name: 'Wild mushroom', quality: 'standard', properties: {} });
+    const masterwork = makeItem({ name: 'Wild mushroom', quality: 'masterwork', properties: {} });
+    expect(getNutritionValue(masterwork)).toBeGreaterThan(getNutritionValue(standard));
+    // masterwork = 35 * 1.5 = 52.5 → 53
+    expect(getNutritionValue(masterwork)).toBe(53);
+  });
+
+  it('raw foraged food restores less than cooked meals', () => {
+    const raw = makeItem({ name: 'Wild mushroom', properties: {} });
+    const cooked = makeItem({ name: 'Prepared meal', quality: 'fine', properties: {} });
+    expect(getNutritionValue(cooked)).toBeGreaterThan(getNutritionValue(raw));
+  });
+});
+
+describe('getHydrationValue', () => {
+  it('returns properties.hydration_value when set', () => {
+    const item = makeItem({ category: 'drink', name: 'Custom drink', properties: { hydration_value: 55 } });
+    expect(getHydrationValue(item)).toBe(55);
+  });
+
+  it('falls back to DRINK_HYDRATION by name', () => {
+    const item = makeItem({ category: 'drink', name: 'Plump helmet brew', properties: {} });
+    expect(getHydrationValue(item)).toBe(70);
+  });
+
+  it('falls back to DRINK_RESTORE_AMOUNT for unknown names', () => {
+    const item = makeItem({ category: 'drink', name: 'Mystery liquid', properties: {} });
+    expect(getHydrationValue(item)).toBe(DRINK_RESTORE_AMOUNT);
+  });
+
+  it('applies quality multiplier', () => {
+    const standard = makeItem({ category: 'drink', name: 'Plump helmet brew', quality: 'standard', properties: {} });
+    const masterwork = makeItem({ category: 'drink', name: 'Plump helmet brew', quality: 'masterwork', properties: {} });
+    expect(getHydrationValue(masterwork)).toBeGreaterThan(getHydrationValue(standard));
+  });
+});

--- a/sim/src/nutrition.ts
+++ b/sim/src/nutrition.ts
@@ -1,0 +1,36 @@
+import {
+  FOOD_RESTORE_AMOUNT,
+  DRINK_RESTORE_AMOUNT,
+  FOOD_NUTRITION,
+  DRINK_HYDRATION,
+  QUALITY_NUTRITION_MULTIPLIER,
+} from "@pwarf/shared";
+import type { Item } from "@pwarf/shared";
+
+/**
+ * Get the nutrition value for a food item.
+ * Checks item.properties.nutrition_value first, then FOOD_NUTRITION by name,
+ * then falls back to FOOD_RESTORE_AMOUNT. Applies quality multiplier.
+ */
+export function getNutritionValue(item: Item): number {
+  const base = typeof item.properties?.nutrition_value === 'number'
+    ? item.properties.nutrition_value
+    : FOOD_NUTRITION[item.name] ?? FOOD_RESTORE_AMOUNT;
+
+  const qualityMul = QUALITY_NUTRITION_MULTIPLIER[item.quality] ?? 1.0;
+  return Math.round(base * qualityMul);
+}
+
+/**
+ * Get the hydration value for a drink item.
+ * Checks item.properties.hydration_value first, then DRINK_HYDRATION by name,
+ * then falls back to DRINK_RESTORE_AMOUNT. Applies quality multiplier.
+ */
+export function getHydrationValue(item: Item): number {
+  const base = typeof item.properties?.hydration_value === 'number'
+    ? item.properties.hydration_value
+    : DRINK_HYDRATION[item.name] ?? DRINK_RESTORE_AMOUNT;
+
+  const qualityMul = QUALITY_NUTRITION_MULTIPLIER[item.quality] ?? 1.0;
+  return Math.round(base * qualityMul);
+}

--- a/sim/src/phases/task-completion.ts
+++ b/sim/src/phases/task-completion.ts
@@ -1,6 +1,8 @@
 import {
   FOOD_RESTORE_AMOUNT,
   DRINK_RESTORE_AMOUNT,
+  FOOD_NUTRITION,
+  DRINK_HYDRATION,
   FLOOR_SLEEP_STRESS,
   MAX_NEED,
   XP_MINE,
@@ -34,6 +36,7 @@ import { consumeResources } from "../resource-check.js";
 import { generateArtifactName, randomArtifactQuality } from "../artifact-names.js";
 import { getNeighbors } from "../pathfinding.js";
 import { buildTileLookup } from "../tile-lookup.js";
+import { getNutritionValue, getHydrationValue } from "../nutrition.js";
 
 /** Chance of finding a rare artifact when mining a gem tile. */
 export const ARTIFACT_CHANCE_GEM = 0.05;
@@ -635,7 +638,7 @@ function completeForage(dwarf: Dwarf, task: Task, ctx: SimContext): void {
     position_y: task.target_y,
     position_z: task.target_z,
     lore: null,
-    properties: {},
+    properties: { nutrition_value: FOOD_NUTRITION[name] ?? FOOD_RESTORE_AMOUNT },
     created_at: new Date().toISOString(),
   };
 
@@ -644,28 +647,34 @@ function completeForage(dwarf: Dwarf, task: Task, ctx: SimContext): void {
 }
 
 function completeEat(dwarf: Dwarf, task: Task, ctx: SimContext): void {
+  let restoreAmount = FOOD_RESTORE_AMOUNT;
+
   if (task.target_item_id) {
     const itemIdx = ctx.state.items.findIndex(i => i.id === task.target_item_id);
     if (itemIdx !== -1) {
+      restoreAmount = getNutritionValue(ctx.state.items[itemIdx]);
       ctx.state.items.splice(itemIdx, 1);
     }
   }
 
-  dwarf.need_food = Math.min(MAX_NEED, dwarf.need_food + FOOD_RESTORE_AMOUNT);
+  dwarf.need_food = Math.min(MAX_NEED, dwarf.need_food + restoreAmount);
   ctx.state.dirtyDwarfIds.add(dwarf.id);
 
   ctx.state.zeroFoodTicks.delete(dwarf.id);
 }
 
 function completeDrink(dwarf: Dwarf, task: Task, ctx: SimContext): void {
+  let restoreAmount = DRINK_RESTORE_AMOUNT;
+
   if (task.target_item_id) {
     const itemIdx = ctx.state.items.findIndex(i => i.id === task.target_item_id);
     if (itemIdx !== -1) {
+      restoreAmount = getHydrationValue(ctx.state.items[itemIdx]);
       ctx.state.items.splice(itemIdx, 1);
     }
   }
 
-  dwarf.need_drink = Math.min(MAX_NEED, dwarf.need_drink + DRINK_RESTORE_AMOUNT);
+  dwarf.need_drink = Math.min(MAX_NEED, dwarf.need_drink + restoreAmount);
   ctx.state.dirtyDwarfIds.add(dwarf.id);
 
   ctx.state.zeroDrinkTicks.delete(dwarf.id);
@@ -843,7 +852,7 @@ export function completeBrew(dwarf: Dwarf, task: Task, ctx: SimContext): void {
     position_y: task.target_y,
     position_z: task.target_z,
     lore: null,
-    properties: {},
+    properties: { hydration_value: DRINK_HYDRATION['Plump helmet brew'] ?? DRINK_RESTORE_AMOUNT },
     created_at: new Date().toISOString(),
   };
   ctx.state.items.push(ale);
@@ -883,7 +892,7 @@ export function completeCook(dwarf: Dwarf, task: Task, ctx: SimContext): void {
     position_y: task.target_y,
     position_z: task.target_z,
     lore: null,
-    properties: {},
+    properties: { nutrition_value: FOOD_NUTRITION['Prepared meal'] ?? FOOD_RESTORE_AMOUNT },
     created_at: new Date().toISOString(),
   };
   ctx.state.items.push(meal);


### PR DESCRIPTION
## Summary

- Food/drink items now restore varying amounts based on type and quality
- Raw foraged food (35-40) < dried meat (50) < prepared meals (75+)
- Quality multiplier: standard 1x through masterwork 1.5x, artifact 2x
- Values stored in item properties JSONB — no schema change
- 9 unit tests for nutrition/hydration helpers

## Test plan

- [x] 9 new unit tests (getNutritionValue, getHydrationValue)
- [x] Updated existing eat test for new nutrition values
- [x] All 1127 tests pass
- [x] Build passes

Generated with [Claude Code](https://claude.com/claude-code)