### PR TITLE
feat: sim debug mode — log pathfinding failures, stuck tasks, tick timing

### DIFF
--- a/sim/src/__tests__/sim-debug.test.ts
+++ b/sim/src/__tests__/sim-debug.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { runScenario } from '../run-scenario.js';
+import { makeDwarf, makeSkill, makeItem, makeMapTile, makeTask } from './test-helpers.js';
+import { WORK_MINE_BASE } from '@pwarf/shared';
+
+describe('sim debug mode', () => {
+  it('debug=true captures pathfinding and task failure logs', async () => {
+    const dwarf = makeDwarf({
+      position_x: 1, position_y: 5, position_z: 0,
+      need_food: 95, need_drink: 95, need_sleep: 95,
+    });
+    const skill = makeSkill(dwarf.id, 'mining', 1);
+
+    const tiles = [];
+    for (let x = 0; x <= 5; x++) {
+      for (let y = 3; y <= 7; y++) {
+        tiles.push(makeMapTile(x, y, 0, 'grass'));
+      }
+    }
+    // Unreachable mine target — surrounded by walls
+    tiles.push(makeMapTile(20, 20, 0, 'rock'));
+    for (const [dx, dy] of [[-1,0],[1,0],[0,-1],[0,1]]) {
+      tiles.push(makeMapTile(20+dx, 20+dy, 0, 'constructed_wall'));
+    }
+
+    const mineTask = makeTask('mine', {
+      status: 'pending', target_x: 20, target_y: 20, target_z: 0,
+      work_required: WORK_MINE_BASE, priority: 10,
+    });
+
+    const food = Array.from({ length: 10 }, (_, i) =>
+      makeItem({ category: 'food', position_x: 0, position_y: i + 3, position_z: 0, held_by_dwarf_id: null, located_in_civ_id: 'test-civ' }),
+    );
+    const drink = Array.from({ length: 10 }, (_, i) =>
+      makeItem({ category: 'drink', position_x: 5, position_y: i + 3, position_z: 0, held_by_dwarf_id: null, located_in_civ_id: 'test-civ' }),
+    );
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      dwarfSkills: [skill],
+      tasks: [mineTask],
+      items: [...food, ...drink],
+      fortressTileOverrides: tiles,
+      ticks: 200,
+      seed: 42,
+      debug: true,
+    });
+
+    // Debug log should contain pathfinding failure entries
+    expect(result.debugLog).toBeDefined();
+    expect(result.debugLog!.length).toBeGreaterThan(0);
+
+    const pathLogs = result.debugLog!.filter(e => e.category === 'pathfinding');
+    expect(pathLogs.length).toBeGreaterThan(0);
+    expect(pathLogs[0].message).toContain('no path');
+
+    const taskLogs = result.debugLog!.filter(e => e.category === 'task');
+    expect(taskLogs.length).toBeGreaterThan(0);
+    expect(taskLogs.some(e => e.message.includes('failed') || e.message.includes('cancelled'))).toBe(true);
+  });
+
+  it('debug=false produces no debug log', async () => {
+    const dwarf = makeDwarf({ position_x: 1, position_y: 5, position_z: 0, need_food: 95, need_drink: 95, need_sleep: 95 });
+    const food = Array.from({ length: 5 }, (_, i) =>
+      makeItem({ category: 'food', position_x: 0, position_y: i, position_z: 0, held_by_dwarf_id: null, located_in_civ_id: 'test-civ' }),
+    );
+    const drink = Array.from({ length: 5 }, (_, i) =>
+      makeItem({ category: 'drink', position_x: 5, position_y: i, position_z: 0, held_by_dwarf_id: null, located_in_civ_id: 'test-civ' }),
+    );
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      items: [...food, ...drink],
+      ticks: 100,
+      seed: 55,
+    });
+
+    expect(result.debugLog).toBeUndefined();
+  });
+
+  it('timing logs are captured every 100 ticks', async () => {
+    const dwarf = makeDwarf({ position_x: 5, position_y: 5, position_z: 0, need_food: 95, need_drink: 95, need_sleep: 95 });
+    const food = Array.from({ length: 10 }, (_, i) =>
+      makeItem({ category: 'food', position_x: 0, position_y: i, position_z: 0, held_by_dwarf_id: null, located_in_civ_id: 'test-civ' }),
+    );
+    const drink = Array.from({ length: 10 }, (_, i) =>
+      makeItem({ category: 'drink', position_x: 8, position_y: i, position_z: 0, held_by_dwarf_id: null, located_in_civ_id: 'test-civ' }),
+    );
+
+    const result = await runScenario({
+      dwarves: [dwarf],
+      items: [...food, ...drink],
+      ticks: 200,
+      seed: 77,
+      debug: true,
+    });
+
+    const timingLogs = result.debugLog!.filter(e => e.category === 'timing');
+    // Should have timing entries from tick 0 and tick 100
+    expect(timingLogs.length).toBeGreaterThan(0);
+    expect(timingLogs.some(e => e.message.includes('tick'))).toBe(true);
+  });
+});

--- a/sim/src/phases/task-execution.ts
+++ b/sim/src/phases/task-execution.ts
@@ -18,6 +18,7 @@ import { getDwarfSkillLevel, getRequiredSkill } from "../task-helpers.js";
 import { bfsNextStep, findFullPath, posKey, getNeighbors, type ZResolver } from "../pathfinding.js";
 import { buildTileLookup } from "../tile-lookup.js";
 import { canPickUp, pickUpItem } from "../inventory.js";
+import { simDebug } from "../sim-debug.js";
 import { handleDeprivationDeaths } from "./deprivation.js";
 import { completeTask } from "./task-completion.js";
 
@@ -90,7 +91,7 @@ export async function taskExecution(ctx: SimContext): Promise<void> {
             if (canPickUp(dwarf.id, haulItem, state.items)) {
               pickUpItem(dwarf, haulItem, state);
             } else {
-              failTask(dwarf, task, state);
+              failTask(dwarf, task, ctx);
             }
           } else {
             const getTile = buildTileLookup(ctx);
@@ -110,7 +111,7 @@ export async function taskExecution(ctx: SimContext): Promise<void> {
                 const haulPrevPos = ctx.state._previousPositions?.get(dwarf.id);
                 if (haulUsedAlt && haulPrevPos && haulPrevPos === finalKey) {
                   if (!incrementOccupancyWait(dwarf, ctx)) {
-                    failTask(dwarf, task, state);
+                    failTask(dwarf, task, ctx);
                   }
                 } else {
                   ctx.state._occupancyWaitTicks?.delete(dwarf.id);
@@ -145,17 +146,17 @@ export async function taskExecution(ctx: SimContext): Promise<void> {
                 } else if (trySwapWithBlocker(dwarf, haulNext, ctx, occupiedTiles, dwarfAtPos)) {
                   // Swapped — dwarf already moved
                 } else if (!incrementOccupancyWait(dwarf, ctx)) {
-                  failTask(dwarf, task, state);
+                  failTask(dwarf, task, ctx);
                 }
               }
             } else {
-              failTask(dwarf, task, state);
+              failTask(dwarf, task, ctx);
             }
           }
           continue;
         }
         if (haulItem.held_by_dwarf_id !== null) {
-          failTask(dwarf, task, state);
+          failTask(dwarf, task, ctx);
           continue;
         }
       }
@@ -174,7 +175,7 @@ export async function taskExecution(ctx: SimContext): Promise<void> {
         && dwarf.position_x === task.target_x && dwarf.position_y === task.target_y && dwarf.position_z === task.target_z) {
         const stepped = stepOffTarget(dwarf, task, ctx, occupiedTiles, zResolver);
         if (!stepped) {
-          failTask(dwarf, task, state);
+          failTask(dwarf, task, ctx);
         }
         continue;
       }
@@ -182,7 +183,7 @@ export async function taskExecution(ctx: SimContext): Promise<void> {
       if (!atSite) {
         const moved = moveTowardTarget(dwarf, task, ctx, occupiedTiles, dwarfAtPos, zResolver);
         if (!moved) {
-          failTask(dwarf, task, state);
+          failTask(dwarf, task, ctx);
         }
         continue;
       }
@@ -303,6 +304,7 @@ function moveTowardTarget(dwarf: Dwarf, task: Task, ctx: SimContext, occupiedTil
 
     if (fullPath === null) {
       // No path exists within node limit
+      simDebug(ctx, 'pathfinding', `no path: ${dwarf.name} at (${start.x},${start.y},${start.z}) → (${goal.x},${goal.y},${goal.z}) for ${task.task_type}`);
       return false;
     }
     if (fullPath.length === 0) {
@@ -550,7 +552,8 @@ const NO_REQUEUE_TASK_TYPES: ReadonlySet<string> = new Set([
 /** Max consecutive failures before a player-designated task is cancelled. */
 const MAX_TASK_FAIL_COUNT = 3;
 
-function failTask(dwarf: Dwarf, task: Task, state: SimContext['state']): void {
+function failTask(dwarf: Dwarf, task: Task, ctx: SimContext): void {
+  const { state } = ctx;
   // Self-generated tasks (haul, eat, drink, sleep) get cancelled — their
   // respective phases will recreate them if still needed. This prevents the
   // fail→pending→reclaim→fail loop that kept haul tasks stuck at 0%.
@@ -566,8 +569,10 @@ function failTask(dwarf: Dwarf, task: Task, state: SimContext['state']): void {
       // Task has failed too many times — likely unreachable, cancel it
       task.status = 'cancelled';
       failCounts.delete(task.id);
+      simDebug(ctx, 'task', `cancelled unreachable ${task.task_type} at (${task.target_x},${task.target_y},${task.target_z}) after ${MAX_TASK_FAIL_COUNT} failures`);
     } else {
       task.status = 'pending';
+      simDebug(ctx, 'task', `${task.task_type} failed (attempt ${count}/${MAX_TASK_FAIL_COUNT}) for ${dwarf.name} at (${task.target_x},${task.target_y},${task.target_z})`);
     }
   }
   task.assigned_dwarf_id = null;

--- a/sim/src/run-scenario.ts
+++ b/sim/src/run-scenario.ts
@@ -29,6 +29,8 @@ export interface ScenarioConfig {
   stepsPerYear?: number;
   /** Override STEPS_PER_DAY for faster day progression in tests. */
   stepsPerDay?: number;
+  /** Enable debug logging (pathfinding failures, task issues, tick timing). */
+  debug?: boolean;
 }
 
 /** Full final state returned after a scenario run — suitable for test assertions. */
@@ -57,6 +59,8 @@ export interface ScenarioResult {
   monsters: Monster[];
   /** Final cave state. */
   caves: Cave[];
+  /** Debug log entries (only populated when debug=true). */
+  debugLog?: import("./sim-debug.js").DebugLogEntry[];
 }
 
 /**
@@ -105,6 +109,8 @@ export async function runScenario(config: ScenarioConfig): Promise<ScenarioResul
     state,
     stepsPerYear: config.stepsPerYear,
     stepsPerDay: config.stepsPerDay,
+    debug: config.debug,
+    debugLog: config.debug ? [] : undefined,
   };
 
   // Accumulate all events fired across the run
@@ -140,5 +146,6 @@ export async function runScenario(config: ScenarioConfig): Promise<ScenarioResul
     dwarfRelationships: state.dwarfRelationships,
     monsters: state.monsters,
     caves: state.caves,
+    debugLog: ctx.debugLog,
   };
 }

--- a/sim/src/sim-context.ts
+++ b/sim/src/sim-context.ts
@@ -240,6 +240,11 @@ export interface SimContext {
   stepsPerYear?: number;
   /** Override for STEPS_PER_DAY — used in tests to speed up day progression. */
   stepsPerDay?: number;
+
+  /** Enable debug logging for pathfinding failures, task issues, tick timing. */
+  debug?: boolean;
+  /** Accumulated debug log entries (only populated when debug=true). */
+  debugLog?: import("./sim-debug.js").DebugLogEntry[];
 }
 
 /** Creates a SimContext with a default test seed. Used in tests. */

--- a/sim/src/sim-debug.ts
+++ b/sim/src/sim-debug.ts
@@ -1,0 +1,29 @@
+import type { SimContext } from "./sim-context.js";
+
+/** Log categories for sim debug output. */
+export type DebugCategory = 'pathfinding' | 'task' | 'timing' | 'phase';
+
+/**
+ * Log a debug message if debug mode is enabled on the context.
+ * No-op when ctx.debug is false/undefined (zero overhead in production).
+ */
+export function simDebug(ctx: SimContext, category: DebugCategory, message: string): void {
+  if (!ctx.debug) return;
+
+  const debugLog = ctx.debugLog;
+  if (debugLog) {
+    debugLog.push({ step: ctx.step, category, message });
+  }
+
+  // Also log to console in non-test environments
+  if (typeof process !== 'undefined' && process.env.NODE_ENV !== 'test') {
+    console.warn(`[sim:${category}] step=${ctx.step} ${message}`);
+  }
+}
+
+/** A single debug log entry. */
+export interface DebugLogEntry {
+  step: number;
+  category: DebugCategory;
+  message: string;
+}

--- a/sim/src/tick.ts
+++ b/sim/src/tick.ts
@@ -1,6 +1,7 @@
 import { STEPS_PER_YEAR, STEPS_PER_DAY } from "@pwarf/shared";
 import type { SimContext } from "./sim-context.js";
 import { pruneTerminalTasks } from "./flush-state.js";
+import { simDebug } from "./sim-debug.js";
 import {
   needsDecay,
   taskExecution,
@@ -23,26 +24,48 @@ import {
   idleBehavior,
 } from "./phases/index.js";
 
+/** Phase definitions for timing instrumentation. */
+const PHASES: Array<{ name: string; fn: (ctx: SimContext) => void | Promise<void> }> = [
+  { name: 'needsDecay', fn: needsDecay },
+  { name: 'taskExecution', fn: taskExecution },
+  { name: 'needSatisfaction', fn: needSatisfaction },
+  { name: 'stressUpdate', fn: stressUpdate },
+  { name: 'tantrumCheck', fn: tantrumCheck },
+  { name: 'tantrumActions', fn: tantrumActions },
+  { name: 'monsterSpawning', fn: monsterSpawning },
+  { name: 'monsterPathfinding', fn: monsterPathfinding },
+  { name: 'combatResolution', fn: combatResolution },
+  { name: 'haulAssignment', fn: haulAssignment },
+  { name: 'taskRecovery', fn: taskRecovery },
+  { name: 'autoCookPhase', fn: autoCookPhase },
+  { name: 'autoBrew', fn: autoBrew },
+  { name: 'autoForage', fn: autoForage },
+  { name: 'idleBehavior', fn: idleBehavior },
+  { name: 'jobClaiming', fn: jobClaiming },
+  { name: 'eventFiring', fn: eventFiring },
+  { name: 'thoughtGeneration', fn: thoughtGeneration },
+];
+
 /** Run all sim phases for one tick in deterministic order. */
 export async function runTick(ctx: SimContext): Promise<void> {
-  await needsDecay(ctx);
-  await taskExecution(ctx);
-  await needSatisfaction(ctx);
-  await stressUpdate(ctx);
-  await tantrumCheck(ctx);
-  await tantrumActions(ctx);
-  await monsterSpawning(ctx);
-  await monsterPathfinding(ctx);
-  await combatResolution(ctx);
-  await haulAssignment(ctx);
-  taskRecovery(ctx);
-  await autoCookPhase(ctx);
-  await autoBrew(ctx);
-  await autoForage(ctx);
-  await idleBehavior(ctx);
-  await jobClaiming(ctx);
-  await eventFiring(ctx);
-  await thoughtGeneration(ctx);
+  const timing = ctx.debug && ctx.step % 100 === 0;
+  const tickStart = timing ? performance.now() : 0;
+
+  for (const phase of PHASES) {
+    const phaseStart = timing ? performance.now() : 0;
+    await phase.fn(ctx);
+    if (timing) {
+      const elapsed = performance.now() - phaseStart;
+      if (elapsed > 1) { // Only log phases taking > 1ms
+        simDebug(ctx, 'timing', `${phase.name}: ${elapsed.toFixed(1)}ms`);
+      }
+    }
+  }
+
+  if (timing) {
+    const totalMs = performance.now() - tickStart;
+    simDebug(ctx, 'timing', `tick ${ctx.step} total: ${totalMs.toFixed(1)}ms (${ctx.state.dwarves.length} dwarves, ${ctx.state.tasks.length} tasks)`);
+  }
 
   // Prune completed/cancelled/failed tasks every 100 ticks to prevent unbounded growth.
   // In live mode, flushState also prunes — this ensures headless mode stays clean too.


### PR DESCRIPTION
## Summary

- Add ctx.debug flag and ctx.debugLog for optional sim debug logging
- Three categories: pathfinding (no-path warnings), task (failure tracking), timing (per-phase ms)
- Zero overhead when disabled — all gated behind ctx.debug check
- ScenarioConfig.debug enables in headless tests, debugLog returned in ScenarioResult
- 3 new tests: pathfinding/task logs, no-log when disabled, timing capture

## Test plan

- [x] 3 new tests for debug mode
- [x] All 1130 tests pass
- [x] Build passes

Generated with [Claude Code](https://claude.com/claude-code)